### PR TITLE
Clean up reporting APIs.

### DIFF
--- a/services/app-api/handlers/reports/archive.test.ts
+++ b/services/app-api/handlers/reports/archive.test.ts
@@ -1,10 +1,10 @@
 import { fetchReport } from "./fetch";
-import { updateReport } from "./update";
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { proxyEvent } from "../../utils/testing/proxyEvent";
 import { StatusCodes } from "../../utils/types/types";
 import { mockReport } from "../../utils/testing/setupJest";
 import { error } from "../../utils/constants/constants";
+import { archiveReport } from "./archive";
 
 jest.mock("../../utils/auth/authorization", () => ({
   isAuthorized: jest.fn().mockResolvedValue(true),
@@ -57,8 +57,7 @@ describe("Test archiveReport method", () => {
       },
       body: JSON.stringify(mockReport),
     });
-    const res: any = await updateReport(archiveEvent, null);
-
+    const res: any = await archiveReport(archiveEvent, null);
     const body = JSON.parse(res.body);
     expect(res.statusCode).toBe(StatusCodes.SUCCESS);
     expect(body.archived).toBe(true);
@@ -73,7 +72,7 @@ describe("Test archiveReport method", () => {
       },
       body: undefined!,
     });
-    const res = await updateReport(archiveEvent, null);
+    const res = await archiveReport(archiveEvent, null);
     expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
     expect(res.body).toContain(error.NO_MATCHING_RECORD);
   });

--- a/services/app-api/handlers/reports/archive.test.ts
+++ b/services/app-api/handlers/reports/archive.test.ts
@@ -10,6 +10,7 @@ jest.mock("../../utils/auth/authorization", () => ({
   isAuthorized: jest.fn().mockResolvedValue(true),
   hasPermissions: jest.fn(() => {}),
 }));
