### PR TITLE
MLR Bug Fixes (3-17-23)

### DIFF
--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -39,12 +39,13 @@ export const ChoiceListField = ({
     useState<Choice[]>(defaultValue);
 
   const { report, updateReport } = useContext(ReportContext);
-  const { full_name, state } = useUser().user ?? {};
+  const { full_name, state, userIsAdmin } = useUser().user ?? {};
   // get form context and register field
   const form = useFormContext();
   form.register(name);
 
-  const shouldDisableChildFields = !!props?.disabled;
+  const shouldDisableChildFields =
+    userIsAdmin && report?.formTemplate.adminDisabled;
 
   // set initial display value to form state field value or hydration value
   const hydrationValue = props?.hydrate;

--- a/services/ui-src/src/components/layout/Header.tsx
+++ b/services/ui-src/src/components/layout/Header.tsx
@@ -64,9 +64,16 @@ export const Header = ({ handleLogout }: Props) => {
           <Container sx={sx.subnavContainer}>
             <Flex sx={sx.subnavFlex}>
               <Flex>
-                <Text sx={sx.programNameText}>
-                  Program: {report?.programName}
-                </Text>
+                {report?.reportType === "MCPAR" && (
+                  <Text sx={sx.programNameText}>
+                    Program: {report?.programName}
+                  </Text>
+                )}
+                {report?.reportType === "MLR" && (
+                  <Text sx={sx.programNameText}>
+                    Submission: {report?.submissionName}
+                  </Text>
+                )}
               </Flex>
               <Flex sx={sx.subnavFlexRight}>
                 {lastSavedTime && (

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.test.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.test.tsx
@@ -104,10 +104,16 @@ describe("Test McparReviewSubmitPage functionality", () => {
 describe("Success Message Generator", () => {
   it("should give the full success date if given all params", () => {
     const programName = "test-program";
+    const reportType = "MCPAR";
     const submittedDate = 1663163109045;
     const submittersName = "Carol California";
     expect(
-      SuccessMessageGenerator(programName, submittedDate, submittersName)
+      SuccessMessageGenerator(
+        reportType,
+        programName,
+        submittedDate,
+        submittersName
+      )
     ).toBe(
       `MCPAR report for ${programName} was submitted on Wednesday, September 14, 2022 by ${submittersName}.`
     );
@@ -115,11 +121,17 @@ describe("Success Message Generator", () => {
 
   it("should give a reduced version if not given all params", () => {
     const programName = "test-program";
+    const reportType = "MLR";
     const submittedDate = undefined;
     const submittersName = "Carol California";
     expect(
-      SuccessMessageGenerator(programName, submittedDate, submittersName)
-    ).toBe(`MCPAR report for ${programName} was submitted.`);
+      SuccessMessageGenerator(
+        reportType,
+        programName,
+        submittedDate,
+        submittersName
+      )
+    ).toBe(`MLR report for ${programName} was submitted.`);
   });
 
   it("if pdfExport flag is true, print button should be visible and correctly formed", async () => {

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -177,7 +177,7 @@ export const SuccessMessageGenerator = (
     const submittersName = `by ${submittedBy}`;
     return `${reportType} report for ${name} ${submittedDate} ${submittersName}.`;
   }
-  return `MCPAR report for ${name} was submitted.`;
+  return `${reportType} report for ${name} was submitted.`;
 };
 
 export const SuccessMessage = ({

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -68,7 +68,8 @@ export const McparReviewSubmitPage = () => {
     <Flex sx={sx.pageContainer} data-testid="review-submit-page">
       {report?.status === ReportStatus.SUBMITTED ? (
         <SuccessMessage
-          programName={report.programName}
+          reportType={report.reportType}
+          name={report.programName ?? report.submissionName}
           date={report?.submittedOnDate}
           submittedBy={report?.submittedBy}
           reviewVerbiage={reviewVerbiage}
@@ -165,7 +166,8 @@ interface ReadyToSubmitProps {
 }
 
 export const SuccessMessageGenerator = (
-  programName: string,
+  reportType: string,
+  name: string,
   submissionDate?: number,
   submittedBy?: string
 ) => {
@@ -173,13 +175,14 @@ export const SuccessMessageGenerator = (
     const readableDate = utcDateToReadableDate(submissionDate, "full");
     const submittedDate = `was submitted on ${readableDate}`;
     const submittersName = `by ${submittedBy}`;
-    return `MCPAR report for ${programName} ${submittedDate} ${submittersName}.`;
+    return `${reportType} report for ${name} ${submittedDate} ${submittersName}.`;
   }
-  return `MCPAR report for ${programName} was submitted.`;
+  return `MCPAR report for ${name} was submitted.`;
 };
 
 export const SuccessMessage = ({
-  programName,
+  reportType,
+  name,
   date,
   submittedBy,
   reviewVerbiage,
@@ -187,7 +190,8 @@ export const SuccessMessage = ({
   const { submitted } = reviewVerbiage;
   const { intro } = submitted;
   const submissionMessage = SuccessMessageGenerator(
-    programName,
+    reportType,
+    name,
     date,
     submittedBy
   );
@@ -221,7 +225,8 @@ export const SuccessMessage = ({
 };
 
 interface SuccessMessageProps {
-  programName: string;
+  reportType: string;
+  name: string;
   date?: number;
   submittedBy?: string;
   reviewVerbiage: AnyObject;

--- a/services/ui-src/src/forms/mlr/mlr.json
+++ b/services/ui-src/src/forms/mlr/mlr.json
@@ -99,7 +99,6 @@
                             "parentFieldName": "versionControl"
                           },
                           "props": {
-                            "disabled": false,
                             "label": "H. Version control description",
                             "hint": "Select the response(s) that best describes the changes between this version and the prior version of the annual summary MLR Report submission.",
                             "choices": [

--- a/tests/cypress/tests/e2e/mlr/release.feature
+++ b/tests/cypress/tests/e2e/mlr/release.feature
@@ -5,7 +5,8 @@ Feature: MLR E2E Form Submission
         When I create, fill, and submit a report
         Then the report is submitted successfully
         Given I am logged in as an admin user
-        When I release a report
+        Then I release a report
+        Given I am logged in as a state user
         Then the report will have the correct content pre-filled
 
     Scenario: A report cannot be released if it is archived.

--- a/tests/cypress/tests/e2e/mlr/release.stepdef.js
+++ b/tests/cypress/tests/e2e/mlr/release.stepdef.js
@@ -94,6 +94,7 @@ Then("I cannot release that archived report", () => {
 });
 
 Then("the report will have the correct content pre-filled", () => {
+  cy.visit("/mlr");
   cy.findByText(programName)
     .last()
     .parent()


### PR DESCRIPTION
## Summary
A collection of small MLR bugfixes

### Description
Addresses issues:
* Admins should not be able to edit Question H.
* The banner should show the submission name for MLR reports.
* `ReviewSubmit` page success message should not show MCPAR related verbiage.

### Related ticket
#11129 

### How to test
1. Create a new MLR submission. Verify that you can see the submission name in the banner.
2. Complete that submission. Verify that the submit page doesn't say "MCPAR report".
3. Log in as an admin user and verify you cannot edit the report.
4. Release the new report.
5. Verify that you still can't edit that report.
6. Verify that this report is editable by a state user.

### Important updates
<!-- Any changed dependencies, .env files, local configs, etc. and
instructions for other engineers, e.g. requires new installs in directories -->

### Author checklist
<!-- Complete the following before marking ready for review -->
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated the documentation, if necessary
