### PR TITLE
[MDCT-2274] Delete topic before teardown

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -42,6 +42,6 @@ jobs:
         run: ./.github/github-lock.sh $branch_name
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./scripts/destroy.sh $STAGE_PREFIX$branch_name
       - name: Delete topics
         run: run deleteTopics --stage $STAGE_NAME
+      - run: ./scripts/destroy.sh $STAGE_PREFIX$branch_name


### PR DESCRIPTION
## Summary

### Description
Move the deletion of kafka topics to take place before the teardown of AWS resources. The delete topics handler has been tested and works, so this should just be an order of operations problem

### Related ticket
[MDCT-2274](https://qmacbis.atlassian.net/browse/MDCT-2274)

### How to test
Merge :(

### Important updates
None

### Author checklist
<!-- Complete the following before marking ready for review -->
- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated the documentation, if necessary
