### PR TITLE
Revert Reporting API Path (Serverless Bug Fix)

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -165,7 +165,7 @@ functions:
     handler: handlers/reports/fetch.fetchReport
     events:
       - http:
-          path: reporting/{reportType}/{state}/{id}
+          path: reports/{reportType}/{state}/{id}
           method: get
           cors: true
           authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
@@ -179,7 +179,7 @@ functions:
     handler: handlers/reports/fetch.fetchReportsByState
     events:
       - http:
-          path: reporting/{reportType}/{state}
+          path: reports/{reportType}/{state}
           method: get
           cors: true
           authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
@@ -193,7 +193,7 @@ functions:
     handler: handlers/reports/archive.archiveReport
     events:
       - http:
-          path: reporting/archive/{reportType}/{state}/{id}
+          path: reports/archive/{reportType}/{state}/{id}
           method: put
           cors: true
           authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
@@ -206,7 +206,7 @@ functions:
     handler: handlers/reports/create.createReport
     events:
       - http:
-          path: reporting/{reportType}/{state}
+          path: reports/{reportType}/{state}
           method: post
           cors: true
           authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
@@ -221,7 +221,7 @@ functions:
     memorySize: 2048
     events:
       - http:
-          path: reporting/{reportType}/{state}/{id}
+          path: reports/{reportType}/{state}/{id}
           method: put
           cors: true
           authorizer: ${self:custom.authValue.${self:custom.stage}, ""}

--- a/services/ui-src/src/utils/api/requestMethods/report.ts
+++ b/services/ui-src/src/utils/api/requestMethods/report.ts
@@ -13,7 +13,7 @@ async function archiveReport(reportKeys: ReportKeys) {
   updateTimeout();
   const response = await API.put(
     "mcr",
-    `/reporting/archive/${reportType}/${state}/${id}`,
+    `/reports/archive/${reportType}/${state}/${id}`,
     request
   );
   return response;
@@ -29,7 +29,7 @@ async function getReport(reportKeys: ReportKeys) {
   updateTimeout();
   const response = await API.get(
     "mcr",
-    `/reporting/${reportType}/${state}/${id}`,
+    `/reports/${reportType}/${state}/${id}`,
     request
   );
   return response;
@@ -44,7 +44,7 @@ async function getReportsByState(reportType: string, state: string) {
   updateTimeout();
   const response = await API.get(
     "mcr",
-    `/reporting/${reportType}/${state}`,
+    `/reports/${reportType}/${state}`,
     request
   );
   return response;
@@ -64,7 +64,7 @@ async function postReport(
   updateTimeout();
   const response = await API.post(
     "mcr",
-    `/reporting/${reportType}/${state}`,
+    `/reports/${reportType}/${state}`,
     request
   );
   return response;
@@ -81,7 +81,7 @@ async function putReport(reportKeys: ReportKeys, report: ReportShape) {
   updateTimeout();
   const response = await API.put(
     "mcr",
-    `/reporting/${reportType}/${state}/${id}`,
+    `/reports/${reportType}/${state}/${id}`,
     request
   );
   return response;


### PR DESCRIPTION
## Summary

### Description

Context on this closed out [PR](https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/11086).

This branch reverts the new `reporting/` API path to `reports/` 

### Related ticket

N/A

### How to test

N/A

### Important updates

See description.

### Author checklist
<!-- Complete the following before marking ready for review -->
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated the documentation, if necessary
