### PR TITLE
[MDCT-2293] Uploads Timeout, also increase mem for potential speedup

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -189,6 +189,7 @@ functions:
   updateReport:
     handler: handlers/reports/update.updateReport
     timeout: 30
+    memorySize: 2048
     events:
       - http:
           path: reports/{state}/{id}


### PR DESCRIPTION
## Description
Bump up memory on the heavier validation operation in hopes that it speeds up runtime as well. The endpoint runs a heavy-ish validation op in addition to retrieving templates etc.

### How to test
Nothing to do local.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
