### PR TITLE
Add in Quality Measure Name to detail drawer

### DIFF
--- a/services/ui-src/src/components/drawers/ReportDrawerDetails.test.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawerDetails.test.tsx
@@ -31,6 +31,7 @@ const ReportDrawerDetailsSanctionsComponent = (
 
 const mockQualityMeasuresDrawerDetails = {
   domain: "mock domain",
+  name: "mock quality measure name",
   nqfNumber: "mock nqf number",
   reportingRateType: "mock reporting rate type",
   set: "mock measure set",
@@ -68,6 +69,9 @@ describe("Test ReportDrawerDetails renders given text", () => {
     render(ReportDrawerDetailsQualityMeasuresComponent);
     expect(
       screen.getByText(mockQualityMeasuresDrawerDetails.domain)
+    ).toBeVisible();
+    expect(
+      screen.getByText(mockQualityMeasuresDrawerDetails.name)
     ).toBeVisible();
   });
 });

--- a/services/ui-src/src/components/drawers/ReportDrawerDetails.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawerDetails.tsx
@@ -44,6 +44,7 @@ export const ReportDrawerDetails = ({ entityType, drawerDetails }: Props) => {
     case ModalDrawerEntityTypes.QUALITY_MEASURES:
       return (
         <Box sx={sx.detailBox}>
+          <Text sx={sx.detailHeader}>{drawerDetails.name}</Text>
           <Text sx={sx.detailSubtitle}>Measure Domain</Text>
           <Text sx={sx.detailSubtext}>{drawerDetails.domain}</Text>
           <Grid sx={sx.grid}>


### PR DESCRIPTION
## Summary

### Description
Kim noticed the that Quality Measures doesn't show the name of the measure in the drawer. Lets fix that up!

### Related ticket
<!-- Link to related ticket or issue -->

### How to test
Create a MCPAR report
Go to Quality Measures
Create a Measure
Open the drawer
See the name of the measure at the top!

It should look like [this figma](https://www.figma.com/file/GBktI8ZIJM9YYcdNva0ltg/MDCT---MCR?node-id=4708-252110&t=vG1ECRgtHfdGYlVF-0)
### Important updates
<!-- Any changed dependencies, .env files, local configs, etc. and
instructions for other engineers, e.g. requires new installs in directories -->

### Author checklist
<!-- Complete the following before marking ready for review -->
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated the documentation, if necessary
