### PR TITLE
MLR Design Feedback

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -3,7 +3,7 @@ import { Button, Image, Td, Tr } from "@chakra-ui/react";
 import { Spinner } from "@cmsgov/design-system";
 import { Table } from "components";
 // utils
-import { AnyObject, ReportMetadataShape } from "types";
+import { AnyObject, ReportMetadataShape, TableContentShape } from "types";
 import { convertDateUtcToEt } from "utils";
 // assets
 import editIcon from "assets/icons/icon_edit_square_gray.png";
@@ -23,7 +23,11 @@ export const DashboardTable = ({
   isStateLevelUser,
   isAdmin,
 }: DashboardTableProps) => (
-  <Table content={body.table} data-testid="desktop-table" sx={sx.table}>
+  <Table
+    content={tableBody(body.table, isAdmin)}
+    data-testid="desktop-table"
+    sx={sx.table}
+  >
     {reportsByState.map((report: ReportMetadataShape) => (
       <Tr key={report.id}>
         {/* Edit Button */}
@@ -47,7 +51,7 @@ export const DashboardTable = ({
         {/* Report Status */}
         <Td>{report?.archived ? "Archived" : report?.status}</Td>
         {/* MLR-ONLY: Submission count */}
-        {reportType === "MLR" && (
+        {reportType === "MLR" && isAdmin && (
           <Td> {report.submissionCount === 0 ? 1 : report.submissionCount} </Td>
         )}
         {/* Action Buttons */}
@@ -105,6 +109,15 @@ interface DashboardTableProps {
   releasing?: boolean | undefined;
   sxOverride: AnyObject;
 }
+
+const tableBody = (body: TableContentShape, isAdmin: boolean) => {
+  var tableContent = body;
+  if (!isAdmin) {
+    tableContent.headRow = tableContent.headRow!.filter((e) => e !== "#");
+    return tableContent;
+  }
+  return body;
+};
 
 const EditReportButton = ({
   report,

--- a/services/ui-src/src/verbiage/pages/mlr/mlr-accordions.ts
+++ b/services/ui-src/src/verbiage/pages/mlr/mlr-accordions.ts
@@ -1,6 +1,6 @@
 export default {
   formIntro: {
-    buttonLabel: "Introduction",
+    buttonLabel: "Instructions",
     intro:
       'States must provide summary MLR report data at the plan level. The summary reports are based on the plans\' annual MLR reports tot he state under <a href="https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)">42 CFR 438.8(k)</a>. States have the option of reporting these data for eac plan by program, statewide, or at another level of aggregation (e.g., eligibility groups). Program is defined by a specified set of benefits and elegibility criteria that are articulated in a contract between the state and managed care plans. <b>MLR data should not be aggregated across multiple plans or across multiple programs; however there is an exception if a managed care plan has more than one contract with the state — the state can report results for each contract separately or combine results for each plan.</b> If a state combines the reporting for plans with multiple contracts, the report must use a consistent MLR reporting year.',
     list: [


### PR DESCRIPTION
## Summary

### Description

Based on feedback from design, we are:
- Changing `Introduction` to `Instructions` on the MLR reporting 
- Only showing the number of submissions `#` column on the MLR dashboard for admins

### Related ticket

N/A

### How to test

- Log in as a state user
- Navigate to `/mlr`
- You shouldn't be able to see a `#` column

And the opposite for an admin

### Important updates

N/A

### Author checklist
<!-- Complete the following before marking ready for review -->
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated the documentation, if necessary
