### PR TITLE
MLR Admin Actions Fix

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -147,7 +147,7 @@ const AdminUnlockButton = ({
     <Td>
       <Button
         variant="link"
-        disabled={report.locked === false}
+        disabled={report.archived || report.locked}
         sx={sxOverride.adminActionButton}
         onClick={() => unlockReport!(report)}
       >

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
@@ -147,7 +147,7 @@ const AdminUnlockButton = ({
   return (
     <Button
       variant="link"
-      disabled={report.locked === false}
+      disabled={report.archived || report.locked}
       sx={sxOverride.adminActionButton}
       onClick={() => unlockReport!(report)}
     >


### PR DESCRIPTION
## Summary

### Description

Admins should only be able to unlock a report that is not archived or that is locked.

### Related ticket

N/A

### How to test

- Create an MLR report
- Log in as admin
- Archive that report

`Unlock` should be disabled.

### Important updates

N/A

### Author checklist
<!-- Complete the following before marking ready for review -->
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated the documentation, if necessary
