### PR TITLE
Nested Choicelist Fix and saving on continue

### DIFF
--- a/services/ui-src/src/components/fields/ChoiceListField.test.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.test.tsx
@@ -468,7 +468,10 @@ describe("Test Choicelist onChangeHandler", () => {
     const firstRadioOptionOptionData = [{ key: "Choice 1", value: "Choice 1" }];
     expect(mockSetValue).toHaveBeenCalledWith(
       "radioField",
-      firstRadioOptionOptionData
+      firstRadioOptionOptionData,
+      {
+        shouldValidate: true,
+      }
     );
 
     // Now check the second radio option to trigger the onChangeHandler
@@ -488,7 +491,10 @@ describe("Test Choicelist onChangeHandler", () => {
     // Make sure the form value is set to default state
     expect(mockSetValue).toHaveBeenCalledWith(
       "radioField",
-      firstRadioOptionOptionData
+      firstRadioOptionOptionData,
+      {
+        shouldValidate: true,
+      }
     );
   });
 });

--- a/services/ui-src/src/components/fields/ChoiceListField.test.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.test.tsx
@@ -499,7 +499,7 @@ describe("Test Choicelist onChangeHandler", () => {
     );
   });
 
-  test("Checking and unchecking choices that have nested children sets those children to default values", async () => {
+  test("Checking and unchecking choices that have a nested textbox child sets that textbox to its default value", async () => {
     mockGetValues(undefined);
 
     // Create the Checkbox Component
@@ -555,7 +555,7 @@ describe("Test Choicelist onChangeHandler", () => {
       }
     );
 
-    // Now blur the parent and make sure the fields underneath are clean
+    // Now uncheck the parent
     fireEvent.click(parentCheckbox);
 
     // Confirm the checkbox options are unchecked correctly
@@ -578,13 +578,97 @@ describe("Test Choicelist onChangeHandler", () => {
     expect(recheckedOptions).toHaveLength(1);
     expect(parentCheckbox).toBeChecked();
 
-    // Tab away to trigger onComponentBlur()
-    fireEvent.blur(parentCheckbox);
-
     const childTextBoxCleared: HTMLInputElement =
       wrapper.container.querySelector("[name='Choice 3-otherText']")!;
 
     expect(childTextBoxCleared.value).toBe("");
+  });
+
+  test("Checking and unchecking a checkbox that has a nested radio child sets that radio to its default value (Nothing is checked)", async () => {
+    mockGetValues(undefined);
+
+    // Create the Checkbox Component
+    const wrapper = render(CheckboxComponentWithNestedChildren);
+
+    const parentCheckbox = wrapper.getByRole("checkbox", { name: "Choice 3" });
+
+    // Make sure default state is set correctly
+    expect(parentCheckbox).not.toBeChecked();
+
+    // Select the first Checkbox and check it
+    fireEvent.click(parentCheckbox);
+
+    // Confirm the checkbox options are checked correctly
+    const checkedOptions = wrapper.getAllByRole("checkbox", {
+      checked: true,
+    });
+    expect(checkedOptions).toHaveLength(1);
+    expect(parentCheckbox).toBeChecked();
+
+    // Tab away to trigger onComponentBlur()
+    fireEvent.blur(parentCheckbox);
+
+    // Make sure the form value is set to what we've clicked (Which is only Choice 3)
+    const parentCheckboxData = [{ key: "Choice 3", value: "Choice 3" }];
+    expect(mockSetValue).toHaveBeenCalledWith(
+      "checkboxFieldWithNestedChildren",
+      parentCheckboxData,
+      {
+        shouldValidate: true,
+      }
+    );
+
+    // Now check the child radio field
+    const childRadioField = wrapper.getByRole("radio", {
+      name: "Choice 4",
+    });
+    fireEvent.click(childRadioField);
+
+    // Confirm the option was checked
+    expect(childRadioField).toBeChecked();
+
+    // Tab away to trigger onComponentBlur()
+    fireEvent.blur(childRadioField);
+
+    // Make sure the form value is set to with new child option
+    const childRadioData = [
+      { key: "test-nested-child-radio-Choice 4", value: "Choice 4" },
+    ];
+    expect(mockSetValue).toHaveBeenCalledWith(
+      "test-nested-child-radio",
+      childRadioData,
+      {
+        shouldValidate: true,
+      }
+    );
+
+    // Now uncheck the parent
+    fireEvent.click(parentCheckbox);
+
+    // Confirm the checkbox options are unchecked correctly
+    const uncheckedOptions = wrapper.getAllByRole("checkbox", {
+      checked: false,
+    });
+    expect(uncheckedOptions).toHaveLength(3);
+    expect(parentCheckbox).not.toBeChecked();
+
+    // Tab away to trigger onComponentBlur()
+    fireEvent.blur(parentCheckbox);
+
+    // Rechecking should show the child radiofield doesn't have any option checked anymore
+    fireEvent.click(parentCheckbox);
+
+    // Confirm the checkbox options are checked correctly
+    const recheckedOptions = wrapper.getAllByRole("checkbox", {
+      checked: true,
+    });
+    expect(recheckedOptions).toHaveLength(1);
+    expect(parentCheckbox).toBeChecked();
+
+    const childRadioCleared: HTMLInputElement =
+      wrapper.container.querySelector("[name='Choice 4']")!;
+
+    expect(childRadioCleared).not.toBeChecked;
   });
 });
 

--- a/services/ui-src/src/components/fields/ChoiceListField.test.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.test.tsx
@@ -62,6 +62,23 @@ const mockNestedChoices = [
   },
 ];
 
+const mockNestedCheckboxChoices = [
+  {
+    id: "Choice 6",
+    name: "Choice 6",
+    label: "Choice 6",
+    value: "Choice 6",
+    checked: false,
+  },
+  {
+    id: "Choice 7",
+    name: "Choice 7",
+    label: "Choice 7",
+    value: "Choice 7",
+    checked: false,
+  },
+];
+
 const mockDropdownOptions = [
   {
     label: "Option 1",
@@ -84,6 +101,13 @@ const mockNestedChildren = [
     type: "radio",
     props: {
       choices: [...mockNestedChoices],
+    },
+  },
+  {
+    id: "test-nested-child-checkbox",
+    type: "checkbox",
+    props: {
+      choices: [...mockNestedCheckboxChoices],
     },
   },
   {
@@ -669,6 +693,95 @@ describe("Test Choicelist onChangeHandler", () => {
       wrapper.container.querySelector("[name='Choice 4']")!;
 
     expect(childRadioCleared).not.toBeChecked;
+  });
+
+  test("Selecting and unselecting a radio button that has nested checkbox children sets that checkbox to its default state", () => {
+    mockGetValues(undefined);
+
+    // Create the Radio Component
+    const wrapper = render(RadioComponentWithNestedChildren);
+
+    const parentRadio = wrapper.getByRole("radio", { name: "Choice 3" });
+
+    // Make sure default state is set correctly
+    expect(parentRadio).not.toBeChecked();
+
+    // Select the first Radio button and check it
+    fireEvent.click(parentRadio);
+
+    // Confirm the radio options are checked correctly
+    const selectedOptions = wrapper.getAllByRole("radio", {
+      checked: true,
+    });
+    expect(selectedOptions).toHaveLength(1);
+    expect(parentRadio).toBeChecked();
+
+    // Tab away to trigger onComponentBlur()
+    fireEvent.blur(parentRadio);
+
+    // Make sure the form value is set to what we've clicked (Which is only Choice 3)
+    const parentRadioData = [{ key: "Choice 3", value: "Choice 3" }];
+    expect(mockSetValue).toHaveBeenCalledWith(
+      "radioFieldWithNestedChildren",
+      parentRadioData,
+      {
+        shouldValidate: true,
+      }
+    );
+
+    // Now check the child radio field
+    const childCheckboxField = wrapper.getByRole("checkbox", {
+      name: "Choice 6",
+    });
+    fireEvent.click(childCheckboxField);
+
+    // Confirm the option was checked
+    expect(childCheckboxField).toBeChecked();
+
+    // Tab away to trigger onComponentBlur()
+    fireEvent.blur(childCheckboxField);
+
+    // Make sure the form value is set to with new child option
+    const childCheckboxData = [
+      { key: "test-nested-child-checkbox-Choice 6", value: "Choice 6" },
+    ];
+    expect(mockSetValue).toHaveBeenCalledWith(
+      "test-nested-child-checkbox",
+      childCheckboxData,
+      {
+        shouldValidate: true,
+      }
+    );
+
+    const otherRadio = wrapper.getByRole("radio", { name: "Choice 1" });
+
+    // Now uncheck the parent
+    fireEvent.click(otherRadio);
+
+    // Confirm the checkbox options are unchecked correctly
+    const unselectedOptions = wrapper.getAllByRole("radio", {
+      checked: false,
+    });
+    expect(unselectedOptions).toHaveLength(2);
+    expect(parentRadio).not.toBeChecked();
+
+    // Tab away to trigger onComponentBlur()
+    fireEvent.blur(parentRadio);
+
+    // Rechecking should show the child checkbox doesn't have any option checked anymore
+    fireEvent.click(parentRadio);
+
+    // Confirm the checkbox options are checked correctly
+    const reselectedOptions = wrapper.getAllByRole("radio", {
+      checked: true,
+    });
+    expect(reselectedOptions).toHaveLength(1);
+    expect(parentRadio).toBeChecked();
+
+    const childCheckboxCleared: HTMLInputElement =
+      wrapper.container.querySelector("[name='Choice 6']")!;
+
+    expect(childCheckboxCleared).not.toBeChecked;
   });
 });
 

--- a/services/ui-src/src/components/fields/ChoiceListField.test.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.test.tsx
@@ -76,6 +76,7 @@ const mockDropdownOptions = [
 const mockNestedChildren = [
   {
     id: "Choice 3-otherText",
+    name: "Choice 3-otherText",
     type: "text",
   },
   {
@@ -496,6 +497,94 @@ describe("Test Choicelist onChangeHandler", () => {
         shouldValidate: true,
       }
     );
+  });
+
+  test("Checking and unchecking choices that have nested children sets those children to default values", async () => {
+    mockGetValues(undefined);
+
+    // Create the Checkbox Component
+    const wrapper = render(CheckboxComponentWithNestedChildren);
+
+    const parentCheckbox = wrapper.getByRole("checkbox", { name: "Choice 3" });
+
+    // Make sure default state is set correctly
+    expect(parentCheckbox).not.toBeChecked();
+
+    // Select the first Checkbox and check it
+    fireEvent.click(parentCheckbox);
+
+    // Confirm the checkbox options are checked correctly
+    const checkedOptions = wrapper.getAllByRole("checkbox", {
+      checked: true,
+    });
+    expect(checkedOptions).toHaveLength(1);
+    expect(parentCheckbox).toBeChecked();
+
+    // Tab away to trigger onComponentBlur()
+    fireEvent.blur(parentCheckbox);
+
+    // Make sure the form value is set to what we've clicked (Which is only Choice 3)
+    const parentCheckboxData = [{ key: "Choice 3", value: "Choice 3" }];
+    expect(mockSetValue).toHaveBeenCalledWith(
+      "checkboxFieldWithNestedChildren",
+      parentCheckboxData,
+      {
+        shouldValidate: true,
+      }
+    );
+
+    const childTextBox: HTMLInputElement = wrapper.container.querySelector(
+      "[name='Choice 3-otherText']"
+    )!;
+    // Now type in the child textbox
+    fireEvent.click(childTextBox);
+    fireEvent.change(childTextBox, { target: { value: "Added Text" } });
+
+    // Confirm the text change was made
+    expect(childTextBox.value).toBe("Added Text");
+
+    // Tab away to trigger onComponentBlur()
+    fireEvent.blur(childTextBox);
+
+    // Make sure the form value is set to with new child text
+    expect(mockSetValue).toHaveBeenCalledWith(
+      "Choice 3-otherText",
+      "Added Text",
+      {
+        shouldValidate: true,
+      }
+    );
+
+    // Now blur the parent and make sure the fields underneath are clean
+    fireEvent.click(parentCheckbox);
+
+    // Confirm the checkbox options are unchecked correctly
+    const uncheckedOptions = wrapper.getAllByRole("checkbox", {
+      checked: false,
+    });
+    expect(uncheckedOptions).toHaveLength(3);
+    expect(parentCheckbox).not.toBeChecked();
+
+    // Tab away to trigger onComponentBlur()
+    fireEvent.blur(parentCheckbox);
+
+    // Rechecking should show the child textbox doesn't have the 'Added Text' value anymore
+    fireEvent.click(parentCheckbox);
+
+    // Confirm the checkbox options are checked correctly
+    const recheckedOptions = wrapper.getAllByRole("checkbox", {
+      checked: true,
+    });
+    expect(recheckedOptions).toHaveLength(1);
+    expect(parentCheckbox).toBeChecked();
+
+    // Tab away to trigger onComponentBlur()
+    fireEvent.blur(parentCheckbox);
+
+    const childTextBoxCleared: HTMLInputElement =
+      wrapper.container.querySelector("[name='Choice 3-otherText']")!;
+
+    expect(childTextBoxCleared.value).toBe("");
   });
 });
 

--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -86,20 +86,21 @@ export const ChoiceListField = ({
     choices.forEach((choice: FieldChoice) => {
       // if a choice is not selected and there are children, clear out any saved data
       if (choice.children) {
-        choice.children.forEach((child) => {
+        choice.children.forEach((child: FormField) => {
           switch (child.type) {
             case "radio":
             case "checkbox":
               if (child.props?.choices) {
                 child.props.choices.forEach((choice: FieldChoice) => {
                   choice.checked = false;
-                  form.setValue(child.id, [], { shouldValidate: true });
+                  form.setValue(child.id, []);
                 });
                 clearUncheckedNestedFields(child.props.choices);
               }
               break;
             default:
-              form.setValue(child.id, "", { shouldValidate: true });
+              child.props = { ...child.props, clear: true };
+              form.setValue(child.id, "");
               break;
           }
         });

--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -46,10 +46,11 @@ export const ChoiceListField = ({
 
   // set initial display value to form state field value or hydration value
   const hydrationValue = props?.hydrate;
+
   useEffect(() => {
     // if form state has value for field, set as display value
     const fieldValue = form.getValues(name);
-    if (fieldValue?.length > 0) {
+    if (fieldValue) {
       setDisplayValue(fieldValue);
       setLastDatabaseValue(fieldValue);
     }
@@ -168,14 +169,6 @@ export const ChoiceListField = ({
           fields,
           report: reportArgs,
           user,
-        });
-        /*
-         * This is used to trigger a final rerender of the fields so that the
-         * database and ui stay insync https://bit.ly/41jIn21
-         */
-        fields.forEach((field) => {
-          const { name, value } = field;
-          form.setValue(name, value, { shouldValidate: true });
         });
       }, timeInMs);
     }

--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -121,19 +121,22 @@ export const ChoiceListField = ({
     const preChangeFieldValues = displayValue || [];
     let selectedOptions = null;
 
-    if (!isOptionChecked) {
-      let option = choices.find((choice) => choice.id == clickedOption.key);
-      clearUncheckedNestedFields([option!]);
-    }
-
     // handle radio
     if (type === "radio") {
+      let everyOtherOption = choices.filter(
+        (choice) => choice.id != clickedOption.key
+      );
+      clearUncheckedNestedFields(everyOtherOption);
       selectedOptions = [clickedOption];
       setDisplayValue(selectedOptions);
-      form.setValue(name, selectedOptions);
+      form.setValue(name, selectedOptions, { shouldValidate: true });
     }
     // handle checkbox
     if (type === "checkbox") {
+      if (!isOptionChecked) {
+        let option = choices.find((choice) => choice.id == clickedOption.key);
+        clearUncheckedNestedFields([option!]);
+      }
       const checkedOptionValues = [...preChangeFieldValues, clickedOption];
       const uncheckedOptionValues = preChangeFieldValues.filter(
         (field) => field.value !== clickedOption.value

--- a/services/ui-src/src/components/fields/DateField.test.tsx
+++ b/services/ui-src/src/components/fields/DateField.test.tsx
@@ -75,6 +75,24 @@ describe("Test DateField hydration functionality", () => {
     />
   );
 
+  const clearPropGivenAndTrueDateField = (
+    <DateField
+      name="testDateFieldWithHydrationValue"
+      label="test-date-field-with-hydration-value"
+      hydrate={mockHydrationValue}
+      clear
+    />
+  );
+
+  const clearPropGivenAndFalseDateField = (
+    <DateField
+      name="testDateFieldWithHydrationValue"
+      label="test-date-field-with-hydration-value"
+      hydrate={mockHydrationValue}
+      clear={false}
+    />
+  );
+
   beforeEach(() => {
     mockedUseUser.mockReturnValue(mockStateUser);
   });
@@ -107,6 +125,27 @@ describe("Test DateField hydration functionality", () => {
     )!;
     const displayValue = dateFieldInput.value;
     expect(displayValue).toEqual(mockFormFieldValue);
+  });
+
+  test("should set value to default if given clear prop and clear is set to true", () => {
+    mockGetValues(undefined);
+
+    const result = render(clearPropGivenAndTrueDateField);
+    const dateField: HTMLInputElement = result.container.querySelector(
+      "[name='testDateFieldWithHydrationValue']"
+    )!;
+    const displayValue = dateField.value;
+    expect(displayValue).toEqual("");
+  });
+
+  test("should set value to hydrationvalue if given clear prop and clear is set to false", () => {
+    mockGetValues(undefined);
+    const result = render(clearPropGivenAndFalseDateField);
+    const dateField: HTMLInputElement = result.container.querySelector(
+      "[name='testDateFieldWithHydrationValue']"
+    )!;
+    const displayValue = dateField.value;
+    expect(displayValue).toEqual(mockHydrationValue);
   });
 });
 

--- a/services/ui-src/src/components/fields/DateField.tsx
+++ b/services/ui-src/src/components/fields/DateField.tsx
@@ -42,8 +42,13 @@ export const DateField = ({
     }
     // else set hydrationValue or defaultValue as display value
     else if (hydrationValue) {
-      setDisplayValue(hydrationValue);
-      form.setValue(name, hydrationValue);
+      if (props.clear) {
+        setDisplayValue(defaultValue);
+        form.setValue(name, defaultValue);
+      } else {
+        setDisplayValue(hydrationValue);
+        form.setValue(name, hydrationValue);
+      }
     }
   }, [hydrationValue]); // only runs on hydrationValue fetch/update
 

--- a/services/ui-src/src/components/fields/NumberField.test.tsx
+++ b/services/ui-src/src/components/fields/NumberField.test.tsx
@@ -185,6 +185,7 @@ describe("Test Masked NumberField", () => {
 describe("Test NumberField hydration functionality", () => {
   const mockFormFieldValue = "54321";
   const mockHydrationValue = "12345";
+  const mockCommaMaskedHydrationValue = "12,345";
 
   const numberFieldComponentWithHydrationValue = (
     <NumberField
@@ -192,6 +193,26 @@ describe("Test NumberField hydration functionality", () => {
       label="test-label"
       hydrate={mockHydrationValue}
       data-testid="test-id"
+    />
+  );
+
+  const clearPropGivenAndTrueNumberField = (
+    <NumberField
+      name="testNumberField"
+      label=""
+      mask="currency"
+      hydrate={mockHydrationValue}
+      clear
+    />
+  );
+
+  const clearPropGivenAndFalseNumberField = (
+    <NumberField
+      name="testNumberField"
+      label=""
+      mask="currency"
+      hydrate={mockHydrationValue}
+      clear={false}
     />
   );
 
@@ -230,6 +251,27 @@ describe("Test NumberField hydration functionality", () => {
     )!;
     const displayValue = numberField.value;
     expect(displayValue).toEqual(mockFormFieldValue);
+  });
+
+  test("should set value to default if given clear prop and clear is set to true", () => {
+    mockGetValues(undefined);
+
+    const result = render(clearPropGivenAndTrueNumberField);
+    const numberField: HTMLInputElement = result.container.querySelector(
+      "[name='testNumberField']"
+    )!;
+    const displayValue = numberField.value;
+    expect(displayValue).toEqual("");
+  });
+
+  test("should set value to hydrationvalue if given clear prop and clear is set to false", () => {
+    mockGetValues(undefined);
+    const result = render(clearPropGivenAndFalseNumberField);
+    const numberField: HTMLInputElement = result.container.querySelector(
+      "[name='testNumberField']"
+    )!;
+    const displayValue = numberField.value;
+    expect(displayValue).toEqual(mockCommaMaskedHydrationValue);
   });
 });
 

--- a/services/ui-src/src/components/fields/NumberField.tsx
+++ b/services/ui-src/src/components/fields/NumberField.tsx
@@ -42,9 +42,14 @@ export const NumberField = ({
     }
     // else set hydrationValue or defaultValue display value
     else if (hydrationValue) {
-      const maskedHydrationValue = applyCustomMask(hydrationValue, mask);
-      setDisplayValue(maskedHydrationValue);
-      form.setValue(name, maskedHydrationValue);
+      if (props.clear) {
+        setDisplayValue(defaultValue);
+        form.setValue(name, defaultValue);
+      } else {
+        const maskedHydrationValue = applyCustomMask(hydrationValue, mask);
+        setDisplayValue(maskedHydrationValue);
+        form.setValue(name, maskedHydrationValue);
+      }
     }
   }, [hydrationValue]); // only runs on hydrationValue fetch/update
 

--- a/services/ui-src/src/components/fields/RadioField.test.tsx
+++ b/services/ui-src/src/components/fields/RadioField.test.tsx
@@ -60,9 +60,11 @@ describe("Test RadioField component", () => {
     );
     const firstRadio = radioContainers[0].children[0] as HTMLInputElement;
     await userEvent.click(firstRadio);
-    expect(mockSetValue).toHaveBeenCalledWith("radio_choices", [
-      { key: "Choice 1", value: "A" },
-    ]);
+    expect(mockSetValue).toHaveBeenCalledWith(
+      "radio_choices",
+      [{ key: "Choice 1", value: "A" }],
+      { shouldValidate: true }
+    );
   });
 });
 

--- a/services/ui-src/src/components/fields/TextField.test.tsx
+++ b/services/ui-src/src/components/fields/TextField.test.tsx
@@ -83,6 +83,28 @@ describe("Test TextField hydration functionality", () => {
     />
   );
 
+  const clearPropGivenAndTrueTextField = (
+    <TextField
+      name="testTextFieldWithHydrationValue"
+      label="test-label"
+      placeholder="test-placeholder"
+      hydrate={mockHydrationValue}
+      data-testid="test-text-field-with-hydration-value"
+      clear
+    />
+  );
+
+  const clearPropGivenAndFalseTextField = (
+    <TextField
+      name="testTextFieldWithHydrationValue"
+      label="test-label"
+      placeholder="test-placeholder"
+      hydrate={mockHydrationValue}
+      data-testid="test-text-field-with-hydration-value"
+      clear={false}
+    />
+  );
+
   test("If only formFieldValue exists, displayValue is set to it", () => {
     mockGetValues(mockFormFieldValue);
     render(textFieldComponent);
@@ -109,6 +131,27 @@ describe("Test TextField hydration functionality", () => {
     );
     const displayValue = textField.value;
     expect(displayValue).toEqual(mockFormFieldValue);
+  });
+
+  test("should set value to default if given clear prop and clear is set to true", () => {
+    mockGetValues(undefined);
+
+    const result = render(clearPropGivenAndTrueTextField);
+    const textField: HTMLInputElement = result.container.querySelector(
+      "[name='testTextFieldWithHydrationValue']"
+    )!;
+    const displayValue = textField.value;
+    expect(displayValue).toEqual("");
+  });
+
+  test("should set value to hydrationvalue if given clear prop and clear is set to false", () => {
+    mockGetValues(undefined);
+    const result = render(clearPropGivenAndFalseTextField);
+    const textField: HTMLInputElement = result.container.querySelector(
+      "[name='testTextFieldWithHydrationValue']"
+    )!;
+    const displayValue = textField.value;
+    expect(displayValue).toEqual(mockHydrationValue);
   });
 });
 

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -29,6 +29,7 @@ export const TextField = ({
 
   // set initial display value to form state field value or hydration value
   const hydrationValue = props?.hydrate || defaultValue;
+
   useEffect(() => {
     // if form state has value for field, set as display value
     const fieldValue = form.getValues(name);
@@ -37,8 +38,13 @@ export const TextField = ({
     }
     // else set hydrationValue or defaultValue as display value
     else if (hydrationValue) {
-      setDisplayValue(hydrationValue);
-      form.setValue(name, hydrationValue, { shouldValidate: true });
+      if (props.clear) {
+        setDisplayValue(defaultValue);
+        form.setValue(name, defaultValue);
+      } else {
+        setDisplayValue(hydrationValue);
+        form.setValue(name, hydrationValue, { shouldValidate: true });
+      }
     }
   }, [hydrationValue]); // only runs on hydrationValue fetch/update
 

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -43,7 +43,7 @@ export const TextField = ({
         form.setValue(name, defaultValue);
       } else {
         setDisplayValue(hydrationValue);
-        form.setValue(name, hydrationValue, { shouldValidate: true });
+        form.setValue(name, hydrationValue);
       }
     }
   }, [hydrationValue]); // only runs on hydrationValue fetch/update

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -1,5 +1,10 @@
 import { ReactNode } from "react";
-import { FormProvider, useForm } from "react-hook-form";
+import {
+  FieldValues,
+  FormProvider,
+  SubmitErrorHandler,
+  useForm,
+} from "react-hook-form";
 import { object as yupSchema } from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
 // components
@@ -47,7 +52,9 @@ export const Form = ({
   });
 
   // will run if any validation errors exist on form submission
-  const onErrorHandler = (errors: AnyObject) => {
+  const onErrorHandler: SubmitErrorHandler<FieldValues> = (
+    errors: AnyObject
+  ) => {
     // sort errors in order of registration/page display
     const sortedErrors: string[] = sortFormErrors(formValidationSchema, errors);
     // focus the first error on the page and scroll to it
@@ -71,10 +78,7 @@ export const Form = ({
     <FormProvider {...form}>
       <form
         id={id}
-        onSubmit={form.handleSubmit(
-          onSubmit as any,
-          onError || (onErrorHandler as any)
-        )}
+        onSubmit={form.handleSubmit(onSubmit as any, onError || onErrorHandler)}
         {...props}
       >
         <Box sx={sx}>{renderFormFields(fields)}</Box>
@@ -88,7 +92,7 @@ interface Props {
   id: string;
   formJson: FormJson;
   onSubmit: Function;
-  onError?: Function;
+  onError?: SubmitErrorHandler<FieldValues>;
   formData?: AnyObject;
   autosave?: boolean;
   children?: ReactNode;

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -19,6 +19,7 @@ export const Form = ({
   id,
   formJson,
   onSubmit,
+  onError,
   formData,
   autosave,
   children,
@@ -70,7 +71,10 @@ export const Form = ({
     <FormProvider {...form}>
       <form
         id={id}
-        onSubmit={form.handleSubmit(onSubmit as any, onErrorHandler)}
+        onSubmit={form.handleSubmit(
+          onSubmit as any,
+          onError || (onErrorHandler as any)
+        )}
         {...props}
       >
         <Box sx={sx}>{renderFormFields(fields)}</Box>
@@ -84,6 +88,7 @@ interface Props {
   id: string;
   formJson: FormJson;
   onSubmit: Function;
+  onError?: Function;
   formData?: AnyObject;
   autosave?: boolean;
   children?: ReactNode;

--- a/services/ui-src/src/components/reports/ReportPageFooter.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.tsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import { useNavigate } from "react-router-dom";
 // components
-import { Box, Button, Flex, Image } from "@chakra-ui/react";
+import { Box, Button, Flex, Image, Spinner } from "@chakra-ui/react";
 import { ReportContext } from "components";
 // utils
 import { useFindRoute, useUser } from "utils";
@@ -10,7 +10,7 @@ import { FormJson } from "types";
 import nextIcon from "assets/icons/icon_next_white.png";
 import previousIcon from "assets/icons/icon_previous_blue.png";
 
-export const ReportPageFooter = ({ form, ...props }: Props) => {
+export const ReportPageFooter = ({ submitting, form, ...props }: Props) => {
   const navigate = useNavigate();
   const { report } = useContext(ReportContext);
   const { previousRoute, nextRoute } = useFindRoute(
@@ -39,7 +39,13 @@ export const ReportPageFooter = ({ form, ...props }: Props) => {
           {!form?.id || formIsDisabled ? (
             <Button
               onClick={() => navigate(nextRoute)}
-              rightIcon={<Image src={nextIcon} alt="Next" sx={sx.arrowIcon} />}
+              rightIcon={
+                submitting ? (
+                  <></>
+                ) : (
+                  <Image src={nextIcon} alt="Next" sx={sx.arrowIcon} />
+                )
+              }
             >
               Continue
             </Button>
@@ -47,9 +53,14 @@ export const ReportPageFooter = ({ form, ...props }: Props) => {
             <Button
               form={form.id}
               type="submit"
-              rightIcon={<Image src={nextIcon} alt="Next" sx={sx.arrowIcon} />}
+              sx={sx.button}
+              rightIcon={
+                !submitting ? (
+                  <Image src={nextIcon} alt="Next" sx={sx.arrowIcon} />
+                ) : undefined
+              }
             >
-              Continue
+              {submitting ? <Spinner size="sm" /> : "Continue"}
             </Button>
           )}
         </Flex>
@@ -61,6 +72,7 @@ export const ReportPageFooter = ({ form, ...props }: Props) => {
 
 interface Props {
   form?: FormJson;
+  submitting?: boolean;
   [key: string]: any;
 }
 
@@ -75,5 +87,8 @@ const sx = {
   },
   arrowIcon: {
     width: "1rem",
+  },
+  button: {
+    width: "8.25rem",
   },
 };

--- a/services/ui-src/src/components/reports/StandardReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
+import userEvent from "@testing-library/user-event";
 // components
 import { ReportContext, StandardReportPage } from "components";
 // utils
@@ -24,6 +25,31 @@ describe("Test StandardReportPage", () => {
   test("StandardReportPage view renders", () => {
     render(standardPageSectionComponent);
     expect(screen.getByTestId("standard-page")).toBeVisible();
+  });
+
+  test("StandardReportPage correctly submits a valid form", async () => {
+    const result = render(standardPageSectionComponent);
+    const textFieldInput: HTMLInputElement = result.container.querySelector(
+      "[id='mock-text-field'"
+    )!;
+    await userEvent.type(textFieldInput, "ABC");
+    expect(textFieldInput.value).toEqual("ABC");
+    const continueButton = screen.getByText("Continue")!;
+    await userEvent.click(continueButton);
+  });
+
+  test("StandardReportPage navigates to next route onError", async () => {
+    const result = render(standardPageSectionComponent);
+    const currentPath = window.location.pathname;
+    const textFieldInput: HTMLInputElement = result.container.querySelector(
+      "[id='mock-text-field'"
+    )!;
+    await userEvent.type(textFieldInput, "      ");
+    const continueButton = screen.getByText("Continue")!;
+    await userEvent.click(continueButton);
+    // test that form navigates with an error in the field
+    const newPath = window.location.pathname;
+    expect(currentPath).not.toBe(newPath);
   });
 });
 

--- a/services/ui-src/src/components/reports/StandardReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.test.tsx
@@ -40,16 +40,17 @@ describe("Test StandardReportPage", () => {
 
   test("StandardReportPage navigates to next route onError", async () => {
     const result = render(standardPageSectionComponent);
-    const currentPath = window.location.pathname;
+    let currentPath = window.location.pathname;
+    expect(currentPath).toBe("/");
     const textFieldInput: HTMLInputElement = result.container.querySelector(
       "[id='mock-text-field'"
     )!;
     await userEvent.type(textFieldInput, "      ");
     const continueButton = screen.getByText("Continue")!;
     await userEvent.click(continueButton);
+    currentPath = window.location.pathname;
     // test that form navigates with an error in the field
-    const newPath = window.location.pathname;
-    expect(currentPath).not.toBe(newPath);
+    expect(currentPath).not.toBe("/");
   });
 });
 

--- a/services/ui-src/src/components/reports/StandardReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.test.tsx
@@ -40,7 +40,7 @@ describe("Test StandardReportPage", () => {
 
   test("StandardReportPage navigates to next route onError", async () => {
     const result = render(standardPageSectionComponent);
-    let currentPath = window.location.pathname;
+    const currentPath = window.location.pathname;
     expect(currentPath).toBe("/");
     const textFieldInput: HTMLInputElement = result.container.querySelector(
       "[id='mock-text-field'"
@@ -48,9 +48,9 @@ describe("Test StandardReportPage", () => {
     await userEvent.type(textFieldInput, "      ");
     const continueButton = screen.getByText("Continue")!;
     await userEvent.click(continueButton);
-    currentPath = window.location.pathname;
     // test that form navigates with an error in the field
-    expect(currentPath).not.toBe("/");
+    const newPath = window.location.pathname;
+    expect(newPath).not.toBe("/");
   });
 });
 

--- a/services/ui-src/src/components/reports/StandardReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.test.tsx
@@ -40,8 +40,6 @@ describe("Test StandardReportPage", () => {
 
   test("StandardReportPage navigates to next route onError", async () => {
     const result = render(standardPageSectionComponent);
-    const currentPath = window.location.pathname;
-    expect(currentPath).toBe("/");
     const textFieldInput: HTMLInputElement = result.container.querySelector(
       "[id='mock-text-field'"
     )!;

--- a/services/ui-src/src/components/reports/StandardReportPage.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 // components
 import { Box } from "@chakra-ui/react";
@@ -9,16 +9,42 @@ import {
   ReportPageIntro,
 } from "components";
 // utils
-import { useFindRoute } from "utils";
-import { StandardReportPageShape } from "types";
+import { filterFormData, useFindRoute, useUser } from "utils";
+import { AnyObject, ReportStatus, StandardReportPageShape } from "types";
 
 export const StandardReportPage = ({ route }: Props) => {
-  const { report } = useContext(ReportContext);
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const { report, updateReport } = useContext(ReportContext);
+  const { full_name, state } = useUser().user ?? {};
   const navigate = useNavigate();
   const { nextRoute } = useFindRoute(
     report!.formTemplate.flatRoutes!,
     report!.formTemplate.basePath
   );
+
+  const onError = () => {
+    navigate(nextRoute);
+  };
+
+  const onSubmit = async (enteredData: AnyObject) => {
+    setSubmitting(true);
+    const reportKeys = {
+      state: state,
+      id: report?.id,
+    };
+    const filteredFormData = filterFormData(enteredData, route.form.fields);
+    const dataToWrite = {
+      metadata: {
+        status: ReportStatus.IN_PROGRESS,
+        lastAlteredBy: full_name,
+      },
+      fieldData: filteredFormData,
+    };
+    await updateReport(reportKeys, dataToWrite);
+    setSubmitting(false);
+
+    navigate(nextRoute);
+  };
 
   return (
     <Box data-testid="standard-page">
@@ -26,11 +52,12 @@ export const StandardReportPage = ({ route }: Props) => {
       <Form
         id={route.form.id}
         formJson={route.form}
-        onSubmit={() => navigate(nextRoute)}
+        onSubmit={onSubmit}
+        onError={onError}
         formData={report?.fieldData}
         autosave
       />
-      <ReportPageFooter form={route.form} />
+      <ReportPageFooter submitting={submitting} form={route.form} />
     </Box>
   );
 };


### PR DESCRIPTION
## Summary

### Description
<!-- Detailed description of changes and related context -->

Autosave has been updated with quite a few new fixes:

- Hitting enter on the form will autosave the formpage before navigating you to the next page
- Validation will no longer stop you form continuing to the next page
- Choicelists and their children have been revamped to clear any choices or text boxes underneath them if you uncheck them
- Validation on Choicelists has been slightly relaxed to not be so angry all the time.


### Related ticket
<!-- Link to related ticket or issue -->

### How to test
<!-- Step-by-step instructions on how to test -->
./dev local
Sign in as a state user
Create a report
Open report
Start filling out fields! Pay particular attention to checkboxes and radiofields that have nested options under them (Like page B3!)

### Important updates
<!-- Any changed dependencies, .env files, local configs, etc. and
instructions for other engineers, e.g. requires new installs in directories -->

### Author checklist
<!-- Complete the following before marking ready for review -->
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated the documentation, if necessary