+
 const mockAuthUtil = require("../../utils/auth/authorization");
 
 jest.mock("../../utils/debugging/debug-lib", () => ({
@@ -41,8 +42,9 @@ describe("Test archiveReport method", () => {
   beforeEach(() => {
     // fail state and pass admin auth checks
     mockAuthUtil.hasPermissions
-      .mockReturnValueOnce(false)
-      .mockReturnValueOnce(true);
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false);
   });
   afterEach(() => {
     jest.clearAllMocks();
@@ -75,5 +77,19 @@ describe("Test archiveReport method", () => {
     const res = await archiveReport(archiveEvent, null);
     expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
     expect(res.body).toContain(error.NO_MATCHING_RECORD);
+  });
+
+  test("Test archive report without admin permissions throws 403", async () => {
+    mockedFetchReport.mockResolvedValue({
+      statusCode: 200,
+      headers: {
+        "Access-Control-Allow-Origin": "string",
+        "Access-Control-Allow-Credentials": true,
+      },
+      body: undefined!,
+    });
+    const res = await archiveReport(archiveEvent, null);
+    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    expect(res.body).toContain(error.UNAUTHORIZED);
   });
 });

--- a/services/app-api/handlers/reports/archive.ts
+++ b/services/app-api/handlers/reports/archive.ts
@@ -6,36 +6,44 @@ import { StatusCodes } from "../../utils/types/types";
 import { error } from "../../utils/constants/constants";
 
 export const archiveReport = handler(async (event, context) => {
-  let status, body;
   // get current report
   const reportEvent = { ...event, body: "" };
   const getCurrentReport = await fetchReport(reportEvent, context);
 
-  // if current report exists, parse for archived status
-  if (getCurrentReport?.body) {
-    const currentReport = JSON.parse(getCurrentReport.body);
-    const currentArchivedStatus = currentReport?.archived;
-
-    // Delete raw data prior to updating
-    delete currentReport.fieldData;
-    delete currentReport.formTemplate;
-
-    // toggle archived status in report metadata table
-    const reportMetadataParams = {
-      TableName: process.env.MCPAR_REPORT_TABLE_NAME!,
-      Item: {
-        ...currentReport,
-        archived: !currentArchivedStatus,
-      },
+  if (!getCurrentReport.body) {
+    return {
+      status: StatusCodes.NOT_FOUND,
+      body: error.NO_MATCHING_RECORD,
     };
-    await dynamoDb.put(reportMetadataParams);
-
-    // set response status and body
-    status = StatusCodes.SUCCESS;
-    body = reportMetadataParams.Item;
-  } else {
-    status = StatusCodes.NOT_FOUND;
-    body = error.NO_MATCHING_RECORD;
   }
-  return { status, body };
+
+  const currentReport = JSON.parse(getCurrentReport.body);
+  const currentArchivedStatus = currentReport?.archived;
+
+  // Delete raw data prior to updating
+  delete currentReport.fieldData;
+  delete currentReport.formTemplate;
+
+  // Toggle archived state in DynamoDB.
+  const reportMetadataParams = {
+    TableName: process.env.MCPAR_REPORT_TABLE_NAME!,
+    Item: {
+      ...currentReport,
+      archived: !currentArchivedStatus,
+    },
+  };
+
+  try {
+    await dynamoDb.put(reportMetadataParams);
+  } catch (err) {
+    return {
+      status: StatusCodes.SERVER_ERROR,
+      body: error.DYNAMO_UPDATE_ERROR,
+    };
+  }
+
+  return {
+    status: StatusCodes.SUCCESS,
+    body: reportMetadataParams.Item,
+  };
 });

--- a/services/app-api/handlers/reports/create.test.ts
+++ b/services/app-api/handlers/reports/create.test.ts
@@ -68,25 +68,25 @@ describe("Test createReport API method", () => {
     expect(res.body).toContain(error.MISSING_DATA);
   });
 
-  test("Test reportKey not provided throws 500 error", async () => {
+  test("Test reportKey not provided throws 400 error", async () => {
     const noKeyEvent: APIGatewayProxyEvent = {
       ...creationEvent,
       pathParameters: {},
     };
     const res = await createReport(noKeyEvent, null);
 
-    expect(res.statusCode).toBe(StatusCodes.SERVER_ERROR);
+    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
     expect(res.body).toContain(error.NO_KEY);
   });
 
-  test("Test reportKey empty throws 500 error", async () => {
+  test("Test reportKey empty throws 400 error", async () => {
     const noKeyEvent: APIGatewayProxyEvent = {
       ...creationEvent,
       pathParameters: { state: "" },
     };
     const res = await createReport(noKeyEvent, null);
 
-    expect(res.statusCode).toBe(StatusCodes.SERVER_ERROR);
+    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
     expect(res.body).toContain(error.NO_KEY);
   });
 });

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -12,89 +12,118 @@ import { S3Put, StatusCodes, UserRoles } from "../../utils/types/types";
 import { error, buckets } from "../../utils/constants/constants";
 
 export const createReport = handler(async (event, _context) => {
-  let status, body;
   if (!hasPermissions(event, [UserRoles.STATE_USER, UserRoles.STATE_REP])) {
-    status = StatusCodes.UNAUTHORIZED;
-    body = error.UNAUTHORIZED;
-  } else if (!event?.pathParameters?.state!) {
-    throw new Error(error.NO_KEY);
-  } else {
-    const state: string = event.pathParameters.state;
-    const unvalidatedPayload = JSON.parse(event!.body!);
-    const {
-      metadata: unvalidatedMetadata,
-      fieldData: unvalidatedFieldData,
-      formTemplate,
-    } = unvalidatedPayload;
-    const fieldDataValidationJson = formTemplate.validationJson;
-
-    // if field data and validation json have been passed
-    if (unvalidatedFieldData && fieldDataValidationJson) {
-      const reportId: string = KSUID.randomSync().string;
-      const fieldDataId: string = KSUID.randomSync().string;
-      const formTemplateId: string = KSUID.randomSync().string;
-
-      // validate field data
-      const validatedFieldData = await validateFieldData(
-        fieldDataValidationJson,
-        unvalidatedFieldData
-      );
-
-      // if field data passes validation,
-      if (validatedFieldData) {
-        // post validated field data to s3 bucket
-        const fieldDataParams: S3Put = {
-          Bucket: process.env.MCPAR_FORM_BUCKET!,
-          Key: `${buckets.FIELD_DATA}/${state}/${fieldDataId}.json`,
-          Body: JSON.stringify(validatedFieldData),
-          ContentType: "application/json",
-        };
-        await s3Lib.put(fieldDataParams);
-        // post form template to s3 bucket
-        const formTemplateParams: S3Put = {
-          Bucket: process.env.MCPAR_FORM_BUCKET!,
-          Key: `${buckets.FORM_TEMPLATE}/${state}/${formTemplateId}.json`,
-          Body: JSON.stringify(formTemplate),
-          ContentType: "application/json",
-        };
-        await s3Lib.put(formTemplateParams);
-
-        // validate report metadata
-        const validatedMetadata = await validateData(metadataValidationSchema, {
-          ...unvalidatedMetadata,
-        });
-        // if metadata passes validation,
-        if (validatedMetadata) {
-          // create record in report metadata table
-          let reportMetadataParams = {
-            TableName: process.env.MCPAR_REPORT_TABLE_NAME!,
-            Item: {
-              ...validatedMetadata,
-              state,
-              id: reportId,
-              fieldDataId,
-              formTemplateId,
-              createdAt: Date.now(),
-              lastAltered: Date.now(),
-            },
-          };
-          await dynamoDb.put(reportMetadataParams);
-
-          // set response status and body
-          status = StatusCodes.CREATED;
-          body = { ...reportMetadataParams.Item };
-        } else {
-          status = StatusCodes.BAD_REQUEST;
-          body = error.INVALID_DATA;
-        }
-      } else {
-        status = StatusCodes.BAD_REQUEST;
-        body = error.INVALID_DATA;
-      }
-    } else {
-      status = StatusCodes.BAD_REQUEST;
-      body = error.MISSING_DATA;
-    }
+    return {
+      status: StatusCodes.UNAUTHORIZED,
+      body: error.UNAUTHORIZED,
+    };
   }
-  return { status, body };
+
+  // Return error if no state is passed.
+  if (!event.pathParameters?.state) {
+    return {
+      status: StatusCodes.SERVER_ERROR,
+      body: error.NO_KEY,
+    };
+  }
+
+  const state: string = event.pathParameters.state;
+  const unvalidatedPayload = JSON.parse(event!.body!);
+  const {
+    metadata: unvalidatedMetadata,
+    fieldData: unvalidatedFieldData,
+    formTemplate,
+  } = unvalidatedPayload;
+  const fieldDataValidationJson = formTemplate.validationJson;
+
+  // Return MISSING_DATA error if missing unvalidated data or validators.
+  if (!unvalidatedFieldData || !fieldDataValidationJson) {
+    return {
+      status: StatusCodes.BAD_REQUEST,
+      body: error.MISSING_DATA,
+    };
+  }
+
+  // Create report and field ids.
+  const reportId: string = KSUID.randomSync().string;
+  const fieldDataId: string = KSUID.randomSync().string;
+  const formTemplateId: string = KSUID.randomSync().string;
+
+  // Validate field data
+  const validatedFieldData = await validateFieldData(
+    fieldDataValidationJson,
+    unvalidatedFieldData
+  );
+
+  // Return INVALID_DATA error if field data is not valid.
+  if (!validatedFieldData) {
+    return {
+      status: StatusCodes.BAD_REQUEST,
+      body: error.INVALID_DATA,
+    };
+  }
+
+  const fieldDataParams: S3Put = {
+    Bucket: process.env.MCPAR_FORM_BUCKET!,
+    Key: `${buckets.FIELD_DATA}/${state}/${fieldDataId}.json`,
+    Body: JSON.stringify(validatedFieldData),
+    ContentType: "application/json",
+  };
+
+  const formTemplateParams: S3Put = {
+    Bucket: process.env.MCPAR_FORM_BUCKET!,
+    Key: `${buckets.FORM_TEMPLATE}/${state}/${formTemplateId}.json`,
+    Body: JSON.stringify(formTemplate),
+    ContentType: "application/json",
+  };
+
+  try {
+    await s3Lib.put(fieldDataParams);
+    await s3Lib.put(formTemplateParams);
+  } catch (err) {
+    return {
+      status: StatusCodes.SERVER_ERROR,
+      body: error.S3_OBJECT_CREATION_ERROR,
+    };
+  }
+
+  const validatedMetadata = await validateData(metadataValidationSchema, {
+    ...unvalidatedMetadata,
+  });
+
+  // Return INVALID_DATA error if metadata is not valid.
+  if (!validatedMetadata) {
+    return {
+      status: StatusCodes.BAD_REQUEST,
+      body: error.INVALID_DATA,
+    };
+  }
+
+  // Create DyanmoDB record.
+  const reportMetadataParams = {
+    TableName: process.env.MCPAR_REPORT_TABLE_NAME!,
+    Item: {
+      ...validatedMetadata,
+      state,
+      id: reportId,
+      fieldDataId,
+      formTemplateId,
+      createdAt: Date.now(),
+      lastAltered: Date.now(),
+    },
+  };
+
+  try {
+    await dynamoDb.put(reportMetadataParams);
+  } catch (err) {
+    return {
+      status: StatusCodes.SERVER_ERROR,
+      body: error.DYNAMO_CREATION_ERROR,
+    };
+  }
+
+  return {
+    status: StatusCodes.CREATED,
+    body: { ...reportMetadataParams.Item },
+  };
 });

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -20,9 +20,9 @@ export const createReport = handler(async (event, _context) => {
   }
 
   // Return error if no state is passed.
-  if (!event.pathParameters?.state) {
+  if (!event.pathParameters?.state || !event.pathParameters) {
     return {
-      status: StatusCodes.SERVER_ERROR,
+      status: StatusCodes.BAD_REQUEST,
       body: error.NO_KEY,
     };
   }

--- a/services/app-api/handlers/reports/fetch.test.ts
+++ b/services/app-api/handlers/reports/fetch.test.ts
@@ -68,23 +68,23 @@ describe("Test fetchReport API method", () => {
     expect(body.formTemplate).toStrictEqual(mockReportJson);
   });
 
-  test("Test reportKeys not provided throws 500 error", async () => {
+  test("Test reportKeys not provided throws 400 error", async () => {
     const noKeyEvent: APIGatewayProxyEvent = {
       ...testReadEvent,
       pathParameters: {},
     };
     const res = await fetchReport(noKeyEvent, null);
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(400);
     expect(res.body).toContain(error.NO_KEY);
   });
 
-  test("Test reportKeys empty throws 500 error", async () => {
+  test("Test reportKeys empty throws 400 error", async () => {
     const noKeyEvent: APIGatewayProxyEvent = {
       ...testReadEvent,
       pathParameters: { state: "", id: "" },
     };
     const res = await fetchReport(noKeyEvent, null);
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(400);
     expect(res.body).toContain(error.NO_KEY);
   });
 });
@@ -101,23 +101,23 @@ describe("Test fetchReportsByState API method", () => {
     expect(body[0].programName).toContain("testProgram");
   });
 
-  test("Test reportKeys not provided throws 500 error", async () => {
+  test("Test reportKeys not provided throws 400 error", async () => {
     const noKeyEvent: APIGatewayProxyEvent = {
       ...testReadEventByState,
       pathParameters: {},
     };
     const res = await fetchReportsByState(noKeyEvent, null);
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(400);
     expect(res.body).toContain(error.NO_KEY);
   });
 
-  test("Test reportKeys empty throws 500 error", async () => {
+  test("Test reportKeys empty throws 400 error", async () => {
     const noKeyEvent: APIGatewayProxyEvent = {
       ...testReadEventByState,
       pathParameters: { state: "" },
     };
     const res = await fetchReportsByState(noKeyEvent, null);
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(400);
     expect(res.body).toContain(error.NO_KEY);
   });
 });

--- a/services/app-api/handlers/reports/fetch.ts
+++ b/services/app-api/handlers/reports/fetch.ts
@@ -8,7 +8,7 @@ import { DocumentClient } from "aws-sdk/clients/dynamodb";
 export const fetchReport = handler(async (event, _context) => {
   if (!event?.pathParameters?.state! || !event?.pathParameters?.id!) {
     return {
-      status: StatusCodes.SERVER_ERROR,
+      status: StatusCodes.BAD_REQUEST,
       body: error.NO_KEY,
     };
   }
@@ -89,7 +89,7 @@ interface DynamoFetchParams {
 export const fetchReportsByState = handler(async (event, _context) => {
   if (!event?.pathParameters?.state!) {
     return {
-      status: StatusCodes.SERVER_ERROR,
+      status: StatusCodes.BAD_REQUEST,
       body: error.NO_KEY,
     };
   }

--- a/services/app-api/handlers/reports/fetch.ts
+++ b/services/app-api/handlers/reports/fetch.ts
@@ -3,56 +3,98 @@ import dynamoDb from "../../utils/dynamo/dynamodb-lib";
 import s3Lib from "../../utils/s3/s3-lib";
 import { AnyObject, S3Get, StatusCodes } from "../../utils/types/types";
 import { error, buckets } from "../../utils/constants/constants";
+import { DocumentClient } from "aws-sdk/clients/dynamodb";
 
 export const fetchReport = handler(async (event, _context) => {
-  let status, body;
   if (!event?.pathParameters?.state! || !event?.pathParameters?.id!) {
-    throw new Error(error.NO_KEY);
+    return {
+      status: StatusCodes.SERVER_ERROR,
+      body: error.NO_KEY,
+    };
   }
-  const state = event.pathParameters.state;
-  const reportId = event.pathParameters.id;
 
-  // get current report metadata
+  const { state, reportId } = event.pathParameters;
+
+  // Get current report metadata
   const reportMetadataParams = {
     TableName: process.env.MCPAR_REPORT_TABLE_NAME!,
     Key: { state, id: reportId },
   };
+
   try {
     const response = await dynamoDb.get(reportMetadataParams);
-    if (!response?.Item) throw error.NOT_IN_DATABASE;
-    const reportMetadata: any = response.Item; // TODO: strict typing
+    if (!response?.Item) {
+      return {
+        status: StatusCodes.NOT_FOUND,
+        body: error.NOT_IN_DATABASE,
+      };
+    }
+
+    const reportMetadata = response.Item as Record<string, any>;
     const { formTemplateId, fieldDataId } = reportMetadata;
 
-    // get formTemplate from s3 bucket
+    // Get form template from S3
     const formTemplateParams: S3Get = {
       Bucket: process.env.MCPAR_FORM_BUCKET!,
       Key: `${buckets.FORM_TEMPLATE}/${state}/${formTemplateId}.json`,
     };
-    const formTemplate: any = await s3Lib.get(formTemplateParams); // TODO: strict typing
-    if (!formTemplate) throw error.MISSING_FORM_TEMPLATE;
 
-    // get fieldData from s3 bucket
-    const fieldDataParams = {
+    const formTemplate = await s3Lib.get(formTemplateParams); // TODO: strict typing
+    if (!formTemplate) {
+      return {
+        status: StatusCodes.NOT_FOUND,
+        body: error.MISSING_FORM_TEMPLATE,
+      };
+    }
+
+    // Get field data from S3
+    const fieldDataParams: S3Get = {
       Bucket: process.env.MCPAR_FORM_BUCKET!,
       Key: `${buckets.FIELD_DATA}/${state}/${fieldDataId}.json`,
     };
-    const fieldData: any = await s3Lib.get(fieldDataParams); // TODO: strict typing
-    if (!fieldData) throw error.MISSING_FIELD_DATA;
 
-    status = StatusCodes.SUCCESS;
-    body = { ...reportMetadata, formTemplate, fieldData };
+    const fieldData = await s3Lib.get(fieldDataParams); // TODO: strict typing
+
+    if (!fieldData) {
+      return {
+        status: StatusCodes.NOT_FOUND,
+        body: error.NO_MATCHING_RECORD,
+      };
+    }
+
+    return {
+      status: StatusCodes.SUCCESS,
+      body: {
+        ...reportMetadata,
+        formTemplate,
+        fieldData,
+      },
+    };
   } catch (err) {
-    status = StatusCodes.NOT_FOUND;
-    body = error.NO_MATCHING_RECORD;
+    return {
+      status: StatusCodes.NOT_FOUND,
+      body: error.NO_MATCHING_RECORD,
+    };
   }
-  return { status, body };
 });
+
+interface DynamoFetchParams {
+  TableName: string;
+  KeyConditionExpression: string;
+  ExpressionAttributeValues: Record<string, string>;
+  ExpressionAttributeNames: Record<string, string>;
+  ExclusiveStartKey?: DocumentClient.Key;
+}
 
 export const fetchReportsByState = handler(async (event, _context) => {
   if (!event?.pathParameters?.state!) {
-    throw new Error(error.NO_KEY);
+    return {
+      status: StatusCodes.SERVER_ERROR,
+      body: error.NO_KEY,
+    };
   }
-  let queryParams: any = {
+
+  const queryParams: DynamoFetchParams = {
     TableName: process.env.MCPAR_REPORT_TABLE_NAME!,
     KeyConditionExpression: "#state = :state",
     ExpressionAttributeValues: {
@@ -67,7 +109,7 @@ export const fetchReportsByState = handler(async (event, _context) => {
   let existingItems = [];
   let results;
 
-  const queryTable = async (startingKey?: any) => {
+  const queryTable = async (startingKey?: DocumentClient.Key) => {
     queryParams.ExclusiveStartKey = startingKey;
     let results = await dynamoDb.query(queryParams);
     if (results.LastEvaluatedKey) {
@@ -81,7 +123,7 @@ export const fetchReportsByState = handler(async (event, _context) => {
   // Looping to perform complete scan of tables due to 1 mb limit per iteration
   do {
     [startingKey, results] = await queryTable(startingKey);
-    const items: AnyObject[] = results.Items;
+    const items: AnyObject[] = results?.Items;
     existingItems.push(...items);
   } while (startingKey);
 

--- a/services/app-api/handlers/reports/fetch.ts
+++ b/services/app-api/handlers/reports/fetch.ts
@@ -13,12 +13,12 @@ export const fetchReport = handler(async (event, _context) => {
     };
   }
 
-  const { state, reportId } = event.pathParameters;
+  const { state, id } = event.pathParameters;
 
   // Get current report metadata
   const reportMetadataParams = {
     TableName: process.env.MCPAR_REPORT_TABLE_NAME!,
-    Key: { state, id: reportId },
+    Key: { state, id },
   };
 
   try {

--- a/services/app-api/handlers/reports/update.test.ts
+++ b/services/app-api/handlers/reports/update.test.ts
@@ -95,22 +95,6 @@ describe("Test updateReport API method", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-  test("Test Successful Run of report update", async () => {
-    mockedFetchReport.mockResolvedValue({
-      statusCode: 200,
-      headers: {
-        "Access-Control-Allow-Origin": "string",
-        "Access-Control-Allow-Credentials": true,
-      },
-      body: JSON.stringify(mockDynamoData),
-    });
-    const res = await updateReport(updateEvent, null);
-    const body = JSON.parse(res.body);
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
-    expect(body.status).toContain("in progress");
-    expect(body.fieldData.number).toBe("1");
-  });
-
   test("Test report update submission succeeds", async () => {
     mockedFetchReport.mockResolvedValue({
       statusCode: 200,
@@ -181,7 +165,7 @@ describe("Test updateReport API method", () => {
     const res = await updateReport(updateEvent, null);
 
     expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
-    expect(res.body).toContain(error.ALREADY_ARCHIVED);
+    expect(res.body).toContain(error.UNAUTHORIZED);
   });
 
   test("Test reportKey not provided throws 400 error", async () => {

--- a/services/app-api/handlers/reports/update.test.ts
+++ b/services/app-api/handlers/reports/update.test.ts
@@ -181,28 +181,28 @@ describe("Test updateReport API method", () => {
     const res = await updateReport(updateEvent, null);
 
     expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
-    expect(res.body).toContain(error.UNAUTHORIZED);
+    expect(res.body).toContain(error.ALREADY_ARCHIVED);
   });
 
-  test("Test reportKey not provided throws 500 error", async () => {
+  test("Test reportKey not provided throws 400 error", async () => {
     const noKeyEvent: APIGatewayProxyEvent = {
       ...updateEvent,
       pathParameters: {},
     };
     const res = await updateReport(noKeyEvent, null);
 
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(400);
     expect(res.body).toContain(error.NO_KEY);
   });
 
-  test("Test reportKey empty throws 500 error", async () => {
+  test("Test reportKey empty throws 400 error", async () => {
     const noKeyEvent: APIGatewayProxyEvent = {
       ...updateEvent,
       pathParameters: { state: "", id: "" },
     };
     const res = await updateReport(noKeyEvent, null);
 
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(400);
     expect(res.body).toContain(error.NO_KEY);
   });
 });

--- a/services/app-api/handlers/reports/update.ts
+++ b/services/app-api/handlers/reports/update.ts
@@ -1,7 +1,5 @@
 import handler from "../handler-lib";
 import { fetchReport } from "./fetch";
-import { archiveReport } from "./archive";
-// utils
 import dynamoDb from "../../utils/dynamo/dynamodb-lib";
 import { hasPermissions } from "../../utils/auth/authorization";
 import s3Lib from "../../utils/s3/s3-lib";
@@ -14,132 +12,173 @@ import { StatusCodes, UserRoles } from "../../utils/types/types";
 import { error, buckets } from "../../utils/constants/constants";
 
 export const updateReport = handler(async (event, context) => {
-  let status, body;
   if (!event?.pathParameters?.state! || !event?.pathParameters?.id!) {
-    throw new Error(error.NO_KEY);
-  } else if (
-    !hasPermissions(event, [UserRoles.STATE_USER, UserRoles.STATE_REP])
-  ) {
-    // if they have admin permissions, attempt the archive function
-    if (hasPermissions(event, [UserRoles.ADMIN])) {
-      const { statusCode: archiveStatus, body: archiveBody } =
-        await archiveReport(event, context);
-      status = archiveStatus;
-      body = JSON.parse(archiveBody);
-    } else {
-      status = StatusCodes.UNAUTHORIZED;
-      body = error.UNAUTHORIZED;
-    }
-  } else {
-    // get current report
-    const reportEvent = { ...event, body: "" };
-    const getCurrentReport = await fetchReport(reportEvent, context);
-
-    // if current report exists, get formTemplateId and fieldDataId
-    if (getCurrentReport?.body) {
-      const currentReport = JSON.parse(getCurrentReport.body);
-      const { formTemplateId, fieldDataId } = currentReport;
-      if (formTemplateId && fieldDataId) {
-        // if report not in archived state, proceed with updates
-        if (!currentReport.archived) {
-          const state: string = event.pathParameters.state;
-
-          // get formTemplate from s3 bucket (for passed fieldData validation)
-          const formTemplateParams = {
-            Bucket: process.env.MCPAR_FORM_BUCKET!,
-            Key: `${buckets.FORM_TEMPLATE}/${state}/${formTemplateId}.json`,
-          };
-          const formTemplate: any = await s3Lib.get(formTemplateParams); // TODO: strict typing
-
-          // get existing fieldData from s3 bucket (for patching with passed data)
-          const fieldDataParams = {
-            Bucket: process.env.MCPAR_FORM_BUCKET!,
-            Key: `${buckets.FIELD_DATA}/${state}/${fieldDataId}.json`,
-          };
-          const existingFieldData: any = await s3Lib.get(fieldDataParams); // TODO: strict typing
-
-          // parse the passed payload
-          const unvalidatedPayload = JSON.parse(event!.body!);
-          const {
-            metadata: unvalidatedMetadata,
-            fieldData: unvalidatedFieldData,
-          } = unvalidatedPayload;
-
-          if (unvalidatedFieldData) {
-            // validate passed field data
-            const validatedFieldData = await validateFieldData(
-              formTemplate?.validationJson,
-              unvalidatedFieldData
-            );
-
-            // if field data passes validation,
-            if (validatedFieldData) {
-              // post validated field data to s3 bucket
-              const fieldData = {
-                ...existingFieldData,
-                ...validatedFieldData,
-              };
-              const fieldDataParams = {
-                Bucket: process.env.MCPAR_FORM_BUCKET!,
-                Key: `${buckets.FIELD_DATA}/${state}/${fieldDataId}.json`,
-                Body: JSON.stringify(fieldData),
-                ContentType: "application/json",
-              };
-              await s3Lib.put(fieldDataParams);
-
-              // validate report metadata
-              const validatedMetadata = await validateData(
-                metadataValidationSchema,
-                { ...unvalidatedMetadata }
-              );
-              // if metadata passes validation,
-              if (validatedMetadata) {
-                //Delete raw data prior to updating
-                delete currentReport.fieldData;
-                delete currentReport.formTemplate;
-
-                // update record in report metadata table
-                const reportMetadataParams = {
-                  TableName: process.env.MCPAR_REPORT_TABLE_NAME!,
-                  Item: {
-                    ...currentReport,
-                    ...validatedMetadata,
-                    lastAltered: Date.now(),
-                  },
-                };
-                await dynamoDb.put(reportMetadataParams);
-
-                // set response status and body
-                status = StatusCodes.SUCCESS;
-                body = {
-                  ...reportMetadataParams.Item,
-                  fieldData,
-                  formTemplate,
-                };
-              } else {
-                status = StatusCodes.BAD_REQUEST;
-                body = error.INVALID_DATA;
-              }
-            } else {
-              status = StatusCodes.BAD_REQUEST;
-              body = error.INVALID_DATA;
-            }
-          } else {
-            status = StatusCodes.BAD_REQUEST;
-            body = error.MISSING_DATA;
-          }
-        } else {
-          status = StatusCodes.UNAUTHORIZED;
-          body = error.UNAUTHORIZED;
-        }
-      } else {
-        status = StatusCodes.BAD_REQUEST;
-        body = error.MISSING_DATA;
-      }
-    } else {
-      status = StatusCodes.NOT_FOUND;
-      body = error.NO_MATCHING_RECORD;
-    }
+    return {
+      status: StatusCodes.BAD_REQUEST,
+      body: error.NO_KEY,
+    };
   }
-  return { status, body };
+
+  // If request body is missing, return a 400 error.
+  if (!event?.body) {
+    return {
+      status: StatusCodes.BAD_REQUEST,
+      body: error.MISSING_DATA,
+    };
+  }
+
+  // Ensure user has correct permissions to update a report.
+  if (!hasPermissions(event, [UserRoles.STATE_USER, UserRoles.STATE_REP])) {
+    return {
+      status: StatusCodes.UNAUTHORIZED,
+      body: error.UNAUTHORIZED,
+    };
+  }
+
+  // Get current report
+  const reportEvent = { ...event, body: "" };
+  const fetchReportRequest = await fetchReport(reportEvent, context);
+
+  if (!fetchReportRequest?.body || fetchReportRequest.statusCode !== 200) {
+    return {
+      status: StatusCodes.NOT_FOUND,
+      body: error.NO_MATCHING_RECORD,
+    };
+  }
+
+  // If current report exists, get formTemplateId and fieldDataId
+  const currentReport = JSON.parse(fetchReportRequest.body);
+
+  if (currentReport.archived) {
+    return {
+      status: StatusCodes.UNAUTHORIZED,
+      body: error.UNAUTHORIZED,
+    };
+  }
+
+  const { formTemplateId, fieldDataId } = currentReport;
+
+  if (!formTemplateId || !fieldDataId) {
+    return {
+      status: StatusCodes.BAD_REQUEST,
+      body: error.MISSING_DATA,
+    };
+  }
+
+  const { state } = event.pathParameters;
+
+  const formTemplateParams = {
+    Bucket: process.env.MCPAR_FORM_BUCKET!,
+    Key: `${buckets.FORM_TEMPLATE}/${state}/${formTemplateId}.json`,
+  };
+  const formTemplate = (await s3Lib.get(formTemplateParams)) as Record<
+    string,
+    any
+  >;
+
+  // Get existing fieldData from s3 bucket (for patching with passed data)
+  const fieldDataParams = {
+    Bucket: process.env.MCPAR_FORM_BUCKET!,
+    Key: `${buckets.FIELD_DATA}/${state}/${fieldDataId}.json`,
+  };
+  const existingFieldData = (await s3Lib.get(fieldDataParams)) as Record<
+    string,
+    any
+  >;
+
+  // Parse the passed payload.
+  const unvalidatedPayload = JSON.parse(event.body);
+
+  const { metadata: unvalidatedMetadata, fieldData: unvalidatedFieldData } =
+    unvalidatedPayload;
+
+  if (!unvalidatedFieldData) {
+    return {
+      status: StatusCodes.BAD_REQUEST,
+      body: error.MISSING_DATA,
+    };
+  }
+
+  // Validate passed field data
+  const validatedFieldData = await validateFieldData(
+    formTemplate?.validationJson,
+    unvalidatedFieldData
+  );
+
+  if (!validatedFieldData) {
+    return {
+      status: StatusCodes.SERVER_ERROR,
+      body: error.INVALID_DATA,
+    };
+  }
+
+  // Post validated field data to s3 bucket
+  const fieldData = {
+    ...existingFieldData,
+    ...validatedFieldData,
+  };
+
+  const updateFieldDataParams = {
+    Bucket: process.env.MCPAR_FORM_BUCKET!,
+    Key: `${buckets.FIELD_DATA}/${state}/${fieldDataId}.json`,
+    Body: JSON.stringify(fieldData),
+    ContentType: "application/json",
+  };
+
+  try {
+    await s3Lib.put(updateFieldDataParams);
+  } catch (err) {
+    return {
+      status: StatusCodes.SERVER_ERROR,
+      body: error.S3_OBJECT_UPDATE_ERROR,
+    };
+  }
+
+  // Validate report metadata
+  const validatedMetadata = await validateData(metadataValidationSchema, {
+    ...unvalidatedMetadata,
+  });
+
+  // If metadata fails validation, return 400
+  if (!validatedMetadata) {
+    return {
+      status: StatusCodes.BAD_REQUEST,
+      body: error.INVALID_DATA,
+    };
+  }
+
+  /*
+   * Data has passed validation
+   * Delete raw data prior to updating
+   */
+  delete currentReport.fieldData;
+  delete currentReport.formTemplate;
+
+  // Update record in report metadata table
+  const reportMetadataParams = {
+    TableName: process.env.MCPAR_REPORT_TABLE_NAME!,
+    Item: {
+      ...currentReport,
+      ...validatedMetadata,
+      lastAltered: Date.now(),
+    },
+  };
+
+  try {
+    await dynamoDb.put(reportMetadataParams);
+  } catch (err) {
+    return {
+      status: StatusCodes.SERVER_ERROR,
+      body: error.DYNAMO_UPDATE_ERROR,
+    };
+  }
+
+  return {
+    status: StatusCodes.SUCCESS,
+    body: {
+      ...reportMetadataParams.Item,
+      fieldData,
+      formTemplate,
+    },
+  };
 });

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -187,7 +187,19 @@ functions:
               paths:
                 state: true
     timeout: 30
-
+  archiveReport:
+    handler: handlers/reports/archive.archiveReport
+    events:
+      - http:
+          path: reports/archive/{state}/{id}
+          method: put
+          cors: true
+          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          request:
+            parameters:
+              paths:
+                state: true
+                id: true
   createReport:
     handler: handlers/reports/create.createReport
     events:

--- a/services/app-api/utils/constants/constants.ts
+++ b/services/app-api/utils/constants/constants.ts
@@ -1,19 +1,24 @@
 export const error = {
   // generic errors
   UNAUTHORIZED: "User is not authorized to access this resource.",
-  NO_KEY: "Must provide key for table",
-  MISSING_DATA: "Missing required data",
-  INVALID_DATA: "Provided data is not valid",
-  NO_MATCHING_RECORD: "No matching record found",
+  NO_KEY: "Must provide key for table.",
+  MISSING_DATA: "Missing required data.",
+  INVALID_DATA: "Provided data is not valid.",
+  NO_MATCHING_RECORD: "No matching record found.",
+  SERVER_ERROR: "An unspecified server error occured.",
   // bucket errors
   S3_OBJECT_CREATION_ERROR: "Report could not be created due to an S3 error.",
   S3_OBJECT_UPDATE_ERROR: "Report could not be updated due to an S3 error.",
+  // dynamo errors
+  DYNAMO_CREATION_ERROR: "Report could not be created due to a database error.",
+  DYNAMO_UPDATE_ERROR: "Report could not be updated due to a database error.",
   // template errors
-  NO_TEMPLATE_NAME: "Must request template for download",
-  INVALID_TEMPLATE_NAME: "Requested template does not exist or does not match",
-  NOT_IN_DATABASE: "Record not found in database",
-  MISSING_FORM_TEMPLATE: "Form Template not found in S3",
-  MISSING_FIELD_DATA: "Field Data not found in S3",
+  NO_TEMPLATE_NAME: "Must request template for download.",
+  INVALID_TEMPLATE_NAME: "Requested template does not exist or does not match.",
+  NOT_IN_DATABASE: "Record not found in database.",
+  MISSING_FORM_TEMPLATE: "Form Template not found in S3.",
+  MISSING_FIELD_DATA: "Field Data not found in S3.",
+  ALREADY_ARCHIVED: "Cannot update archived report.",
 };
 
 export const buckets = {

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -199,7 +199,7 @@ describe("Test Dashboard report archiving privileges (desktop)", () => {
     const archiveProgramButton = screen.getAllByText("Archive")[0];
     expect(archiveProgramButton).toBeVisible();
     await userEvent.click(archiveProgramButton);
-    await expect(mockReportContext.updateReport).toHaveBeenCalledTimes(1);
+    await expect(mockReportContext.archiveReport).toHaveBeenCalledTimes(1);
     // once for render, once for archive
     await expect(mockReportContext.fetchReportsByState).toHaveBeenCalledTimes(
       2
@@ -258,7 +258,7 @@ describe("Test Dashboard report archiving privileges (mobile)", () => {
     const archiveProgramButton = screen.getAllByText("Archive")[0];
     expect(archiveProgramButton).toBeVisible();
     await userEvent.click(archiveProgramButton);
-    await expect(mockReportContext.updateReport).toHaveBeenCalledTimes(1);
+    await expect(mockReportContext.archiveReport).toHaveBeenCalledTimes(1);
     // once for render, once for archive
     await expect(mockReportContext.fetchReportsByState).toHaveBeenCalledTimes(
       2

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -43,7 +43,7 @@ export const DashboardPage = ({ reportType }: Props) => {
     reportsByState,
     clearReportSelection,
     setReportSelection,
-    updateReport,
+    archiveReport,
   } = useContext(ReportContext);
   const navigate = useNavigate();
   const {
@@ -152,7 +152,7 @@ export const DashboardPage = ({ reportType }: Props) => {
         state: adminSelectedState,
         id: report.id,
       };
-      await updateReport(reportKeys, {});
+      await archiveReport(reportKeys);
       await fetchReportsByState(activeState);
       setArchivingReportId(undefined);
       setArchiving(false);

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -2,6 +2,7 @@ import { createContext, ReactNode, useEffect, useMemo, useState } from "react";
 import { useLocation } from "react-router-dom";
 // utils
 import {
+  archiveReport as archiveReportRequest,
   getLocalHourMinuteTime,
   getReport,
   getReportsByState,
@@ -24,8 +25,9 @@ import { reportErrors } from "verbiage/errors";
 export const ReportContext = createContext<ReportContextShape>({
   // report
   report: undefined as ReportShape | undefined,
-  fetchReport: Function,
+  archiveReport: Function,
   createReport: Function,
+  fetchReport: Function,
   updateReport: Function,
   // reports by state
   reportsByState: undefined as ReportMetadataShape[] | undefined,
@@ -89,6 +91,16 @@ export const ReportProvider = ({ children }: Props) => {
     }
   };
 
+  const archiveReport = async (reportKeys: ReportKeys) => {
+    try {
+      const result = await archiveReportRequest(reportKeys);
+      setReport(result);
+      setLastSavedTime(getLocalHourMinuteTime());
+    } catch (e: any) {
+      setError(reportErrors.SET_REPORT_FAILED);
+    }
+  };
+
   // SELECTED REPORT
 
   const clearReportSelection = () => {
@@ -120,6 +132,7 @@ export const ReportProvider = ({ children }: Props) => {
     () => ({
       // report
       report,
+      archiveReport,
       fetchReport,
       createReport,
       updateReport,

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -163,6 +163,7 @@ export interface ReportShape extends ReportMetadataShape {
 export interface ReportContextMethods {
   fetchReport: Function;
   fetchReportsByState: Function;
+  archiveReport: Function;
   createReport: Function;
   updateReport: Function;
   clearReportSelection: Function;

--- a/services/ui-src/src/utils/api/requestMethods/report.ts
+++ b/services/ui-src/src/utils/api/requestMethods/report.ts
@@ -3,6 +3,22 @@ import { ReportKeys, ReportShape } from "types";
 import { getRequestHeaders } from "./getRequestHeaders";
 import { updateTimeout } from "utils";
 
+async function archiveReport(reportKeys: ReportKeys) {
+  const requestHeaders = await getRequestHeaders();
+  const request = {
+    headers: { ...requestHeaders },
+  };
+  const { state, id } = reportKeys;
+
+  updateTimeout();
+  const response = await API.put(
+    "mcr",
+    `/reports/archive/${state}/${id}`,
+    request
+  );
+  return response;
+}
+
 async function getReport(reportKeys: ReportKeys) {
   const requestHeaders = await getRequestHeaders();
   const request = {
@@ -51,4 +67,4 @@ async function putReport(reportKeys: ReportKeys, report: ReportShape) {
   return response;
 }
 
-export { getReport, postReport, putReport, getReportsByState };
+export { archiveReport, getReport, postReport, putReport, getReportsByState };

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -594,6 +594,7 @@ export const mockReportsByState = [
 ];
 
 export const mockReportMethods = {
+  archiveReport: jest.fn(),
   fetchReport: jest.fn(),
   fetchReportsByState: jest.fn(),
   createReport: jest.fn(),


### PR DESCRIPTION
## Summary

This PR cleans up the MCR report CRUD apis to handle errors more cleanly and expose more useful information about errors to the client.

One somewhat breaking change is made—routes will now return a `400 BAD REQUEST` status when required arguments are missing from path parameters. Previously, they returned `500 INTERNAL SERVER ERROR` responses which felt undescriptive.

### Related ticket
N/A

### How to test
Additional manual testing likely unnecessary—all existing tests pass or have been updated.

### Important updates
N/A

### Author checklist
<!-- Complete the following before marking ready for review -->
- [X] I have performed a self-review of my code
- [X] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [X] I have updated the documentation, if necessary
