### PR TITLE
Autosave patch - Dynamic Fields and Autocomplete

### DIFF
--- a/services/ui-src/src/components/fields/DynamicField.tsx
+++ b/services/ui-src/src/components/fields/DynamicField.tsx
@@ -33,6 +33,7 @@ export const DynamicField = ({ name, label, ...props }: Props) => {
 
   // get form context and register field
   const form = useFormContext();
+
   form.register(name);
 
   const openDeleteProgramModal = (index: number) => {
@@ -176,7 +177,6 @@ export const DynamicField = ({ name, label, ...props }: Props) => {
         newInputAdded || existingInputChanged ? displayValues : hydrationValue;
       // set and append values
       setDisplayValues(valuesToSet);
-      append(valuesToSet);
     } else {
       appendNewRecord();
     }

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -78,6 +78,7 @@ export const Form = ({
     <FormProvider {...form}>
       <form
         id={id}
+        autoComplete="off"
         onSubmit={form.handleSubmit(onSubmit as any, onError || onErrorHandler)}
         {...props}
       >

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -42,7 +42,7 @@ export const formFieldFactory = (
       key: field.id,
       name: field.id,
       hydrate: field.props?.hydrate,
-      autoComplete: "one-time-code",
+      autoComplete: "one-time-code", // stops browsers from forcing autofill
       ...options,
       ...field?.props,
     };

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -42,6 +42,7 @@ export const formFieldFactory = (
       key: field.id,
       name: field.id,
       hydrate: field.props?.hydrate,
+      autoComplete: "one-time-code",
       ...options,
       ...field?.props,
     };


### PR DESCRIPTION
## Summary

### Description
<!-- Detailed description of changes and related context -->
There is a duplication bug that was happening for any dynamic fields where if the user adds more then 1 item it will duplicate it. Now users can add back in as many fields as they like and it's saved appropriately

Additionally it was possible for users to autofill over multiple fields. While it showed other fields as being saved it wouldn't actually save that field if a user had not focused it. This makes it so the user can still autofill but only the field they are on


### Related ticket
Fixes [MDCT-2311](https://qmacbis.atlassian.net/browse/MDCT-2311) and [MDCT-2306](https://qmacbis.atlassian.net/browse/MDCT-2306)

### How to test
<!-- Step-by-step instructions on how to test -->

#### Dynamic Field
Create a report
Go to Add a plan in the first sectiion
Add multiple plans using tabs, clicking, whatever,
Save and continue to the next page
come back
Verify everythings the same as you left it
Hard refresh
Verify everythings the same as you left it
Delete a record or 2
Hard refresh/continue away
Verify everythings the same as you left it

#### Autofill
Create a report
Go to the contact information
See that by adding a contact name it won't also add an email if you input an email as the contact name


### Author checklist
<!-- Complete the following before marking ready for review -->
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated the documentation, if necessary
