### PR TITLE
Feature Flagging AdminDashSelector

### DIFF
--- a/services/ui-src/src/components/forms/AdminDashSelector.test.tsx
+++ b/services/ui-src/src/components/forms/AdminDashSelector.test.tsx
@@ -4,7 +4,11 @@ import userEvent from "@testing-library/user-event";
 // components
 import { AdminDashSelector } from "components";
 // utils
-import { mockAdminUser, RouterWrappedComponent } from "utils/testing/setupJest";
+import {
+  mockAdminUser,
+  mockLDFlags,
+  RouterWrappedComponent,
+} from "utils/testing/setupJest";
 import { useUser } from "utils";
 
 // MOCKS
@@ -22,6 +26,8 @@ const adminDashSelectorView = (
     <AdminDashSelector verbiage={mockVerbiage} />
   </RouterWrappedComponent>
 );
+
+mockLDFlags.setDefault({ mlrReport: true });
 
 // TESTS
 
@@ -50,6 +56,28 @@ describe("Test AdminDashSelector view", () => {
     const submitButton = screen.getByRole("button");
     await userEvent.click(submitButton);
     expect(window.location.pathname).toEqual("/mcpar");
+  });
+});
+
+describe("Test mlrReport feature flag functionality", () => {
+  beforeEach(() => {
+    mockedUseUser.mockReturnValue(mockAdminUser);
+  });
+  test("if mlrReport flag is true, MLR radio choice should be visible", async () => {
+    mockLDFlags.set({ mlrReport: true });
+    render(adminDashSelectorView);
+    expect(
+      screen.getByLabelText("Medicaid Medical Loss Ratio (MLR)")
+    ).toBeVisible();
+  });
+
+  test("if mlrReport flag is false, MLR available verbiage should not be visible", async () => {
+    mockLDFlags.set({ mlrReport: false });
+    render(adminDashSelectorView);
+    const mlrRadioChoice = screen.queryByLabelText(
+      "Medicaid Medical Loss Ratio (MLR)"
+    );
+    expect(mlrRadioChoice).toBeNull();
   });
 });
 

--- a/services/ui-src/src/components/forms/AdminDashSelector.tsx
+++ b/services/ui-src/src/components/forms/AdminDashSelector.tsx
@@ -31,7 +31,7 @@ export const AdminDashSelector = ({ verbiage }: Props) => {
   };
 
   // assemble and inject report choices depending on whether report is enabled
-  const { mlrReport } = useFlags();
+  const mlrReport = useFlags()?.mlrReport;
   if (mlrReport) {
     reportChoices.push(mlrReportChoice);
   }

--- a/services/ui-src/src/components/forms/AdminDashSelector.tsx
+++ b/services/ui-src/src/components/forms/AdminDashSelector.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useFlags } from "launchdarkly-react-client-sdk";
 // components
 import { Box, Button, Flex, Heading } from "@chakra-ui/react";
 import { Form } from "components";
@@ -16,6 +17,26 @@ export const AdminDashSelector = ({ verbiage }: Props) => {
 
   const { userIsAdmin, userIsApprover, userIsHelpDeskUser } =
     useUser().user ?? {};
+
+  // create radio options
+  const reportChoices = [
+    {
+      id: "MCPAR",
+      label: "Managed Care Program Annual Report (MCPAR)",
+    },
+  ];
+  const mlrReportChoice = {
+    id: "MLR",
+    label: "Medicaid Medical Loss Ratio (MLR)",
+  };
+
+  // assemble and inject report choices depending on whether report is enabled
+  const { mlrReport } = useFlags();
+  if (mlrReport) {
+    reportChoices.push(mlrReportChoice);
+  }
+  const reportField = formJson.fields.find((field) => field.id === "report")!;
+  reportField.props.choices = reportChoices;
 
   // add validation to formJson
   const form: FormJson = formJson;

--- a/services/ui-src/src/forms/adminDashSelector/adminDashSelector.ts
+++ b/services/ui-src/src/forms/adminDashSelector/adminDashSelector.ts
@@ -9,15 +9,10 @@ const dropdownOptions: DropdownOptions[] = Object.keys(States).map((value) => {
   };
 });
 
-// create radio options
 const reportChoices = [
   {
     id: "MCPAR",
     label: "Managed Care Program Annual Report (MCPAR)",
-  },
-  {
-    id: "MLR",
-    label: "Medicaid Medical Loss Ratio (MLR)",
   },
 ];
 
@@ -45,7 +40,7 @@ export default {
       props: {
         hint: "Select a report:",
         choices: reportChoices,
-        ariaLabel: "Choices of report type, including MCPAR and MLR",
+        ariaLabel: "Choices of report type",
       },
     },
   ],


### PR DESCRIPTION
## Summary

### Description

Setting the `AdminDashSelector` landing page behind a feature flag to not show MLR as an option unless toggled `true`

### Related ticket

N/A

### How to test

- Log in as an admin
- Should be able to see MLR as an option
- Toggle `mlrReport` on LaunchDarkly to `false`
- Should not be able to see MLR as an option

### Important updates

N/A

### Author checklist
<!-- Complete the following before marking ready for review -->
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated the documentation, if necessary
