### PR TITLE
[MDCT-2293] Timeout on update

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -188,6 +188,7 @@ functions:
                 state: true
   updateReport:
     handler: handlers/reports/update.updateReport
+    timeout: 30
     events:
       - http:
           path: reports/{state}/{id}


### PR DESCRIPTION
## Description
State users are seeing errors when trying to update their measures. Logs show a timeout of 6.0x seconds regularly starting that day. Serverless's default timeout is 6s. Bump the update action's timeout up.

### How to test
Nothing to see local

### Changed Dependencies
None

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
