### PR TITLE
Admin Action Buttons for Report Dashboards (Mobile & Desktop)

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -58,16 +58,28 @@ export const DashboardTable = ({
           </Button>
         </Td>
         {isAdmin && (
-          <AdminActionButtons
-            report={report}
-            reportType={reportType}
-            archiveReport={archiveReport}
-            archiving={archiving}
-            unlockReport={unlockReport}
-            unlocking={unlocking}
-            reportId={reportId}
-            sxOverride={sxOverride}
-          />
+          <>
+            {reportType === "MLR" && (
+              <AdminUnlockButton
+                report={report}
+                reportType={reportType}
+                reportId={reportId}
+                unlockReport={unlockReport}
+                unlocking={unlocking}
+                sxOverride={sxOverride}
+              />
+            )}
+            <AdminArchiveButton
+              report={report}
+              reportType={reportType}
+              reportId={reportId}
+              archiveReport={archiveReport}
+              archiving={archiving}
+              unlockReport={unlockReport}
+              unlocking={unlocking}
+              sxOverride={sxOverride}
+            />
+          </>
         )}
       </Tr>
     ))}
@@ -124,51 +136,54 @@ interface DateFieldProps {
   reportType: string;
 }
 
-const AdminActionButtons = ({
+const AdminUnlockButton = ({
   report,
-  reportType,
   reportId,
-  archiveReport,
-  archiving,
   unlocking,
   unlockReport,
   sxOverride,
 }: AdminActionButtonProps) => {
   return (
-    <>
-      {reportType === "MLR" && (
-        <Td>
-          <Button
-            variant="link"
-            disabled={report.locked === false}
-            sx={sxOverride.adminActionButton}
-            onClick={() => unlockReport!(report)}
-          >
-            {unlocking && reportId === report.id ? (
-              <Spinner size="small" />
-            ) : (
-              "Unlock"
-            )}
-          </Button>
-        </Td>
-      )}
+    <Td>
+      <Button
+        variant="link"
+        disabled={report.locked === false}
+        sx={sxOverride.adminActionButton}
+        onClick={() => unlockReport!(report)}
+      >
+        {unlocking && reportId === report.id ? (
+          <Spinner size="small" />
+        ) : (
+          "Unlock"
+        )}
+      </Button>
+    </Td>
+  );
+};
 
-      <Td>
-        <Button
-          variant="link"
-          sx={sxOverride.adminActionButton}
-          onClick={() => archiveReport(report)}
-        >
-          {archiving && reportId === report.id ? (
-            <Spinner size="small" />
-          ) : report?.archived ? (
-            "Unarchive"
-          ) : (
-            "Archive"
-          )}
-        </Button>
-      </Td>
-    </>
+const AdminArchiveButton = ({
+  report,
+  reportId,
+  archiveReport,
+  archiving,
+  sxOverride,
+}: AdminActionButtonProps) => {
+  return (
+    <Td>
+      <Button
+        variant="link"
+        sx={sxOverride.adminActionButton}
+        onClick={() => archiveReport!(report)}
+      >
+        {archiving && reportId === report.id ? (
+          <Spinner size="small" />
+        ) : report?.archived ? (
+          "Unarchive"
+        ) : (
+          "Archive"
+        )}
+      </Button>
+    </Td>
   );
 };
 
@@ -176,11 +191,10 @@ interface AdminActionButtonProps {
   report: ReportMetadataShape;
   reportType: string;
   reportId: string | undefined;
-  archiveReport: Function;
-  archiving: boolean;
+  archiveReport?: Function;
+  archiving?: boolean;
   unlocking?: boolean;
   unlockReport?: Function;
-  mobile?: boolean;
   sxOverride: AnyObject;
 }
 

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
@@ -74,16 +74,24 @@ export const MobileDashboardTable = ({
           </Box>
           <Box sx={sxOverride.adminActionCell}>
             {isAdmin && (
-              <AdminActionButtons
-                report={report}
-                reportType={reportType}
-                reportId={reportId}
-                archiveReport={archiveReport}
-                archiving={archiving}
-                unlockReport={unlockReport}
-                unlocking={unlocking}
-                sxOverride={sxOverride}
-              />
+              <>
+                {reportType === "MLR" && (
+                  <AdminUnlockButton
+                    report={report}
+                    reportId={reportId}
+                    unlockReport={unlockReport}
+                    unlocking={unlocking}
+                    sxOverride={sxOverride}
+                  />
+                )}
+                <AdminArchiveButton
+                  report={report}
+                  reportId={reportId}
+                  archiveReport={archiveReport}
+                  archiving={archiving}
+                  sxOverride={sxOverride}
+                />
+              </>
             )}
           </Box>
         </Flex>
@@ -129,56 +137,58 @@ interface DateFieldProps {
   reportType: string;
 }
 
-const AdminActionButtons = ({
+const AdminUnlockButton = ({
   report,
-  reportType,
   reportId,
-  archiveReport,
-  archiving,
   unlocking,
   unlockReport,
   sxOverride,
 }: AdminActionButtonProps) => {
   return (
-    <>
-      {reportType === "MLR" && (
-        <Button
-          variant="link"
-          disabled={report.locked === false}
-          sx={sxOverride.adminActionButton}
-          onClick={() => unlockReport!(report)}
-        >
-          {unlocking && reportId === report.id ? (
-            <Spinner size="small" />
-          ) : (
-            "Unlock"
-          )}
-        </Button>
+    <Button
+      variant="link"
+      disabled={report.locked === false}
+      sx={sxOverride.adminActionButton}
+      onClick={() => unlockReport!(report)}
+    >
+      {unlocking && reportId === report.id ? (
+        <Spinner size="small" />
+      ) : (
+        "Unlock"
       )}
+    </Button>
+  );
+};
 
-      <Button
-        variant="link"
-        sx={sxOverride.adminActionButton}
-        onClick={() => archiveReport(report)}
-      >
-        {archiving && reportId === report.id ? (
-          <Spinner size="small" />
-        ) : report?.archived ? (
-          "Unarchive"
-        ) : (
-          "Archive"
-        )}
-      </Button>
-    </>
+const AdminArchiveButton = ({
+  report,
+  reportId,
+  archiveReport,
+  archiving,
+  sxOverride,
+}: AdminActionButtonProps) => {
+  return (
+    <Button
+      variant="link"
+      sx={sxOverride.adminActionButton}
+      onClick={() => archiveReport!(report)}
+    >
+      {archiving && reportId === report.id ? (
+        <Spinner size="small" />
+      ) : report?.archived ? (
+        "Unarchive"
+      ) : (
+        "Archive"
+      )}
+    </Button>
   );
 };
 
 interface AdminActionButtonProps {
   report: ReportMetadataShape;
-  reportType: string;
   reportId: string | undefined;
-  archiveReport: Function;
-  archiving: boolean;
+  archiveReport?: Function;
+  archiving?: boolean;
   unlocking?: boolean;
   unlockReport?: Function;
   sxOverride: AnyObject;


### PR DESCRIPTION
## Summary

### Description

Making each action button its own component for better readability and future requirements.

### Related ticket

N/A

### How to test

Log in as an admin, view both dashboards:

- MLR should have `Unlock` and `Archive`
- MCPAR should just have `Archive`

### Important updates

N/A

### Author checklist
<!-- Complete the following before marking ready for review -->
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated the documentation, if necessary
