### PR TITLE
[MDCT-2226] MLR Page 1 (and basic review/submit)

### DIFF
--- a/services/app-api/handlers/reports/archive.test.ts
+++ b/services/app-api/handlers/reports/archive.test.ts
@@ -26,7 +26,7 @@ const mockedFetchReport = fetchReport as jest.MockedFunction<
 const mockProxyEvent: APIGatewayProxyEvent = {
   ...proxyEvent,
   headers: { "cognito-identity-id": "test" },
-  pathParameters: { reportType: "mock-type", state: "AB", id: "testReportId" },
+  pathParameters: { reportType: "MCPAR", state: "AB", id: "testReportId" },
   body: JSON.stringify(mockMcparReport),
 };
 

--- a/services/app-api/handlers/reports/create.test.ts
+++ b/services/app-api/handlers/reports/create.test.ts
@@ -18,7 +18,7 @@ jest.mock("../../utils/debugging/debug-lib", () => ({
 const mockProxyEvent = {
   ...proxyEvent,
   headers: { "cognito-identity-id": "test" },
-  pathParameters: { reportType: "mock-type", state: "AB" },
+  pathParameters: { reportType: "MCPAR", state: "AB" },
 };
 
 const creationEvent: APIGatewayProxyEvent = {

--- a/services/app-api/handlers/reports/fetch.test.ts
+++ b/services/app-api/handlers/reports/fetch.test.ts
@@ -24,7 +24,7 @@ const testReadEvent: APIGatewayProxyEvent = {
   ...proxyEvent,
   headers: { "cognito-identity-id": "test" },
   pathParameters: {
-    reportType: "mock-type",
+    reportType: "MCPAR",
     state: "AB",
     id: "mock-report-id",
   },
@@ -33,7 +33,7 @@ const testReadEvent: APIGatewayProxyEvent = {
 const testReadEventByState: APIGatewayProxyEvent = {
   ...proxyEvent,
   headers: { "cognito-identity-id": "test" },
-  pathParameters: { reportType: "mock-type", state: "AB" },
+  pathParameters: { reportType: "MCPAR", state: "AB" },
 };
 
 describe("Test fetchReport API method", () => {

--- a/services/app-api/handlers/reports/unlock.test.ts
+++ b/services/app-api/handlers/reports/unlock.test.ts
@@ -26,7 +26,7 @@ const mockedFetchReport = fetchReport as jest.MockedFunction<
 const mockProxyEvent: APIGatewayProxyEvent = {
   ...proxyEvent,
   headers: { "cognito-identity-id": "test" },
-  pathParameters: { reportType: "mock-type", state: "AB", id: "testReportId" },
+  pathParameters: { reportType: "MCPAR", state: "AB", id: "testReportId" },
   body: JSON.stringify(mockMcparReport),
 };
 

--- a/services/app-api/handlers/reports/update.test.ts
+++ b/services/app-api/handlers/reports/update.test.ts
@@ -29,7 +29,7 @@ const mockedFetchReport = fetchReport as jest.MockedFunction<
 const mockProxyEvent: APIGatewayProxyEvent = {
   ...proxyEvent,
   headers: { "cognito-identity-id": "test" },
-  pathParameters: { reportType: "mock-type", state: "AB", id: "testReportId" },
+  pathParameters: { reportType: "MCPAR", state: "AB", id: "testReportId" },
   body: JSON.stringify(mockMcparReport),
 };
 

--- a/services/app-api/utils/testing/setupJest.ts
+++ b/services/app-api/utils/testing/setupJest.ts
@@ -54,7 +54,7 @@ export const mockReportJson = {
 };
 
 export const mockReportKeys = {
-  reportType: "mock-type",
+  reportType: "MCPAR",
   state: "AB",
   id: "mock-report-id",
 };
@@ -66,7 +66,7 @@ export const mockReportFieldData = {
 
 export const mockDynamoData = {
   ...mockReportKeys,
-  reportType: "mock-type",
+  reportType: "MCPAR",
   programName: "testProgram",
   status: "Not started",
   reportingPeriodStartDate: 162515200000,
@@ -83,7 +83,7 @@ export const mockDynamoData = {
 export const mockMcparReport = {
   ...mockReportKeys,
   metadata: {
-    reportType: "mock-type",
+    reportType: "MCPAR",
     programName: "testProgram",
     status: "Not started",
     reportingPeriodStartDate: 162515200000,

--- a/services/ui-src/src/components/fields/DynamicField.test.tsx
+++ b/services/ui-src/src/components/fields/DynamicField.test.tsx
@@ -385,7 +385,7 @@ describe("Test DynamicField Autosave Functionality", () => {
     await userEvent.tab();
     expect(mockUpdateReport).toHaveBeenCalledTimes(1);
     expect(mockUpdateReport).lastCalledWith(
-      { reportType: "mock-type", id: "mock-report-id", state: "MN" },
+      { reportType: "MCPAR", id: "mock-report-id", state: "MN" },
       {
         fieldData: {
           plans: [{ id: firstDynamicField.id, name: "Plans" }],
@@ -398,7 +398,7 @@ describe("Test DynamicField Autosave Functionality", () => {
     await userEvent.tab();
     expect(mockUpdateReport).toHaveBeenCalledTimes(1);
     expect(mockUpdateReport).lastCalledWith(
-      { reportType: "mock-type", id: "mock-report-id", state: "MN" },
+      { reportType: "MCPAR", id: "mock-report-id", state: "MN" },
       {
         fieldData: {
           plans: [{ id: firstDynamicField.id, name: "" }],
@@ -425,7 +425,7 @@ describe("Test DynamicField Autosave Functionality", () => {
     expect(firstDynamicField.value).toBe("123");
     expect(mockUpdateReport).toHaveBeenCalledTimes(1);
     expect(mockUpdateReport).lastCalledWith(
-      { reportType: "mock-type", id: "mock-report-id", state: "MN" },
+      { reportType: "MCPAR", id: "mock-report-id", state: "MN" },
       {
         fieldData: {
           plans: [

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -80,7 +80,7 @@ export { HomePage } from "./pages/Home/HomePage";
 export { NotFoundPage } from "./pages/NotFound/NotFoundPage";
 export { ProfilePage } from "./pages/Profile/ProfilePage";
 export { ReportGetStartedPage } from "./pages/GetStarted/ReportGetStartedPage";
-export { McparReviewSubmitPage } from "./pages/ReviewSubmit/McparReviewSubmitPage";
+export { McparReviewSubmitPage } from "./pages/ReviewSubmit/ReviewSubmitPage";
 export { ExportedReportPage } from "./pages/Export/ExportedReportPage";
 // reports
 export { ReportPageWrapper } from "./reports/ReportPageWrapper";

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -85,15 +85,10 @@ export const AddEditReportModal = ({
     const submitButton = document.querySelector("[form=" + form.id + "]");
     submitButton?.setAttribute("disabled", "true");
 
-    let dataToWrite;
-
-    if (reportType === "MCPAR") {
-      dataToWrite = prepareMcparPayload(formData);
-    }
-    // prepare MLR payload
-    else {
-      dataToWrite = prepareMlrPayload(formData);
-    }
+    const dataToWrite =
+      reportType === "MCPAR"
+        ? prepareMcparPayload(formData)
+        : prepareMlrPayload(formData);
 
     // if an existing program was selected, use that report id
     if (selectedReport?.id) {

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -123,6 +123,16 @@ export const AddEditReportModal = ({
         fieldData: {
           ...dataToWrite.fieldData,
           stateName: States[activeState as keyof typeof States],
+          // All new MLR reports are NOT resubmissions by definition.
+          versionControl:
+            reportType === "MLR"
+              ? [
+                  {
+                    key: "versionControl-n",
+                    value: "No, this is an initial submission",
+                  },
+                ]
+              : undefined,
         },
         formTemplate,
       });

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.test.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 // components
 import { ReportContext, McparReviewSubmitPage } from "components";
-import { SuccessMessageGenerator } from "./McparReviewSubmitPage";
+import { SuccessMessageGenerator } from "./ReviewSubmitPage";
 // types
 import { ReportStatus } from "types";
 // utils

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -17,10 +17,12 @@ import { ReportStatus } from "types";
 // utils
 import { useUser, utcDateToReadableDate, convertDateUtcToEt } from "utils";
 // verbiage
-import reviewVerbiage from "verbiage/pages/mcpar/mcpar-review-and-submit";
+import MCPARVerbiage from "verbiage/pages/mcpar/mcpar-review-and-submit";
+import MLRVerbiage from "verbiage/pages/mlr/mlr-review-and-submit";
 // assets
 import checkIcon from "assets/icons/icon_check_circle.png";
 import printIcon from "assets/icons/icon_print.png";
+import { AnyObject } from "yup/lib/types";
 
 export const McparReviewSubmitPage = () => {
   const { report, fetchReport, updateReport } = useContext(ReportContext);
@@ -39,6 +41,8 @@ export const McparReviewSubmitPage = () => {
     report?.reportType || localStorage.getItem("selectedReportType");
   const reportId = report?.id || localStorage.getItem("selectedReport");
   const reportState = state || localStorage.getItem("selectedState");
+
+  const reviewVerbiage = reportType === "MCPAR" ? MCPARVerbiage : MLRVerbiage;
 
   const reportKeys = {
     reportType: reportType,
@@ -81,6 +85,7 @@ export const McparReviewSubmitPage = () => {
           programName={report.programName}
           date={report?.submittedOnDate}
           submittedBy={report?.submittedBy}
+          reviewVerbiage={reviewVerbiage}
         />
       ) : (
         <ReadyToSubmit
@@ -90,13 +95,14 @@ export const McparReviewSubmitPage = () => {
           onClose={onClose}
           submitting={submitting}
           isPermittedToSubmit={isPermittedToSubmit}
+          reviewVerbiage={reviewVerbiage}
         />
       )}
     </Flex>
   );
 };
 
-const PrintButton = () => {
+const PrintButton = ({ reviewVerbiage }: { reviewVerbiage: AnyObject }) => {
   const { print } = reviewVerbiage;
   return (
     // TODO: make the path route to the correct report type (in the future)
@@ -120,6 +126,7 @@ const ReadyToSubmit = ({
   onClose,
   submitting,
   isPermittedToSubmit,
+  reviewVerbiage,
 }: ReadyToSubmitProps) => {
   const { review } = reviewVerbiage;
   const { intro, modal, pageLink } = review;
@@ -137,7 +144,7 @@ const ReadyToSubmit = ({
         </Box>
       </Box>
       <Flex sx={sx.submitContainer}>
-        {pdfExport && <PrintButton />}
+        {pdfExport && <PrintButton reviewVerbiage={reviewVerbiage} />}
         <Button
           type="submit"
           onClick={onOpen as MouseEventHandler}
@@ -168,6 +175,7 @@ interface ReadyToSubmitProps {
   onClose: Function;
   submitting?: boolean;
   isPermittedToSubmit?: boolean;
+  reviewVerbiage: AnyObject;
 }
 
 export const SuccessMessageGenerator = (
@@ -188,6 +196,7 @@ export const SuccessMessage = ({
   programName,
   date,
   submittedBy,
+  reviewVerbiage,
 }: SuccessMessageProps) => {
   const { submitted } = reviewVerbiage;
   const { intro } = submitted;
@@ -218,7 +227,7 @@ export const SuccessMessage = ({
       </Box>
       {pdfExport && (
         <Box sx={sx.infoTextBox}>
-          <PrintButton />
+          <PrintButton reviewVerbiage={reviewVerbiage} />
         </Box>
       )}
     </Flex>
@@ -229,6 +238,7 @@ interface SuccessMessageProps {
   programName: string;
   date?: number;
   submittedBy?: string;
+  reviewVerbiage: AnyObject;
 }
 
 const sx = {

--- a/services/ui-src/src/components/reports/ReportProvider.test.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.test.tsx
@@ -34,7 +34,7 @@ const TestComponent = () => {
         Fetch Report
       </button>
       <button
-        onClick={() => context.createReport("mock-type", "AB", mockMcparReport)}
+        onClick={() => context.createReport("MCPAR", "AB", mockMcparReport)}
         data-testid="create-report-button"
       >
         Create Report
@@ -46,7 +46,7 @@ const TestComponent = () => {
         Update Report
       </button>
       <button
-        onClick={() => context.fetchReportsByState("mock-type", "AB")}
+        onClick={() => context.fetchReportsByState("MCPAR", "AB")}
         data-testid="fetch-reports-by-state-button"
       >
         Fetch Reports By State
@@ -224,7 +224,7 @@ describe("Test ReportProvider error states", () => {
 
 describe("Test ReportProvider fetches when loading on report page", () => {
   beforeEach(async () => {
-    localStorage.setItem("selectedReportType", "mock-type");
+    localStorage.setItem("selectedReportType", "MCPAR");
     localStorage.setItem("selectedState", "AB");
     localStorage.setItem("selectedReport", "mock-report-id");
     localStorage.setItem("selectedReportBasePath", "/mock");

--- a/services/ui-src/src/forms/mlr/mlr.json
+++ b/services/ui-src/src/forms/mlr/mlr.json
@@ -51,7 +51,7 @@
                 }
               },
               {
-                "id": "contactEmailAddress",
+                "id": "contactTitle",
                 "type": "text",
                 "validation": "email",
                 "props": {
@@ -105,7 +105,7 @@
     },
     {
       "name": "Review & Submit",
-      "path": "/mcpar/review-and-submit",
+      "path": "/mlr/review-and-submit",
       "pageType": "reviewSubmit"
     }
   ]

--- a/services/ui-src/src/forms/mlr/mlr.json
+++ b/services/ui-src/src/forms/mlr/mlr.json
@@ -4,5 +4,109 @@
   "basePath": "/mlr",
   "version": "MLR_2023-02-08",
   "adminDisabled": true,
-  "routes": []
+  "routes": [
+    {
+      "name": "Program Information",
+      "path": "/mlr/program-information",
+      "children": [
+        {
+          "name": "Information for Primary Contact",
+          "path": "/mlr/program-information/point-of-contact",
+          "pageType": "standard",
+          "verbiage": {
+            "intro": {
+              "section": "Section A: Program Information",
+              "subsection": "Point of Contact",
+              "spreadsheet": "A_Program_Info"
+            }
+          },
+          "form": {
+            "id": "apoc",
+            "fields": [
+              {
+                "id": "contactName",
+                "type": "text",
+                "validation": "text",
+                "props": {
+                  "label": "A. Contact name",
+                  "hint": "Enter the first and last name of the primary contact for this report."
+                }
+              },
+              {
+                "id": "contactPhone",
+                "type": "text",
+                "validation": "phone",
+                "props": {
+                  "label": "B. Contact phone",
+                  "hint": "Enter phone number as ###-###-####."
+                }
+              },
+              {
+                "id": "contactEmailAddress",
+                "type": "text",
+                "validation": "email",
+                "props": {
+                  "label": "C. Contact email address",
+                  "hint": "Enter email address of the primary contact."
+                }
+              },
+              {
+                "id": "contactEmailAddress",
+                "type": "text",
+                "validation": "email",
+                "props": {
+                  "label": "D. Contact title",
+                  "hint": "Enter the primary contact’s job title."
+                }
+              },
+              {
+                "id": "stateName",
+                "type": "text",
+                "validation": "text",
+                "props": {
+                  "label": "E. State",
+                  "hint": "Auto-populates from your account profile.",
+                  "disabled": true
+                }
+              },
+              {
+                "id": "stateAgencyName",
+                "type": "text",
+                "validation": "text",
+                "props": {
+                  "label": "F. State Agency Name",
+                  "hint": "Enter the name of the state/territory Medicaid agency that is submitting this report."
+                }
+              },
+              {
+                "id": "versionControl",
+                "type": "radio",
+                "validation": "radio",
+                "props": {
+                  "label": "G. Version control",
+                  "hint": "Is this report an updated version of a previously submitted summary MLR report covering the same time period? <br /><br /> Auto-populates. Note: The version control field is determined from the submission status. All new MLR reports are initial submissions.",
+                  "choices": [
+                    {
+                      "id": "Y",
+                      "label": "Yes, this is a resubmission"
+                    },
+                    {
+                      "id": "N",
+                      "label": "No, this is an initial submission"
+                    }
+                  ],
+                  "disabled": true
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Review & Submit",
+      "path": "/mcpar/review-and-submit",
+      "pageType": "reviewSubmit"
+    }
+  ]
 }

--- a/services/ui-src/src/utils/autosave/autosave.test.ts
+++ b/services/ui-src/src/utils/autosave/autosave.test.ts
@@ -9,7 +9,7 @@ const mockForm: any = {
 
 const report = {
   id: "reportId",
-  reportType: "mock-type",
+  reportType: "MCPAR",
   updateReport: jest.fn().mockResolvedValue(true),
 };
 const user = {
@@ -42,7 +42,7 @@ describe("autosaveFieldData", () => {
     await autosaveFieldData({ form: mockForm, fields, report, user });
     expect(mockForm.trigger).toHaveBeenCalledWith("field2");
     expect(report.updateReport).toHaveBeenCalledWith(
-      { reportType: "mock-type", id: "reportId", state: "MN" },
+      { reportType: "MCPAR", id: "reportId", state: "MN" },
       {
         metadata: {
           status: "In progress",
@@ -58,7 +58,7 @@ describe("autosaveFieldData", () => {
     await autosaveFieldData({ form: mockForm, fields, report, user });
     expect(mockForm.trigger).toHaveBeenCalledWith("field2");
     expect(report.updateReport).toHaveBeenCalledWith(
-      { reportType: "mock-type", id: "reportId", state: "MN" },
+      { reportType: "MCPAR", id: "reportId", state: "MN" },
       {
         metadata: {
           status: "In progress",
@@ -74,7 +74,7 @@ describe("autosaveFieldData", () => {
     await autosaveFieldData({ form: mockForm, fields: [], report, user });
     expect(mockForm.trigger).toHaveBeenCalledWith("field2");
     expect(report.updateReport).toHaveBeenCalledWith(
-      { reportType: "mock-type", id: "reportId", state: "MN" },
+      { reportType: "MCPAR", id: "reportId", state: "MN" },
       {
         metadata: {
           status: "In progress",
@@ -89,7 +89,7 @@ describe("autosaveFieldData", () => {
     fields[1].overrideCheck = true;
     await autosaveFieldData({ form: mockForm, fields, report, user });
     expect(report.updateReport).toHaveBeenCalledWith(
-      { reportType: "mock-type", id: "reportId", state: "MN" },
+      { reportType: "MCPAR", id: "reportId", state: "MN" },
       {
         metadata: {
           status: "In progress",

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -400,7 +400,7 @@ export const mockReportJson = {
 };
 
 export const mockReportKeys = {
-  reportType: "mock-type",
+  reportType: "MCPAR",
   state: "AB",
   id: "mock-report-id",
 };
@@ -564,7 +564,7 @@ export const mockReportFieldData = {
       accessMeasure_standardType: [
         {
           key: "option1",
-          value: "mock-type",
+          value: "MCPAR",
         },
       ],
       "accessMeasure_standardType-otherText": "",
@@ -574,7 +574,7 @@ export const mockReportFieldData = {
 
 export const mockMcparReport = {
   ...mockReportKeys,
-  reportType: "mock-type",
+  reportType: "MCPAR",
   formTemplate: mockReportJson,
   programName: "testProgram",
   status: ReportStatus.NOT_STARTED,
@@ -724,7 +724,7 @@ export const mockCompletedQualityMeasuresFormattedEntityData = {
 
 export const mockSanctionsEntity = {
   id: "mock-id",
-  sanction_interventionType: [{ value: "mock-type" }],
+  sanction_interventionType: [{ value: "MCPAR" }],
   sanction_interventionTopic: [{ value: "mock-topic" }],
   sanction_planName: { label: "sanction_planName", value: "mock-plan-id-1" },
   sanction_interventionReason: "mock-reason",
@@ -736,7 +736,7 @@ export const mockSanctionsEntity = {
 };
 
 export const mockUnfinishedSanctionsFormattedEntityData = {
-  interventionType: "mock-type",
+  interventionType: "MCPAR",
   interventionTopic: "mock-topic",
   planName: "mock-plan-name-1",
   interventionReason: "mock-reason",

--- a/services/ui-src/src/verbiage/pages/mlr/mlr-review-and-submit.ts
+++ b/services/ui-src/src/verbiage/pages/mlr/mlr-review-and-submit.ts
@@ -1,0 +1,33 @@
+export default {
+  print: {
+    printPageUrl: "/mcpar/export",
+    printButtonText: "Print",
+  },
+  review: {
+    intro: {
+      header: "Review & Submit",
+      infoHeader: "Ready to Submit?",
+      info: "Double check that everything in your MLR Report is accurate. You will be able to make edits after submitting, and resubmit. Once you’ve reviewed your report, certify that it’s in compliance with 42 CFR § 438.66(e).",
+    },
+    modal: {
+      structure: {
+        heading: "Are you sure you want to submit MLR?",
+        actionButtonText: "Submit MLR",
+        closeButtonText: "Cancel",
+      },
+      body: "You will be able to make edits to this MLR after submitting, and resubmit.",
+    },
+    pageLink: {
+      text: "Submit MLR",
+    },
+  },
+  submitted: {
+    intro: {
+      header: "Successfully Submitted",
+      infoHeader: "Thank you",
+      additionalInfoHeader: "What happens now?",
+      additionalInfo:
+        "No further action is needed at this point. CMS will reach out if in the case they have any questions.",
+    },
+  },
+};

--- a/tests/cypress/tests/e2e/mlr/form.feature
+++ b/tests/cypress/tests/e2e/mlr/form.feature
@@ -1,0 +1,722 @@
+Feature: MLR E2E Form Submission
+
+    Scenario: A state user can fully create a form and submit it
+        Given I am logged in as a state user
+        When I submit a new MLR program
+        Then the program is submitted
+
+# Feature: MCPAR E2E Form Submission
+
+#     Scenario Outline: A State user creates a program
+#         Given I am logged in as a state user
+#         And I am on "/mcpar"
+
+#         When I click the "Add managed care program" button
+#         And these form elements are filled:
+#             | programName              | text           | <title>        |
+#             | reportingPeriodStartDate | text           | <startDate>    |
+#             | reportingPeriodEndDate   | text           | <endDate>      |
+#             | combinedData             | singleCheckbox | <combinedData> |
+#         And I click the "Save" button
+#         Then there is an active program
+
+#         Examples: #Form Data
+#             | title        | startDate  | endDate    | combinedData |
+#             | Test Program | 07/11/2022 | 11/07/2026 | true         |
+
+#     Scenario: Fills out Section A: Program Information
+#         Given I am on "/mcpar"
+#         And I click the "Enter" button
+#         Then the "/mcpar/program-information/point-of-contact" page is loaded
+
+#         When these form elements are filled:
+#             | contactName         | text | Mary Poppins                              |
+#             | contactEmailAddress | text | aspoonfullofsuger@themedicinegoesdown.com |
+#         And these form elements are prefilled and disabled:
+#             | stateName | text | District of Columbia |
+#         And I click the "Save & continue" button
+
+#         Then the "/mcpar/program-information/reporting-period" page is loaded
+
+# Scenario: Fills out Section A: Reporting Period
+#     Given I am on "/mcpar/program-information/reporting-period"
+
+#     When these form elements are prefilled and disabled:
+#         | reportingPeriodStartDate | text | 07/11/2022   |
+#         | reportingPeriodEndDate   | text | 11/07/2026   |
+#         | programName              | text | Test Program |
+
+#     And I click the "Save & continue" button
+
+#     Then the "/mcpar/program-information/reporting-period" page is loaded
+
+# Scenario: Fills out Section A: Add Plans
+#     Given I am on "/mcpar/program-information/add-plans"
+
+#     When these form elements are filled:
+#         | plans[0] | text | First Plan |
+#     And I click the "Add a row" button
+#     And these form elements are filled:
+#         | plans[1] | text | Second Plan |
+
+#     And I click the "Save & continue" button
+
+#     Then the "/mcpar/program-information/add-bss-entities" page is loaded
+
+# Scenario: Fills out Section A: Add BSS Entities
+#     Given I am on "/mcpar/program-information/add-bss-entities"
+
+#     When these form elements are filled:
+#         | bssEntities[0] | text | First Entity |
+#     And I click the "Add a row" button
+#     And these form elements are filled:
+#         | bssEntities[1] | text | Second Entity |
+
+#     And I click the "Save & continue" button
+
+#     Then the "/mcpar/state-level-indicators/program-characteristics" page is loaded
+
+# Scenario: Fills out Section B: State Level Indicators/Program Characteristics
+#     Given I am on "/mcpar/state-level-indicators/program-characteristics"
+
+#     When these form elements are filled:
+#         | state_statewideMedicaidEnrollment            | text | 1020   |
+#         | state_statewideMedicaidManagedCareEnrollment | text | 151512 |
+
+#     And I click the "Save & continue" button
+
+#     Then the "/mcpar/state-level-indicators/encounter-data-report" page is loaded
+
+# Scenario: Fills out Section B: Encounter Data Report
+#     Given I am on "/mcpar/state-level-indicators/encounter-data-report"
+
+#     When these form elements are filled:
+#         | state_encounterDataValidationEntity                | checkbox | State Medicaid agency staff                                   |
+#         | state_encounterDataValidationEntity                | checkbox | Other state agency staff                                      |
+#         | state_encounterDataValidationEntity                | checkbox | State actuaries                                               |
+#         | state_encounterDataValidationEntity                | checkbox | EQRO                                                          |
+#         | state_encounterDataValidationEntity                | checkbox | Other third-party vendor                                      |
+#         | state_encounterDataValidationEntity                | checkbox | Proprietary system(s)                                         |
+#         | state_encounterDataValidationSystemHipaaCompliance | radio    | Yes                                                           |
+#         | state_encounterDataValidationEntity                | checkbox | Other, specify                                                |
+#         | state_encounterDataValidationEntity-otherText      | text     | Textarea that can be filled and entered due to checking Other |
+
+#     And I click the "Save & continue" button
+
+#     Then the "/mcpar/state-level-indicators/program-integrity" page is loaded
+
+# Scenario: Fills out Section B: Program Integrity
+#     Given I am on "/mcpar/state-level-indicators/program-integrity"
+
+#     When these form elements are filled:
+#         | state_focusedProgramIntegrityActivitiesConducted               | text  | 1234124123123198237192 1231231      |
+#         | state_overpaymentStandard                                      | radio | Allow plans to retain overpayments  |
+#         | state_overpaymentStandardContractLanguageLocation              | text  | !@#$%!@*%#!%_!@#123:ASBAC           |
+#         | state_overpaymentStandardDescription                           | text  | State returns payments              |
+#         | state_overpaymentReportingMonitoringEfforts                    | text  | State tracks compliance             |
+#         | state_beneficiaryCircumstanceChangeReconciliationEfforts       | text  | State team dedicated to these cases |
+#         | state_providerTerminationReportingMonitoringEfforts            | radio | Yes                                 |
+#         | state_providerTerminationReportingMonitoringMetrics            | radio | Yes                                 |
+#         | state_providerTerminationReportingMonitoringMetricsDescription | text  | metric here                         |
+#         | state_excludedEntityIdentifiedInFederalDatabaseCheck           | radio | Yes                                 |
+#         | state_excludedEntityIdentificationInstancesSummary             | text  | Instances                           |
+#         | state_ownershipControlDisclosureWebsite                        | radio | Yes                                 |
+#         | state_ownershipControlDisclosureWebsiteLink                    | text  | https://www.auditwebsite.com        |
+#         | state_submittedDataAuditResults                                | text  | Audit Results findings              |
+
+#     And I click the "Save & continue" button
+
+#     Then the "/mcpar/program-level-indicators/program-characteristics" page is loaded
+
+# Scenario: Fills out Section C: Program Characteristics
+#     Given I am on "/mcpar/program-level-indicators/program-characteristics"
+
+#     When these form elements are filled:
+#         | program_contractTitle                        | text     | Contract Title              |
+#         | program_contractDate                         | text     | 07/14/2023                  |
+#         | program_contractUrl                          | text     | https://www.contracturl.com |
+#         | program_type                                 | radio    | Other, specify              |
+#         | program_type-otherText                       | text     | Generic MCP here            |
+#         | program_coveredSpecialBenefits               | checkbox | Dental                      |
+#         | program_specialBenefitsAvailabilityVariation | text     | N/A                         |
+#         | program_enrollment                           | text     | 100                         |
+#         | program_enrollmentBenefitChanges             | text     | Changes to enrollment       |
+
+#     And I click the "Save & continue" button
+
+#     Then the "/mcpar/program-level-indicators/encounter-data-report" page is loaded
+
+# Scenario: Fills out Section C: Encounter Data Report
+#     Given I am on "/mcpar/program-level-indicators/encounter-data-report"
+
+#     When these form elements are filled:
+#         | program_encounterDataUses                                                                      | checkbox | Quality/performance measurement   |
+#         | program_encounterDataSubmissionCorrectionPerformanceEvaluationCriteria                         | checkbox | Timeliness of data corrections    |
+#         | program_encounterDataSubmissionCorrectionPerformanceEvaluationCriteria                         | checkbox | Timeliness of data certifications |
+#         | program_encounterDataSubmissionCorrectionPerformanceEvaluationCriteria                         | checkbox | Use of correct file formats       |
+#         | program_encounterDataSubmissionCorrectionPerformanceEvaluationCriteria                         | checkbox | Provider ID field complete        |
+#         | program_encounterDataSubmissionCorrectionPerformanceEvaluationCriteriaContractLanguageLocation | text     | References Here                   |
+#         | program_encounterDataSubmissionQualityFinancialPenaltiesContractLanguageLocation               | text     | Financial Penalties               |
+#         | program_encounterDataQualityIncentives                                                         | text     | N/A                               |
+#         | program_encounterDataCollectionValidationBarriers                                              | text     | Barriers to collecting data       |
+
+#     And I click the "Save & continue" button
+
+#     Then the "/mcpar/program-level-indicators/appeals-state-fair-hearings-and-grievances" page is loaded
+
+# Scenario: Fills out Section C: Appeals, State Fair Hearings & Grievances
+#     Given I am on "/mcpar/program-level-indicators/appeals-state-fair-hearings-and-grievances"
+
+#     When these form elements are filled:
+#         | program_criticalIncidentDefinition                | text | Data not available              |
+#         | program_standardAppealTimelyResolutionDefinition  | text | No longer then 30 calendar days |
+#         | program_expeditedAppealTimelyResolutionDefinition | text | No longer then 72 hours         |
+#         | program_grievanceTimelyResolutionDefinition       | text | Within 90 days                  |
+
+#     And I click the "Save & continue" button
+
+#     Then the "/mcpar/program-level-indicators/availability-and-accessibility/network-adequacy" page is loaded
+
+# Scenario: Fills out Section C: Availability, Accessibility: Network Adequacy
+#     Given I am on "/mcpar/program-level-indicators/availability-and-accessibility/network-adequacy"
+
+#     When these form elements are filled:
+#         | program_networkAdequacyChallenges         | text | 1 |
+#         | program_networkAdequacyGapResponseEfforts | text | 2 |
+
+#     And I click the "Save & continue" button
+
+#     Then the "/mcpar/program-level-indicators/availability-and-accessibility/access-measures" page is loaded
+
+# Scenario Outline: Fills out Section C: Availability, Accessibility: Access Measures - Create multiple measures
+#     Given I am on "/mcpar/program-level-indicators/availability-and-accessibility/access-measures"
+
+#     When I click the "Add access measure" button
+#     And these form elements are filled:
+#         | accessMeasure_generalCategory     | radio | <category>    |
+#         | accessMeasure_standardDescription | text  | <description> |
+#         | accessMeasure_standardType        | radio | <type>        |
+
+#     And I click the "Save" button
+
+#     Then the access measure "<category>", "<description>", and "<type>" is created
+
+#     Examples: #Access Measure Data
+#         | category                                                     | description            | type                  |
+#         | General quantitative availability and accessibility standard | Wait times             | Appointment wait time |
+#         | LTSS-related standard: provider travels to the enrollee      | Additional Information | Hours of operation    |
+
+
+# Scenario Outline: Fills out Section C: Availability, Accessibility: Access Measures - Edit a measure
+#     Given I am on "/mcpar/program-level-indicators/availability-and-accessibility/access-measures"
+#     And there are "2" "access measures"
+#     And I click the "Edit measure" button
+
+#     When these form elements are edited:
+#         | accessMeasure_generalCategory     | radio | <category>    |
+#         | accessMeasure_standardDescription | text  | <description> |
+#         | accessMeasure_standardType        | radio | <type>        |
+
+#     And I click the "Save" button
+
+#     Then the access measure "<category>", "<description>", and "<type>" is created
+#     And there are "2" "access measures"
+
+#     Examples: #Access Measure Data
+#         | category                                  | description    | type                  |
+#         | Exceptions to time and distance standards | Time Exception | Appointment wait time |
+
+# Scenario Outline: Fills out Section C: Availability, Accessibility: Access Measures - Measure Details
+#     Given I am on "/mcpar/program-level-indicators/availability-and-accessibility/access-measures"
+#     And I click the "Enter details" button
+
+#     When these form elements are filled:
+#         | accessMeasure_providerType             | radio    | <type>       |
+#         | accessMeasure_applicableRegion         | radio    | <region>     |
+#         | accessMeasure_population               | radio    | <population> |
+#         | accessMeasure_monitoringMethods        | checkbox | <method>     |
+#         | accessMeasure_oversightMethodFrequency | radio    | <frequency>  |
+
+#     And I click the "Save & Close" button
+
+#     Then the access measure is completed with "<type>", "<region>", "<population>", "<method>", and "<frequency>"
+
+#     Examples: #Access Measure Details Data
+#         | type         | region | population | method            | frequency |
+#         | Primary care | Urban  | Pediatric  | Geomapping        | Monthly   |
+#         | Hospital     | Rural  | MLTSS      | EVV data analysis | Annually  |
+
+# Scenario Outline: Fills out Section C: Availability, Accessibility: Access Measures - Edit Measure Details
+#     Given I am on "/mcpar/program-level-indicators/availability-and-accessibility/access-measures"
+#     And there are "2" "access measures"
+#     And I click the "Edit details" button
+
+#     When these form elements are edited:
+#         | accessMeasure_providerType             | radio    | <type>       |
+#         | accessMeasure_applicableRegion         | radio    | <region>     |
+#         | accessMeasure_population               | radio    | <population> |
+#         | accessMeasure_monitoringMethods        | checkbox | <method>     |
+#         | accessMeasure_oversightMethodFrequency | radio    | <frequency>  |
+
+#     And I click the "Save & Close" button
+
+#     Then the access measure is completed with "<type>", "<region>", "<population>", "<method>", and "<frequency>"
+#     And there are "2" "access measures"
+#     And I click the "Continue" button
+
+#     Then the "/mcpar/program-level-indicators/bss" page is loaded
+
+#     Examples: #Access Measure Details Data
+#         | type              | region         | population | method               | frequency |
+#         | Behavioral health | Large counties | Adult      | Secret shopper calls | Quarterly |
+
+# Scenario: Fills out Section C: BSS
+#     Given I am on "/mcpar/program-level-indicators/bss"
+
+#     When these form elements are filled:
+#         | state_bssWebsite                              | text | websites here           |
+#         | state_bssEntityServiceAccessibility           | text | In person, phone, email |
+#         | state_bssEntityLtssProgramDataIssueAssistance | text | Assistance here         |
+#         | state_bssEntityPerformanceEvaluationMethods   | text | Performance evaluations |
+
+#     And I click the "Save & continue" button
+
+#     Then the "/mcpar/program-level-indicators/program-integrity" page is loaded
+
+# Scenario: Fills out Section C: Program Integrity
+#     Given I am on "/mcpar/program-level-indicators/program-integrity"
+
+#     When these form elements are filled:
+#         | program_prohibitedAffiliationDisclosure | radio | Yes |
+
+#     And I click the "Save & continue" button
+
+#     Then the "/mcpar/plan-level-indicators/program-characteristics" page is loaded
+
+# Scenario: Fills out Section D: Program Characteristics - Entering Data
+#     Given I am on "/mcpar/plan-level-indicators/program-characteristics"
+
+#     When I click the "Enter" button
+#     And these form elements are filled:
+#         | plan_enrollment                                   | text | 123    |
+#         | plan_medicaidEnrollmentSharePercentage            | text | 10.251 |
+#         | plan_medicaidManagedCareEnrollmentSharePercentage | text | 5      |
+#     And I click the "Save & Close" button
+
+# Scenario: Fills out Section D: Program Characteristics - Editing Data
+#     Given I am on "/mcpar/plan-level-indicators/program-characteristics"
+
+#     When I click the "Edit" button
+#     And these form elements are filled:
+#         | plan_enrollment                                   | text | 456 |
+#         | plan_medicaidEnrollmentSharePercentage            | text | 789 |
+#         | plan_medicaidManagedCareEnrollmentSharePercentage | text | 42  |
+#     And I click the "Save & Close" button
+#     Then I have completed "1" drawer reports
+
+# Scenario: Fills out Section D: Program Characteristics - Enter Additional Data
+#     Given I am on "/mcpar/plan-level-indicators/program-characteristics"
+
+#     When I click the "Enter" button
+#     And these form elements are filled:
+#         | plan_enrollment                                   | text | 123    |
+#         | plan_medicaidEnrollmentSharePercentage            | text | 10.251 |
+#         | plan_medicaidManagedCareEnrollmentSharePercentage | text | 5      |
+#     And I click the "Save & Close" button
+
+#     Then I have completed "2" drawer reports
+#     And I click the "Continue" button
+#     And the "/mcpar/plan-level-indicators/financial-performance" page is loaded
+
+# Scenario Outline: Fills out Section D: Financial Performance
+#     Given I am on "/mcpar/plan-level-indicators/financial-performance"
+
+#     When I click the "Enter" button
+#     And these form elements are filled:
+#         | plan_medicalLossRatioPercentage                           | text  | <percentage>    |
+#         | plan_medicalLossRatioPercentageAggregationLevel           | radio | <aggLevel>      |
+#         | plan_medicalLossRatioPercentageAggregationLevel-otherText | text  | <aggLevelOther> |
+#         | plan_populationSpecificMedicalLossRatioDescription        | text  | <description>   |
+#         | plan_medicalLossRatioReportingPeriod                      | radio | <period>        |
+#         | plan_medicalLossRatioReportingPeriodStartDate             | text  | <startDate>     |
+#         | plan_medicalLossRatioReportingPeriodEndDate               | text  | <endDate>       |
+#     And I click the "Save & Close" button
+
+#     Then I have completed "1" drawer reports
+#     And I click the "Continue" button
+#     And the "/mcpar/plan-level-indicators/encounter-data-report" page is loaded
+
+#     Examples: #Financial Performance Data
+#         | percentage | aggLevel       | aggLevelOther               | description     | period | startDate  | endDate    |
+#         | 100        | Other, specify | Other Levels of aggregation | MLD Description | Yes    | 12/14/2022 | 12/15/2022 |
+
+
+# Scenario: Fills out Section D: Encounter Data Report
+#     Given I am on "/mcpar/plan-level-indicators/encounter-data-report"
+
+#     When I click the "Enter" button
+#     And these form elements are filled:
+#         | program_encounterDataSubmissionTimelinessStandardDefinition | text | N/A |
+#         | plan_encounterDataSubmissionTimelinessCompliancePercentage  | text | 123 |
+#         | plan_encounterDataSubmissionHipaaCompliancePercentage       | text | 123 |
+#     And I click the "Save & Close" button
+
+#     Then I have completed "1" drawer reports
+#     And I click the "Continue" button
+#     And the "/mcpar/plan-level-indicators/appeals-state-fair-hearings-and-grievances/appeals-overview" page is loaded
+
+# Scenario: Fills out Section D: Appeals Overview
+#     Given I am on "/mcpar/plan-level-indicators/appeals-state-fair-hearings-and-grievances/appeals-overview"
+
+#     When I click the "Enter" button
+#     And these form elements are filled:
+#         | plan_resolvedAppeals                                                            | text | N/A |
+#         | plan_activeAppeals                                                              | text | 123 |
+#         | plan_ltssUserFiledAppeals                                                       | text | 123 |
+#         | plan_ltssUserFiledCriticalIncidentsWhenPreviouslyFiledAppeal                    | text | 123 |
+#         | plan_timelyResolvedStandardAppeals                                              | text | 123 |
+#         | plan_timelyResolvedExpeditedAppeals                                             | text | 123 |
+#         | plan_resolvedPreServiceAuthorizationDenialAppeals                               | text | 123 |
+#         | plan_resolvedReductionSuspensionTerminationOfPreviouslyAuthorizedServiceAppeals | text | 123 |
+#         | plan_resolvedPostServiceAuthorizationDenialAppeals                              | text | 123 |
+#         | plan_resolvedServiceTimelinessAppeals                                           | text | 123 |
+#         | plan_resolvedUntimelyResponseAppeals                                            | text | 123 |
+#         | plan_resolvedRightToRequestOutOfNetworkCareDenialAppeals                        | text | 123 |
+#         | plan_resolvedRequestToDisputeFinancialLiabilityDenialAppeals                    | text | 123 |
+#     And I click the "Save & Close" button
+
+#     Then I have completed "1" drawer reports
+#     And I click the "Continue" button
+#     And the "/mcpar/plan-level-indicators/appeals-state-fair-hearings-grievances/appeals-by-service" page is loaded
+
+# Scenario: Fills out Section D: Appeals By Service
+#     Given I am on "/mcpar/plan-level-indicators/appeals-state-fair-hearings-grievances/appeals-by-service"
+
+#     When I click the "Enter" button
+#     And these form elements are filled:
+#         | plan_resolvedGeneralInpatientServiceAppeals           | text | N/A                |
+#         | plan_resolvedGeneralOutpatientServiceAppeals          | text | Data not available |
+#         | plan_resolvedInpatientBehavioralHealthServiceAppeals  | text | 1                  |
+#         | plan_resolvedOutpatientBehavioralHealthServiceAppeals | text | 1                  |
+#         | plan_resolvedCoveredOutpatientPrescriptionDrugAppeals | text | 1                  |
+#         | plan_resolvedSnfServiceAppeals                        | text | 1                  |
+#         | plan_resolvedLtssServiceAppeals                       | text | 1                  |
+#         | plan_resolvedDentalServiceAppeals                     | text | 1                  |
+#         | plan_resolvedNemtAppeals                              | text | 1                  |
+#         | plan_resolvedOtherServiceAppeals                      | text | 1                  |
+#     And I click the "Save & Close" button
+
+#     Then I have completed "1" drawer reports
+#     And I click the "Continue" button
+#     And the "/mcpar/plan-level-indicators/appeals-state-fair-hearings-grievances/state-fair-hearings" page is loaded
+
+# Scenario: Fills out Section D: State Fair Hearings
+#     Given I am on "/mcpar/plan-level-indicators/appeals-state-fair-hearings-grievances/state-fair-hearings"
+
+#     When I click the "Enter" button
+#     And these form elements are filled:
+#         | plan_stateFairHearingRequestsFiled                                          | text | N/A                |
+#         | plan_stateFairHearingRequestsWithFavorableDecision                          | text | Data not available |
+#         | plan_stateFairHearingRequestsWithAdverseDecision                            | text | 1                  |
+#         | plan_stateFairHearingRequestsRetracted                                      | text | 1                  |
+#         | plan_stateFairHearingRequestsWithExternalMedicalReviewWithFavorableDecision | text | 1                  |
+#         | plan_stateFairHearingRequestsWithExternalMedicalReviewWithAdverseDecision   | text | 1                  |
+#     And I click the "Save & Close" button
+
+#     Then I have completed "1" drawer reports
+#     And I click the "Continue" button
+#     And the "/mcpar/plan-level-indicators/appeals-state-fair-hearings-and-grievances/grievances-overview" page is loaded
+
+# Scenario: Fills out Section D: Grievances Overview
+#     Given I am on "/mcpar/plan-level-indicators/appeals-state-fair-hearings-and-grievances/grievances-overview"
+
+#     When I click the "Enter" button
+#     And these form elements are filled:
+#         | plan_resolvedGrievances                                         | text | N/A                |
+#         | plan_activeGrievances                                           | text | Data not available |
+#         | plan_ltssUserFieldGrievances                                    | text | 1                  |
+#         | plan_ltssUserFiledCriticalIncidentsWhenPreviouslyFiledGrievance | text | 1                  |
+#         | plan_timyleResolvedGrievances                                   | text | 1                  |
+#     And I click the "Save & Close" button
+
+#     Then I have completed "1" drawer reports
+#     And I click the "Continue" button
+#     And the "/mcpar/plan-level-indicators/appeals-state-fair-hearings-grievances/grievances-by-service" page is loaded
+
+# Scenario: Fills out Section D: Grievances By Service
+#     Given I am on "/mcpar/plan-level-indicators/appeals-state-fair-hearings-grievances/grievances-by-service"
+
+#     When I click the "Enter" button
+#     And these form elements are filled:
+#         | plan_resolvedGeneralInpatientServiceGrievances           | text | N/A                |
+#         | plan_resolvedGeneralOutpatientServiceGrievances          | text | Data not available |
+#         | plan_resolvedInpatientBehavioralHealthServiceGrievances  | text | 1                  |
+#         | plan_resolvedOutpatientBehavioralHealthServiceGrievances | text | 2                  |
+#         | plan_resolvedCoveredOutpatientPrescriptionDrugGrievances | text | 3                  |
+#         | plan_resolvedSnfServiceGrievances                        | text | 4                  |
+#         | plan_resolvedLtssServiceGrievances                       | text | 5                  |
+#         | plan_resolvedDentalServiceGrievances                     | text | 6                  |
+#         | plan_resolvedNemtGrievances                              | text | 7                  |
+#         | plan_resolvedOtherServiceGrievances                      | text | 8                  |
+#     And I click the "Save & Close" button
+
+#     Then I have completed "1" drawer reports
+#     And I click the "Continue" button
+#     And the "/mcpar/plan-level-indicators/appeals-state-fair-hearings-grievances/grievances-by-reason" page is loaded
+
+# Scenario: Fills out Section D: Grievances By Reason
+#     Given I am on "/mcpar/plan-level-indicators/appeals-state-fair-hearings-grievances/grievances-by-reason"
+
+#     When I click the "Enter" button
+#     And these form elements are filled:
+#         | plan_resolvedCustomerServiceGrievances          | text | N/A                |
+#         | plan_resolvedCareCaseManagementGrievances       | text | Data not available |
+#         | plan_resolvedAccessToCareGrievances             | text | 1                  |
+#         | plan_resolvedQualityOfCareGrievances            | text | 2                  |
+#         | plan_resolvedPlanCommunicationGrievances        | text | 3                  |
+#         | plan_resolvedPaymentBillingGrievances           | text | 4                  |
+#         | plan_resolvedSuspectedFraudGrievances           | text | 5                  |
+#         | plan_resolvedAbuseNeglectExploitationGrievances | text | 6                  |
+#         | plan_resolvedUntimelyResponseGrievances         | text | 7                  |
+#         | plan_resolvedDenialOfExpeditedAppealGrievances  | text | 8                  |
+#         | plan_resolvedOtherGrievances                    | text | 9                  |
+#     And I click the "Save & Close" button
+
+#     Then I have completed "1" drawer reports
+#     And I click the "Continue" button
+#     And the "/mcpar/plan-level-indicators/quality-measures" page is loaded
+
+
+# Scenario Outline: Fills out Section D: Quality & Performance Measures - Create multiple measures
+#     Given I am on "/mcpar/plan-level-indicators/quality-measures"
+
+#     When I click the "Add quality & performance measure" button
+#     And these form elements are filled:
+#         | qualityMeasure_domain            | radio | <domain>      |
+#         | qualityMeasure_name              | text  | <name>        |
+#         | qualityMeasure_nqfNumber         | text  | <nqfNumber>   |
+#         | qualityMeasure_reportingRateType | radio | <type>        |
+#         | qualityMeasure_set               | radio | <set>         |
+#         | qualityMeasure_reportingPeriod   | radio | <period>      |
+#         | qualityMeasure_description       | text  | <description> |
+
+#     And I click the "Save" button
+
+#     Then the access measure "<domain>", "<name>", and "<nqfNumber>" is created
+
+#     Examples: #Quality Measure Data
+#         | domain                          | name           | nqfNumber | type                  | set   | period | description        |
+#         | Dental and oral health services | measure name   | 8675309   | Program-specific rate | HEDIS | Yes    | Details            |
+#         | Maternal and perinatal health   | Second Measure | 123456789 | Program-specific rate | HEDIS | Yes    | Additional Details |
+
+
+# Scenario Outline: Fills out Section D: Quality & Performance Measures - Edit a measure
+#     Given I am on "/mcpar/plan-level-indicators/quality-measures"
+#     And there are "2" "quality measures"
+#     And I click the "Edit measure" button
+
+#     When these form elements are edited:
+#         | qualityMeasure_domain            | radio | <domain>      |
+#         | qualityMeasure_name              | text  | <name>        |
+#         | qualityMeasure_nqfNumber         | text  | <nqfNumber>   |
+#         | qualityMeasure_reportingRateType | radio | <type>        |
+#         | qualityMeasure_set               | radio | <set>         |
+#         | qualityMeasure_reportingPeriod   | radio | <period>      |
+#         | qualityMeasure_description       | text  | <description> |
+
+#     And I click the "Save" button
+
+#     Then the access measure "<domain>", "<name>", and "<nqfNumber>" is created
+#     And there are "2" "quality measures"
+
+#     Examples: #Quality Measure Edited Data
+#         | domain                 | name        | nqfNumber | type                  | set   | period | description    |
+#         | Behavioral health care | Edited Name | 21        | Program-specific rate | HEDIS | Yes    | Edited Details |
+
+# Scenario Outline: Fills out Section D: Quality & Performance Measures - Measure Details
+#     Given I am on "/mcpar/plan-level-indicators/quality-measures"
+#     And I click the "Enter measure results" button
+
+#     When these form elements are filled:
+#         | qualityMeasure_plan_measureResults | repeated | <resultOne> | 0 |
+#         | qualityMeasure_plan_measureResults | repeated | <resultTwo> | 1 |
+
+#     And I click the "Save & Close" button
+
+#     Then the quality measure is completed with "<resultOne>" and "<resultTwo>"
+
+#     Examples: #Quality Measure Details Data
+#         | resultOne  | resultTwo         |
+#         | Detail One | More details      |
+#         | Detail Two | Even more details |
+
+# Scenario Outline: Fills out Section D: Quality & Performance Measures - Edit Measure Details
+#     Given I am on "/mcpar/plan-level-indicators/quality-measures"
+#     And there are "2" "quality measures"
+#     And I click the "Edit measure results" button
+
+#     When these form elements are edited:
+#         | qualityMeasure_plan_measureResults | repeated | <resultOne> | 0 |
+#         | qualityMeasure_plan_measureResults | repeated | <resultTwo> | 1 |
+
+#     And I click the "Save & Close" button
+
+#     Then the quality measure is completed with "<resultOne>" and "<resultTwo>"
+#     And there are "2" "quality measures"
+
+#     Then I click the "Continue" button
+#     And the "/mcpar/plan-level-indicators/sanctions" page is loaded
+
+#     Examples: #Quality Measure Edited Data
+#         | resultOne       | resultTwo                                           |
+#         | Changed Details | Its getting ridiculous how many details are changed |
+
+# Scenario Outline: Fills out Section D: Sanctions - Create multiple measures
+#     Given I am on "/mcpar/plan-level-indicators/sanctions"
+
+#     When I click the "Add sanction" button
+#     And these form elements are filled:
+#         | sanction_interventionType   | radio    | <type>   |
+#         | sanction_interventionTopic  | radio    | <topic>  |
+#         | sanction_planName           | dropdown | <plan>   |
+#         | sanction_interventionReason | text     | <reason> |
+
+#     And I click the "Save" button
+
+#     Then the sanction "<type>" and "<plan>" is created
+
+#     Examples: #Sanctions Measure Data
+#         | type                   | topic                  | plan        | reason               |
+#         | Corrective action plan | Performance management | First Plan  | These are my reasons |
+#         | Fine                   | Reporting              | Second Plan | They are many        |
+
+
+# Scenario Outline: Fills out Section D: Sanctions - Edit a measure
+#     Given I am on "/mcpar/plan-level-indicators/sanctions"
+#     And there are "2" "sanctions"
+#     And I click the "Edit sanction" button
+
+#     When these form elements are edited:
+#         | sanction_interventionType   | radio    | <type>   |
+#         | sanction_interventionTopic  | radio    | <topic>  |
+#         | sanction_planName           | dropdown | <plan>   |
+#         | sanction_interventionReason | text     | <reason> |
+
+#     And I click the "Save" button
+
+#     Then the sanction "<type>" and "<plan>" is created
+#     And there are "2" "sanctions"
+
+#     Examples: #Sanctions Edited Data
+#         | type              | topic          | plan        | reason                                |
+#         | Compliance letter | Excess charges | Second Plan | Many are there just so gosh darn many |
+
+# Scenario Outline: Fills out Section D: Sanctions - Measure Details
+#     Given I am on "/mcpar/plan-level-indicators/sanctions"
+#     And I click the "Enter sanction details" button
+
+#     When these form elements are filled:
+#         | sanction_noncomplianceInstances | text  | <instances>      |
+#         | sanction_dollarAmount           | text  | <amount>         |
+#         | sanction_assessmentDate         | text  | <dateAssessed>   |
+#         | sanction_remediationCompleted   | radio | <remedCompleted> |
+#         | sanction_remediationDate        | text  | <remedDate>      |
+#         | sanction_correctiveActionPlan   | radio | <actionPlan>     |
+
+#     And I click the "Save & Close" button
+
+#     Then the sanction is completed with "<instances>", "<amount>", "<dateAssessed>", "<remedDate>", and "<actionPlan>"
+
+#     Examples: #Sanctions Details Data
+#         | instances | amount | dateAssessed | remedCompleted | remedDate  | actionPlan |
+#         | 1         | 1,109  | 04/05/2022   | Yes            | 05/06/2022 | No         |
+#         | 2         | 1,776  | 04/05/2022   | Yes            | 05/06/2022 | No         |
+
+# Scenario Outline: Fills out Section D: Sanctions - Edit Measure Details
+#     Given I am on "/mcpar/plan-level-indicators/sanctions"
+#     And there are "2" "sanctions"
+#     And I click the "Edit sanction details" button
+
+#     When these form elements are edited:
+#         | sanction_noncomplianceInstances | text  | <instances>      |
+#         | sanction_dollarAmount           | text  | <amount>         |
+#         | sanction_assessmentDate         | text  | <dateAssessed>   |
+#         | sanction_remediationCompleted   | radio | <remedCompleted> |
+#         | sanction_remediationDate        | text  | <remedDate>      |
+#         | sanction_correctiveActionPlan   | radio | <actionPlan>     |
+
+#     And I click the "Save & Close" button
+
+#     Then the sanction is completed with "<instances>", "<amount>", "<dateAssessed>", "<remedDate>", and "<actionPlan>"
+#     And there are "2" "sanctions"
+
+#     Then I click the "Continue" button
+#     And the "/mcpar/plan-level-indicators/program-integrity" page is loaded
+
+#     Examples: #Sanctions Edited Data
+#         | instances | amount | dateAssessed | remedCompleted | remedDate  | actionPlan |
+#         | 3         | 911    | 08/05/2022   | Yes            | 09/06/2022 | Yes        |
+
+# Scenario: Fills out Section D: Program Integrity
+#     Given I am on "/mcpar/plan-level-indicators/program-integrity"
+
+#     When I click the "Enter" button
+#     And these form elements are filled:
+#         | plan_dedicatedProgramIntegrityStaff                         | text  | N/A                                                            |
+#         | plan_openedProgramIntegrityInvestigations                   | text  | Data not available                                             |
+#         | plan_programIntegrityInvestigationsToEnrolleesRatio         | text  | 123:111515111                                                  |
+#         | plan_resolvedProgramIntegrityInvestigations                 | text  | 46                                                             |
+#         | plan_resolvedProgramIntegrityInvestigationsToEnrolleesRatio | text  | 1:1                                                            |
+#         | plan_programIntegrityReferralPath                           | radio | Makes referrals to the Medicaid Fraud Control Unit (MFCU) only |
+#         | plan_mfcuProgramIntegrityReferrals                          | text  | 12                                                             |
+#         | plan_programIntegrityReferralsPerThousandBeneficiaries      | text  | 121                                                            |
+#         | plan_overpaymentRecoveryReportDescription                   | text  | Report Description                                             |
+#         | plan_beneficiaryCircumstanceChangeReportingFrequency        | radio | Daily                                                          |
+#     And I click the "Save & Close" button
+
+#     Then I have completed "1" drawer reports
+#     And I click the "Continue" button
+#     And the "/mcpar/bss-entity-indicators" page is loaded
+
+# Scenario: Fills out Section E: BSS Entity Indicators
+#     Given I am on "/mcpar/bss-entity-indicators"
+
+#     When I click the "Enter" button
+#     And these form elements are filled:
+#         | bssEntity_entityType | checkbox | State Health Insurance Assistance Program (SHIP) |
+#         | bssEntity_entityRole | checkbox | Enrollment Broker/Choice Counseling              |
+#     And I click the "Save & Close" button
+
+#     Then I have completed "1" drawer reports
+#     And I click the "Continue" button
+#     And the "/mcpar/review-and-submit" page is loaded
+
+# Scenario: Submits the Form
+#     Given I am on "/mcpar/review-and-submit"
+
+#     When I click the "Submit MCPAR" button
+#     And I click the "Submit MCPAR" button
+
+#     Then the "/mcpar/review-and-submit" page is loaded
+#     And the page shows "Successfully Submitted"
+
+# Scenario: Submission shows on dashboard
+#     Given I am on "/mcpar/review-and-submit"
+
+#     When I click the "Leave form" button
+#     And I visit "/mcpar"
+
+#     Then the page shows "Submitted"
+
+
+# Scenario: Admin user archives the program
+#     Given I am logged in as an admin user
+#     And I am on "/mcpar"
+#     And these form elements are filled:
+#         | state | dropdown | District of Columbia |
+
+#     When I click the "Go to Report Dashboard" button
+#     And I click the "Archive" button
+#     Then the program is archived
+
+

--- a/tests/cypress/tests/e2e/mlr/form.stepdef.js
+++ b/tests/cypress/tests/e2e/mlr/form.stepdef.js
@@ -1,0 +1,145 @@
+import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
+import template from "../../../../../services/ui-src/src/forms/mlr/mlr.json";
+
+When("I submit a new MLR program", () => {
+  //Create the program
+  const today = new Date();
+  const lastYear = new Date();
+  lastYear.setFullYear(today.getFullYear() - 1);
+  const programName = "automated test - " + today.toISOString();
+  cy.visit(`/mlr`);
+  cy.findByRole("button", { name: "Add new MLR submission" }).click();
+  cy.get('input[id="programName"]').type(programName);
+  cy.get("button[type=submit]").contains("Save").click();
+
+  //Find our new program and open it
+  cy.findByText(programName)
+    .parent()
+    .find('button:contains("Enter")')
+    .focus()
+    .click();
+
+  //Using the mcpar.json as a guide, traverse all the routes/forms and fill it out dynamically
+  traverseRoutes(template.routes);
+
+  //Submit the program
+  cy.get('button:contains("Submit MLR")').focus().click();
+  cy.get('[data-testid="modal-submit-button"]').focus().click();
+});
+
+Then("the program is submitted", () => {
+  cy.contains("Successfully Submitted").should("be.visible");
+});
+
+const traverseRoutes = (routes) => {
+  //iterate over each route
+  routes.forEach((route) => {
+    traverseRoute(route);
+  });
+};
+
+const traverseRoute = (route) => {
+  //only perform checks on route if it contains some time of form fill
+  if (route.form || route.modalForm || route.drawerForm) {
+    //validate we are on the URL we expect to be
+    cy.url().should("include", route.path);
+    //Validate the intro section is presented
+    if (route.verbiage?.intro?.section)
+      cy.contains(route.verbiage?.intro?.section);
+    if (route.verbiage?.intro?.subsection)
+      cy.contains(route.verbiage?.intro?.subsection);
+
+    //Fill out the 3 different types of forms
+    completeFrom(route.form);
+    completeModalForm(route.modalForm, route.verbiage?.addEntityButtonText);
+    completeDrawerForm(route.drawerForm);
+
+    //Sometimes the button is "Continue" sometimes it is "Save & Continue", this will click either.
+    cy.get('button:contains("ontinue")').focus().click();
+  }
+  //If this route has children routes, traverse those as well
+  if (route.children) traverseRoutes(route.children);
+};
+
+const completeDrawerForm = (drawerForm) => {
+  if (drawerForm) {
+    //enter the drawer, then fill out the form and save it
+    cy.get('button:contains("Enter")').focus().click();
+    completeFrom(drawerForm);
+    cy.get('button:contains("Save")').focus().click();
+  }
+};
+
+const completeModalForm = (modalForm, buttonText) => {
+  //open the modal, then fill out the form and save it
+  if (modalForm && buttonText) {
+    cy.get(`button:contains("${buttonText}")`).focus().click();
+    completeFrom(modalForm);
+    cy.get('button:contains("Save")').focus().click();
+  }
+};
+
+const completeFrom = (form) => {
+  //iterate over each field and fill it appropriately
+  form?.fields?.forEach((field) => processField(field));
+};
+
+const processField = (field) => {
+  //only try to fill it out if it's enabled
+  if (!field.props?.disabled) {
+    //Validation method shifts around based on field type
+    const validationType = field.validation?.type
+      ? field.validation?.type
+      : field.validation;
+    switch (field.type) {
+      case "text":
+      case "textarea":
+        switch (validationType) {
+          case "email":
+            cy.get(`[name="${field.id}"]`).type("email@fill.com");
+            break;
+          case "url":
+            cy.get(`[name="${field.id}"]`).type("https://fill.com");
+            break;
+          case "text":
+            if (field.repeat) {
+              //repeats don't use the exact name, but thankfully don't need to worry about similar names
+              cy.get(`[name^="${field.id}"]`).type("Text Fill");
+            } else {
+              cy.get(`[name="${field.id}"]`).type("Text Fill");
+            }
+            break;
+          default:
+            cy.get(`[name="${field.id}"]`).type("Unknown Fill");
+        }
+        break;
+      case "date":
+        cy.get(`[name="${field.id}"]`).type(
+          new Date().toLocaleDateString("en-US")
+        );
+        break;
+      case "dynamic":
+        cy.get(`[name="${field.id}[0]"`).type("Dynamic Fill");
+        break;
+      case "number":
+        switch (validationType) {
+          case "ratio":
+            cy.get(`[name="${field.id}"]`).type("1:1");
+            break;
+          default:
+            cy.get(`[name="${field.id}"]`).type(Math.ceil(Math.random() * 100));
+        }
+        break;
+      case "dropdown":
+        cy.get(`[name="${field.id}"]`).select(1);
+        break;
+      case "radio":
+      case "checkbox":
+        cy.get(`[id="${field.id}-${field.props.choices[0].id}"]`).check();
+        field.props.choices[0].children?.forEach((childField) =>
+          processField(childField)
+        );
+        break;
+    }
+  }
+};


### PR DESCRIPTION
## Summary
This PR adds MLR page 1 (contact info) to the MLR report. Also, creates new MLR reports with "versionControl" always set to "no" (report is not a resubmission).

### Related ticket
[<!-- Link to related ticket or issue -->](https://qmacbis.atlassian.net/browse/MDCT-2226)

### How to test
1) Set `MLR: true` in Launch Darkly flags
2) Open MLR report from State User dashboard
3) Create a new MLR report
4) Enter the report
5) Verify that there is a contact information page with pre-filled state name and version control (set to "no).

### Important updates
None

### Author checklist
<!-- Complete the following before marking ready for review -->
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated the documentation, if necessary
