### PR TITLE
Add `SectionHeader` form field type

### DIFF
--- a/services/ui-src/src/components/export/ExportedReportFieldRow.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldRow.tsx
@@ -3,7 +3,7 @@ import { useContext } from "react";
 import { Box, Tr, Td, Text } from "@chakra-ui/react";
 import { ReportContext } from "components";
 // types
-import { FormField } from "types";
+import { FormField, FormLayoutElement, isFieldElement } from "types";
 // utils
 import { parseFormFieldInfo, parseCustomHtml, renderDataCell } from "utils";
 
@@ -54,6 +54,7 @@ export const ExportedReportFieldRow = ({
       {/* data column/cell */}
       <Td>
         {reportData &&
+          isFieldElement(formField) &&
           renderDataCell(
             formField,
             reportData,
@@ -67,7 +68,7 @@ export const ExportedReportFieldRow = ({
 };
 
 export interface Props {
-  formField: FormField;
+  formField: FormField | FormLayoutElement;
   pageType: string;
   entityType?: string;
   parentFieldCheckedChoiceIds?: string[];

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
@@ -10,6 +10,8 @@ import {
   StandardReportPageShape,
   DrawerReportPageShape,
   ReportShape,
+  FormLayoutElement,
+  isFieldElement,
 } from "types";
 // verbiage
 import verbiage from "verbiage/pages/export";
@@ -24,7 +26,7 @@ export const ExportedReportFieldTable = ({ section }: Props) => {
   const entityType = section.entityType;
 
   const formHasOnlyDynamicFields = formFields?.every(
-    (field: FormField) => field.type === "dynamic"
+    (field: FormField | FormLayoutElement) => field.type === "dynamic"
   );
   const twoColumnHeaderItems = [tableHeaders.indicator, tableHeaders.response];
   const threeColumnHeaderItems = [
@@ -51,7 +53,7 @@ export const ExportedReportFieldTable = ({ section }: Props) => {
 };
 
 export const renderFieldTableBody = (
-  formFields: FormField[],
+  formFields: (FormField | FormLayoutElement)[],
   pageType: string,
   report: ReportShape | undefined,
   entityType?: string
@@ -59,7 +61,7 @@ export const renderFieldTableBody = (
   const tableRows: ReactElement[] = [];
   // recursively renders field rows
   const renderFieldRow = (
-    formField: FormField,
+    formField: FormField | FormLayoutElement,
     parentFieldCheckedChoiceIds?: string[]
   ) => {
     tableRows.push(
@@ -118,7 +120,11 @@ export const renderFieldTableBody = (
     }
   };
   // map through form fields and call renderer
-  formFields?.map((field: FormField) => renderFieldRow(field));
+  formFields?.map((field: FormField | FormLayoutElement) => {
+    if (isFieldElement(field)) {
+      renderFieldRow(field);
+    }
+  });
   return tableRows;
 };
 

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -18,7 +18,13 @@ import {
   sortFormErrors,
   useUser,
 } from "utils";
-import { AnyObject, FormJson, FormField } from "types";
+import {
+  AnyObject,
+  FormJson,
+  FormField,
+  isFieldElement,
+  FormLayoutElement,
+} from "types";
 
 export const Form = ({
   id,
@@ -39,7 +45,9 @@ export const Form = ({
   const fieldInputDisabled = isAdminTypeUser && formJson.adminDisabled;
 
   // create validation schema
-  const formValidationJson = compileValidationJsonFromFields(formJson.fields);
+  const formValidationJson = compileValidationJsonFromFields(
+    formJson.fields.filter(isFieldElement)
+  );
   const formValidationSchema = mapValidationTypesToSchema(formValidationJson);
   const formResolverSchema = yupSchema(formValidationSchema || {});
   mapValidationTypesToSchema;
@@ -66,7 +74,7 @@ export const Form = ({
   };
 
   // hydrate and create form fields using formFieldFactory
-  const renderFormFields = (fields: FormField[]) => {
+  const renderFormFields = (fields: (FormField | FormLayoutElement)[]) => {
     const fieldsToRender = hydrateFormFields(fields, formData);
     return formFieldFactory(fieldsToRender, {
       disabled: !!fieldInputDisabled,

--- a/services/ui-src/src/components/forms/FormLayoutElements.test.tsx
+++ b/services/ui-src/src/components/forms/FormLayoutElements.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+import { SectionHeader } from "./FormLayoutElements";
+
+const sectionHeaderComponentTopDivider = (
+  <SectionHeader
+    divider="top"
+    name="sectionHeader"
+    content="1. Section Header"
+    data-testid="test-section-header"
+  />
+);
+
+const sectionHeaderComponentBottomDivider = (
+  <SectionHeader
+    divider="bottom"
+    name="sectionHeader"
+    content="1. Section Header"
+    data-testid="test-section-header"
+  />
+);
+
+const sectionHeaderComponentNoDivider = (
+  <SectionHeader
+    divider="none"
+    name="sectionHeader"
+    content="1. Section Header"
+    data-testid="test-section-header"
+  />
+);
+
+describe("Test SectionHeader component", () => {
+  test("Top should make the section divider on the top.", async () => {
+    const { findByText, getByRole } = render(sectionHeaderComponentTopDivider);
+    const sectionHeader = screen.getByTestId("test-section-header");
+
+    expect(sectionHeader).toBeVisible();
+    expect(await findByText("1. Section Header")).toBeTruthy();
+    expect(sectionHeader.childNodes[0]).toMatchObject(getByRole("separator"));
+  });
+
+  test("Bottom should make the section divider on the bottom", async () => {
+    const { findByText, getByRole } = render(
+      sectionHeaderComponentBottomDivider
+    );
+    const sectionHeader = screen.getByTestId("test-section-header");
+
+    expect(sectionHeader).toBeVisible();
+    expect(await findByText("1. Section Header")).toBeTruthy();
+    expect(sectionHeader.childNodes[1]).toMatchObject(getByRole("separator"));
+  });
+
+  test("None should make the section divider not there.", async () => {
+    const { findByText, queryByRole } = render(sectionHeaderComponentNoDivider);
+    const sectionHeader = screen.getByTestId("test-section-header");
+
+    expect(sectionHeader).toBeVisible();
+    expect(await findByText("1. Section Header")).toBeTruthy();
+    expect(queryByRole("separator")).not.toBeInTheDocument();
+  });
+});
+
+describe("Test TextAreaField accessibility", () => {
+  it("Should not have basic accessibility issues", async () => {
+    for (const component of [
+      sectionHeaderComponentBottomDivider,
+      sectionHeaderComponentTopDivider,
+      sectionHeaderComponentNoDivider,
+    ]) {
+      const { container } = render(component);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    }
+  });
+});

--- a/services/ui-src/src/components/forms/FormLayoutElements.tsx
+++ b/services/ui-src/src/components/forms/FormLayoutElements.tsx
@@ -1,0 +1,23 @@
+import { Box } from "@chakra-ui/react";
+
+export const SectionHeader = ({ content, divider, ...props }: Props) => {
+  return (
+    <Box sx={sx} {...props}>
+      {divider === "top" && <hr></hr>}
+      <h3>{content}</h3>
+      {divider === "bottom" && <hr></hr>}
+    </Box>
+  );
+};
+
+interface Props {
+  content: string;
+  divider: "top" | "bottom" | "none";
+  [key: string]: any;
+}
+
+const sx = {
+  h3: {
+    padding: "2rem 0 1rem 0",
+  },
+};

--- a/services/ui-src/src/components/forms/FormLayoutElements.tsx
+++ b/services/ui-src/src/components/forms/FormLayoutElements.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@chakra-ui/react";
+import { Box, Heading } from "@chakra-ui/react";
 
 export const SectionHeader = ({ content, divider, ...props }: Props) => {
   const sx = {
@@ -9,7 +9,7 @@ export const SectionHeader = ({ content, divider, ...props }: Props) => {
   return (
     <Box sx={sx} {...props}>
       {divider === "top" && <hr></hr>}
-      <h3>{content}</h3>
+      <Heading size="md">{content}</Heading>
       {divider === "bottom" && <hr></hr>}
     </Box>
   );

--- a/services/ui-src/src/components/forms/FormLayoutElements.tsx
+++ b/services/ui-src/src/components/forms/FormLayoutElements.tsx
@@ -1,6 +1,11 @@
 import { Box } from "@chakra-ui/react";
 
 export const SectionHeader = ({ content, divider, ...props }: Props) => {
+  const sx = {
+    h3: {
+      padding: divider === "bottom" ? "2rem 0 1rem 0" : "1rem 0 2rem 0",
+    },
+  };
   return (
     <Box sx={sx} {...props}>
       {divider === "top" && <hr></hr>}
@@ -15,9 +20,3 @@ interface Props {
   divider: "top" | "bottom" | "none";
   [key: string]: any;
 }
-
-const sx = {
-  h3: {
-    padding: "2rem 0 1rem 0",
-  },
-};

--- a/services/ui-src/src/components/modals/AddEditEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.tsx
@@ -5,7 +5,13 @@ import { Form, Modal, ReportContext } from "components";
 import { Text } from "@chakra-ui/react";
 import { Spinner } from "@cmsgov/design-system";
 // utils
-import { AnyObject, EntityShape, FormJson, ReportStatus } from "types";
+import {
+  AnyObject,
+  EntityShape,
+  FormJson,
+  isFieldElement,
+  ReportStatus,
+} from "types";
 import { filterFormData, useUser } from "utils";
 
 export const AddEditEntityModal = ({
@@ -37,7 +43,10 @@ export const AddEditEntityModal = ({
       fieldData: {},
     };
     const currentEntities = report?.fieldData?.[entityType] || [];
-    const filteredFormData = filterFormData(enteredData, form.fields);
+    const filteredFormData = filterFormData(
+      enteredData,
+      form.fields.filter(isFieldElement)
+    );
     if (selectedEntity?.id) {
       // if existing entity selected, edit
       const selectedEntityIndex = currentEntities.findIndex(

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -22,6 +22,7 @@ import {
   DrawerReportPageShape,
   ReportStatus,
   FormField,
+  isFieldElement,
 } from "types";
 import completedIcon from "assets/icons/icon_check_circle.png";
 
@@ -56,7 +57,10 @@ export const DrawerReportPage = ({ route }: Props) => {
       const selectedEntityIndex = report?.fieldData[entityType].findIndex(
         (entity: EntityShape) => entity.name === selectedEntity?.name
       );
-      const filteredFormData = filterFormData(enteredData, drawerForm.fields);
+      const filteredFormData = filterFormData(
+        enteredData,
+        drawerForm.fields.filter(isFieldElement)
+      );
       const newEntity = {
         ...selectedEntity,
         ...filteredFormData,
@@ -84,9 +88,9 @@ export const DrawerReportPage = ({ route }: Props) => {
        * If the entity has the same fields from drawerForms fields, it was completed
        * at somepoint.
        */
-      const isEntityCompleted = drawerForm.fields?.every(
-        (field: FormField) => field.id in entity
-      );
+      const isEntityCompleted = drawerForm.fields
+        ?.filter(isFieldElement)
+        .every((field: FormField) => field.id in entity);
       return (
         <Flex key={entity.id} sx={sx.entityRow}>
           {isEntityCompleted && (

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -22,6 +22,7 @@ import {
   EntityShape,
   EntityType,
   FormField,
+  isFieldElement,
   ModalDrawerReportPageShape,
   ReportStatus,
 } from "types";
@@ -41,12 +42,12 @@ export const ModalDrawerReportPage = ({ route }: Props) => {
 
   // create drawerForm from json with repeated fields
   const drawerForm = { ...drawerFormJson };
-  const formContainsFieldsToRepeat = drawerFormJson.fields.find(
-    (field: FormField) => field.repeat
-  );
+  const formContainsFieldsToRepeat = drawerFormJson.fields
+    .filter(isFieldElement)
+    .find((field: FormField) => field.repeat);
   if (formContainsFieldsToRepeat) {
     drawerForm.fields = createRepeatedFields(
-      drawerFormJson.fields,
+      drawerFormJson.fields.filter(isFieldElement),
       report?.fieldData
     );
   }
@@ -114,7 +115,10 @@ export const ModalDrawerReportPage = ({ route }: Props) => {
       const selectedEntityIndex = report?.fieldData[entityType].findIndex(
         (entity: EntityShape) => entity.id === selectedEntity?.id
       );
-      const filteredFormData = filterFormData(enteredData, drawerForm.fields);
+      const filteredFormData = filterFormData(
+        enteredData,
+        drawerForm.fields.filter(isFieldElement)
+      );
       const newEntity = {
         ...selectedEntity,
         ...filteredFormData,

--- a/services/ui-src/src/components/reports/StandardReportPage.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.tsx
@@ -10,7 +10,12 @@ import {
 } from "components";
 // utils
 import { filterFormData, useFindRoute, useUser } from "utils";
-import { AnyObject, ReportStatus, StandardReportPageShape } from "types";
+import {
+  AnyObject,
+  isFieldElement,
+  ReportStatus,
+  StandardReportPageShape,
+} from "types";
 
 export const StandardReportPage = ({ route }: Props) => {
   const [submitting, setSubmitting] = useState<boolean>(false);
@@ -33,7 +38,10 @@ export const StandardReportPage = ({ route }: Props) => {
       state: state,
       id: report?.id,
     };
-    const filteredFormData = filterFormData(enteredData, route.form.fields);
+    const filteredFormData = filterFormData(
+      enteredData,
+      route.form.fields.filter(isFieldElement)
+    );
     const dataToWrite = {
       metadata: {
         status: ReportStatus.IN_PROGRESS,

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -241,7 +241,7 @@ export type FieldValidationObject =
 export interface FormField {
   id: string;
   type: string;
-  validation: string | FieldValidationObject;
+  validation?: string | FieldValidationObject;
   hydrate?: string;
   props?: AnyObject;
   choices?: FieldChoice[];

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -248,6 +248,24 @@ export interface FormField {
   repeat?: string;
 }
 
+export function isFieldElement(
+  field: FormField | FormLayoutElement
+): field is FormLayoutElement {
+  return (field as FormField).validation !== undefined;
+}
+
+export interface FormLayoutElement {
+  id: string;
+  type: string;
+  props?: AnyObject;
+}
+
+export function isLayoutElement(
+  field: FormField | FormLayoutElement
+): field is FormLayoutElement {
+  return (field as FormField).validation === undefined;
+}
+
 export interface DropdownOptions {
   label: string;
   value: string;

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -251,7 +251,7 @@ export interface FormField {
 export function isFieldElement(
   field: FormField | FormLayoutElement
 ): field is FormField {
-  return (field as FormField).validation !== undefined;
+  return !formLayoutElementTypes.includes(field.type);
 }
 
 export interface FormLayoutElement {
@@ -259,6 +259,8 @@ export interface FormLayoutElement {
   type: string;
   props?: AnyObject;
 }
+
+const formLayoutElementTypes = ["sectionHeader"];
 
 export function isLayoutElement(
   field: FormField | FormLayoutElement

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -206,7 +206,7 @@ export interface EntityShape {
 
 export interface FormJson {
   id: string;
-  fields: FormField[];
+  fields: (FormField | FormLayoutElement)[];
   options?: AnyObject;
   validation?: AnyObject;
   adminDisabled?: boolean;
@@ -241,7 +241,7 @@ export type FieldValidationObject =
 export interface FormField {
   id: string;
   type: string;
-  validation?: string | FieldValidationObject;
+  validation: string | FieldValidationObject;
   hydrate?: string;
   props?: AnyObject;
   choices?: FieldChoice[];
@@ -250,7 +250,7 @@ export interface FormField {
 
 export function isFieldElement(
   field: FormField | FormLayoutElement
-): field is FormLayoutElement {
+): field is FormField {
   return (field as FormField).validation !== undefined;
 }
 

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -59,10 +59,10 @@ export const formFieldFactory = (
 };
 
 export const hydrateFormFields = (
-  formFields: FormField[],
+  formFields: (FormField | FormLayoutElement)[],
   formData: AnyObject | undefined
 ) => {
-  formFields.forEach((field: FormField) => {
+  formFields.forEach((field: FormField | FormLayoutElement) => {
     const fieldFormIndex = formFields.indexOf(field!);
     const fieldProps = formFields[fieldFormIndex].props!;
     // check for children on each choice in field props

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -13,6 +13,7 @@ import {
 } from "components";
 // types
 import { AnyObject, FieldChoice, FormField } from "types";
+import { SectionHeader } from "components/forms/FormLayoutElements";
 
 // return created elements from provided fields
 export const formFieldFactory = (
@@ -34,6 +35,7 @@ export const formFieldFactory = (
     radio: RadioField,
     text: TextField,
     textarea: TextAreaField,
+    sectionHeader: SectionHeader,
   };
   fields = initializeChoiceListFields(fields);
   return fields.map((field) => {

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -12,12 +12,18 @@ import {
   ChoiceField,
 } from "components";
 // types
-import { AnyObject, FieldChoice, FormField } from "types";
+import {
+  AnyObject,
+  FieldChoice,
+  FormField,
+  FormLayoutElement,
+  isFieldElement,
+} from "types";
 import { SectionHeader } from "components/forms/FormLayoutElements";
 
 // return created elements from provided fields
 export const formFieldFactory = (
-  fields: FormField[],
+  fields: Array<FormField | FormLayoutElement>,
   options?: {
     disabled?: boolean;
     nested?: boolean;
@@ -83,24 +89,28 @@ export const hydrateFormFields = (
 };
 
 // add data to choice fields in preparation for render
-export const initializeChoiceListFields = (fields: FormField[]) => {
+export const initializeChoiceListFields = (
+  fields: (FormField | FormLayoutElement)[]
+) => {
   const fieldsWithChoices = fields.filter(
-    (field: FormField) => field.props?.choices
+    (field: FormField | FormLayoutElement) => field.props?.choices
   );
-  fieldsWithChoices.forEach((field: FormField) => {
-    field?.props?.choices.forEach((choice: FieldChoice) => {
-      // set choice value to choice label string
-      choice.value = choice.label;
-      // if choice id has not already had parent field id appended, do so now
-      if (!choice.id.includes("-")) {
-        choice.id = field.id + "-" + choice.id;
-      }
-      choice.name = choice.id;
-      // initialize choice as controlled component in unchecked state
-      if (choice.checked != true) choice.checked = false;
-      // if choice has children, recurse
-      if (choice.children) initializeChoiceListFields(choice.children);
-    });
+  fieldsWithChoices.forEach((field: FormField | FormLayoutElement) => {
+    if (isFieldElement(field)) {
+      field?.props?.choices.forEach((choice: FieldChoice) => {
+        // set choice value to choice label string
+        choice.value = choice.label;
+        // if choice id has not already had parent field id appended, do so now
+        if (!choice.id.includes("-")) {
+          choice.id = field.id + "-" + choice.id;
+        }
+        choice.name = choice.id;
+        // initialize choice as controlled component in unchecked state
+        if (choice.checked != true) choice.checked = false;
+        // if choice has children, recurse
+        if (choice.children) initializeChoiceListFields(choice.children);
+      });
+    }
   });
   return fields;
 };

--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -174,10 +174,10 @@ export const checkLinkTypes = (formField: FormField) => {
   const fieldValidationType =
     typeof formField?.validation === "string"
       ? formField.validation
-      : formField.validation.type;
+      : formField.validation?.type;
   return {
-    isLink: linkTypes.includes(fieldValidationType),
-    isEmail: emailTypes.includes(fieldValidationType),
+    isLink: linkTypes.includes(fieldValidationType ?? ""),
+    isEmail: emailTypes.includes(fieldValidationType ?? ""),
   };
 };
 

--- a/services/ui-src/src/utils/reports/reports.ts
+++ b/services/ui-src/src/utils/reports/reports.ts
@@ -5,6 +5,7 @@ import {
   ReportShape,
   ReportJson,
   ReportRoute,
+  isFieldElement,
 } from "types";
 
 export const sortReportsOldestToNewest = (
@@ -103,13 +104,13 @@ export const compileValidationJsonFromRoutes = (
       Object.assign(validationSchema, { [route.entityType]: "objectArray" });
     }
     // if standard form present, add validation to schema
-    const standardFormFields = route.form?.fields;
+    const standardFormFields = route.form?.fields.filter(isFieldElement);
     if (standardFormFields) addValidationToAccumulator(standardFormFields);
     // if modal form present, add validation to schema
-    const modalFormFields = route.modalForm?.fields;
+    const modalFormFields = route.modalForm?.fields.filter(isFieldElement);
     if (modalFormFields) addValidationToAccumulator(modalFormFields);
     // if drawer form present, add validation to schema
-    const drawerFormFields = route.drawerForm?.fields;
+    const drawerFormFields = route.drawerForm?.fields.filter(isFieldElement);
     if (drawerFormFields) addValidationToAccumulator(drawerFormFields);
   });
   return validationSchema;
@@ -131,13 +132,13 @@ export const makeFieldIdList = (routes: ReportRoute[]): AnyObject => {
     });
   routes.map((route: ReportRoute) => {
     // if standard form present, map to return object
-    const standardFormFields = route.form?.fields;
+    const standardFormFields = route.form?.fields.filter(isFieldElement);
     if (standardFormFields) mapFieldIdsToObject(standardFormFields);
     // if modal form present, map to return object
-    const modalFormFields = route.modalForm?.fields;
+    const modalFormFields = route.modalForm?.fields.filter(isFieldElement);
     if (modalFormFields) mapFieldIdsToObject(modalFormFields);
     // if drawer form present, map to return object
-    const drawerFormFields = route.drawerForm?.fields;
+    const drawerFormFields = route.drawerForm?.fields.filter(isFieldElement);
     if (drawerFormFields) mapFieldIdsToObject(drawerFormFields);
   });
   return objectToReturn;

--- a/services/ui-src/src/utils/validation/validation.ts
+++ b/services/ui-src/src/utils/validation/validation.ts
@@ -17,10 +17,10 @@ export const mapValidationTypesToSchema = (fieldValidationTypes: AnyObject) => {
         }
       }
       // else if nested validation type, make and set nested schema
-      else if (fieldValidation.nested) {
+      else if (fieldValidation && fieldValidation.nested) {
         validationSchema[key] = makeNestedFieldSchema(fieldValidation);
         // else if not nested, make and set other dependent field types
-      } else if (fieldValidation.type === "endDate") {
+      } else if (fieldValidation?.type === "endDate") {
         validationSchema[key] = makeEndDateFieldSchema(fieldValidation);
       }
     }


### PR DESCRIPTION
## Summary
JSON forms need to be able to add layout elements, like section headers. This PR adds that ability, alongside a `SectionHeader` component.

### Description
It’s a field type so it can be rendered as part of a form, but it’s actually not a field in the sense of needing to by hydrated or accepting input.

It wasn't specified, but I went ahead and gave it some customization. The component can take the prop `divider = "none" | "top" | "bottom"`, which changes the location of the `<hr />`.

Add it to your form with: 
```
  {
    "id": "sectionTest",
    "type": "sectionHeader",
    "validation": "text",
    "props": {
      "content": "1. Section Header Test",
      "divider": "top"
    }
  },
```

### Related ticket
[MDCT-2240](https://qmacbis.atlassian.net/browse/MDCT-2240)
### How to test
1. Add the above snippet to the field items of your MCPAR form
2. Verify the section header text appears
3. Verify that the divider options work correctly

### Author checklist
<!-- Complete the following before marking ready for review -->
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated the documentation, if necessary
