### PR TITLE
Support nested select for MLR resubmissions

### DIFF
--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -107,7 +107,6 @@ export const AddEditReportModal = ({
         },
       });
     } else {
-      // create new report
       await createReport(reportType, activeState, {
         ...dataToWrite,
         metadata: {
@@ -123,7 +122,8 @@ export const AddEditReportModal = ({
             reportType === "MLR"
               ? [
                   {
-                    key: "versionControl-n",
+                    // pragma: allowlist nextline secret
+                    key: "versionControl-KFCd3rfEu3eT4UFskUhDtx",
                     value: "No, this is an initial submission",
                   },
                 ]

--- a/services/ui-src/src/forms/mlr/mlr.json
+++ b/services/ui-src/src/forms/mlr/mlr.json
@@ -87,11 +87,63 @@
                   "hint": "Is this report an updated version of a previously submitted summary MLR report covering the same time period? <br /><br /> Auto-populates. Note: The version control field is determined from the submission status. All new MLR reports are initial submissions.",
                   "choices": [
                     {
-                      "id": "Y",
-                      "label": "Yes, this is a resubmission"
+                      "id": "cyUSrTH8mWdpqAKExLZAkz",
+                      "label": "Yes, this is a resubmission",
+                      "children": [
+                        {
+                          "id": "versionControlDescription",
+                          "type": "radio",
+                          "validation": {
+                            "type": "radio",
+                            "nested": true,
+                            "parentFieldName": "versionControl"
+                          },
+                          "props": {
+                            "label": "H. Version control description",
+                            "hint": "Select the response(s) that best describes the changes between this version and the prior version of the annual summary MLR Report submission.",
+                            "choices": [
+                              {
+                                "id": "nwq29k5JoRaUiz7CtBZFQN",
+                                "label": "Revise state contact information"
+                              },
+                              {
+                                "id": "BezTBrQf7t3bud7LaAMLqH",
+                                "label": "Revise program or plan information"
+                              },
+                              {
+                                "id": "Kr7HesM9jxDGfP4xDVAXpm",
+                                "label": "Revise amount(s) for MLR calculation"
+                              },
+                              {
+                                "id": "2tdWvZkAkozLqZie6iwXRh",
+                                "label": "Revise amount of remittance"
+                              },
+                              {
+                                "id": "3fbB2pqVnMAQjKtFVZoSXw",
+                                "label": "Revise member months"
+                              },
+                              {
+                                "id": "4V3X7Mmz6VC89k9bgQUoLK",
+                                "label": "Other, specify",
+                                "children": [
+                                  {
+                                    "id": "versionControlDescriptionOther",
+                                    "type": "text",
+                                    "validation": {
+                                      "type": "text",
+                                      "nested": true,
+                                      "parentFieldName": "versionControlDescription"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        }
+                      ]
                     },
                     {
-                      "id": "N",
+                      "id": "KFCd3rfEu3eT4UFskUhDtx",
                       "label": "No, this is an initial submission"
                     }
                   ],


### PR DESCRIPTION
## Summary
Forgot to add the resubmission case to the primary contact form.

### Description
Also, changes the choice IDs to be random UUIDS.

### Related ticket
[Ticket](https://qmacbis.atlassian.net/browse/MDCT-2226)

### How to test
1. Manually set "disabled: false" on question G
2. Verify that nested radio select appears
3. Verify that the final option (other) has a text input as a child.

### Important updates
None.

### Author checklist
<!-- Complete the following before marking ready for review -->
- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated the documentation, if necessary
