### PR TITLE
added drawer reminder text

### DIFF
--- a/services/ui-src/src/components/drawers/Drawer.test.tsx
+++ b/services/ui-src/src/components/drawers/Drawer.test.tsx
@@ -17,6 +17,7 @@ const mockVerbiage = {
   drawerTitle: "mock title",
   drawerEyebrowTitle: "mock eyebrow title",
   drawerInfo: [{ type: "heading", content: "mock heading" }],
+  drawerReminder: "mock reminder",
 };
 
 const drawerComponent = (

--- a/services/ui-src/src/components/drawers/Drawer.tsx
+++ b/services/ui-src/src/components/drawers/Drawer.tsx
@@ -47,6 +47,7 @@ export const Drawer = ({
               {parseCustomHtml(verbiage.drawerInfo)}
             </Box>
           )}
+          <Text sx={sx.drawerReminderText}>{verbiage.drawerReminder}</Text>
           {verbiage.drawerDetails && entityType && (
             <ReportDrawerDetails
               drawerDetails={verbiage.drawerDetails}
@@ -74,6 +75,7 @@ interface Props {
     drawerTitle: string;
     drawerInfo?: CustomHtmlElement[];
     drawerDetails?: AnyObject;
+    drawerReminder?: string;
   };
   drawerDisclosure: {
     isOpen: boolean;
@@ -105,6 +107,12 @@ const sx = {
     paddingRight: "4rem",
     fontSize: "2xl",
     fontWeight: "bold",
+  },
+  drawerReminderText: {
+    marginTop: ".5rem",
+    paddingRight: "4rem",
+    fontSize: "md",
+    fontWeight: "normal",
   },
   drawerCloseButton: {
     position: "absolute",

--- a/services/ui-src/src/components/drawers/ReportDrawer.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawer.tsx
@@ -81,6 +81,7 @@ interface Props {
     drawerInfo?: CustomHtmlElement[];
     drawerDetails?: AnyObject;
     drawerNoFormMessage?: string;
+    drawerReminder?: string;
   };
   form: FormJson;
   onSubmit: Function;

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -130,6 +130,7 @@ export const DrawerReportPage = ({ route }: Props) => {
         verbiage={{
           drawerTitle: `${verbiage.drawerTitle} ${selectedEntity?.name}`,
           drawerInfo: verbiage.drawerInfo,
+          drawerReminder: verbiage.drawerReminder,
         }}
         form={drawerForm}
         onSubmit={onSubmit}

--- a/services/ui-src/src/forms/mcpar/mcpar.json
+++ b/services/ui-src/src/forms/mcpar/mcpar.json
@@ -1464,6 +1464,7 @@
             },
             "dashboardTitle": "Report program characteristics & enrollment for each plan",
             "drawerTitle": "Report program characteristics & enrollment for",
+            "drawerReminder": "Complete all fields and select the Save & close button to save this section.",
             "missingEntityMessage": [
               {
                 "type": "span",
@@ -1527,6 +1528,7 @@
             },
             "dashboardTitle": "Report financial performance for each plan",
             "drawerTitle": "Report financial performance for",
+            "drawerReminder": "Complete all fields and select the Save & close button to save this section.",
             "missingEntityMessage": [
               {
                 "type": "span",
@@ -1669,6 +1671,7 @@
             },
             "dashboardTitle": "Report on encounter data for each plan",
             "drawerTitle": "Report encounter data for",
+            "drawerReminder": "Complete all fields and select the Save & close button to save this section.",
             "missingEntityMessage": [
               {
                 "type": "span",
@@ -1742,6 +1745,7 @@
                 },
                 "dashboardTitle": "Report on appeals for each plan",
                 "drawerTitle": "Report on appeals for",
+                "drawerReminder": "Complete all fields and select the Save & close button to save this section.",
                 "missingEntityMessage": [
                   {
                     "type": "span",
@@ -1916,6 +1920,7 @@
                 },
                 "dashboardTitle": "Report on appeals by service for each plan",
                 "drawerTitle": "Report appeals by service for",
+                "drawerReminder": "Complete all fields and select the Save & close button to save this section.",
                 "missingEntityMessage": [
                   {
                     "type": "span",
@@ -2056,6 +2061,7 @@
                 },
                 "dashboardTitle": "Report state fair hearings and external medical reviews for each plan",
                 "drawerTitle": "Report state fair hearings and external medical reviews for",
+                "drawerReminder": "Complete all fields and select the Save & close button to save this section.",
                 "missingEntityMessage": [
                   {
                     "type": "span",
@@ -2156,6 +2162,7 @@
                 },
                 "dashboardTitle": "Report on grievances for each plan",
                 "drawerTitle": "Report on grievances for",
+                "drawerReminder": "Complete all fields and select the Save & close button to save this section.",
                 "missingEntityMessage": [
                   {
                     "type": "span",
@@ -2250,6 +2257,7 @@
                 },
                 "dashboardTitle": "Report on grievances by service for each plan",
                 "drawerTitle": "Report encounter data for",
+                "drawerReminder": "Complete all fields and select the Save & close button to save this section.",
                 "missingEntityMessage": [
                   {
                     "type": "span",
@@ -2394,6 +2402,7 @@
                 },
                 "dashboardTitle": "Report on grievances by reason for each plan",
                 "drawerTitle": "Report on grievances by reason for",
+                "drawerReminder": "Complete all fields and select the Save & close button to save this section.",
                 "drawerInfo": [
                   {
                     "type": "p",
@@ -3053,6 +3062,7 @@
             },
             "dashboardTitle": "Report on program integrity for each plan",
             "drawerTitle": "Program integrity for",
+            "drawerReminder": "Complete all fields and select the Save & close button to save this section.",
             "missingEntityMessage": [
               {
                 "type": "span",
@@ -3280,6 +3290,7 @@
         },
         "dashboardTitle": "Report on role and type for each BSS entity",
         "drawerTitle": "Report on",
+        "drawerReminder": "Complete all fields and select the Save & close button to save this section.",
         "missingEntityMessage": [
           {
             "type": "span",

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -112,6 +112,7 @@ export interface DrawerReportPageVerbiage extends ReportPageVerbiage {
   countEntitiesInTitle?: boolean;
   drawerTitle: string;
   drawerInfo?: CustomHtmlElement[];
+  drawerReminder?: string;
   missingEntityMessage?: CustomHtmlElement[];
 }
 

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -319,6 +319,7 @@ export const mockDrawerReportPageJson = {
     intro: mockVerbiageIntro,
     dashboardTitle: "Mock dashboard title",
     drawerTitle: "Mock drawer title",
+    drawerReminder: "Mock drawer reminder",
   },
   drawerForm: mockDrawerForm,
 };


### PR DESCRIPTION
## Summary

### Description
On behalf of @ailZhao 
<!-- Detailed description of changes and related context -->
Added new drawer reminder verbiage to show up in all instance of drawer components in MCPAR.

### Related ticket
<!-- Link to related ticket or issue -->
https://qmacbis.atlassian.net/browse/MDCT-2109?atlOrigin=eyJpIjoiMmRlMWM5ZDYyMjY3NDcyMjlkMTE3MDRhNDdjMDdmNDYiLCJwIjoiaiJ9

### How to test
<!-- Step-by-step instructions on how to test -->
1. Login to MDCT, account type should not matter.
2. Enter MCPAR online
3. Select any Care Report
4. Click Program Integrity and select a report
5. The new text should be displayed underneath the drawer title

### Important updates
<!-- Any changed dependencies, .env files, local configs, etc. and
instructions for other engineers, e.g. requires new installs in directories -->

### Author checklist
<!-- Complete the following before marking ready for review -->
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated the documentation, if necessary
