### PR TITLE
Make ReviewSubmit error status update more frequently when page hopping

### DIFF
--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -55,12 +55,14 @@ export const ReviewSubmitPage = () => {
   const { alertBox } = reviewVerbiage;
 
   useEffect(() => {
-    setHasError(!!document.querySelector("img[alt='Error notification']"));
-
     if (report?.id) {
       fetchReport(reportKeys);
     }
   }, []);
+
+  useEffect(() => {
+    setHasError(!!document.querySelector("img[alt='Error notification']"));
+  }, [fetchReport]);
 
   const submitForm = async () => {
     setSubmitting(true);


### PR DESCRIPTION
## Summary

### Description
The error message on the review submit page doesn't update if you race it by updating a field and then immediately navigating to the review and submit page. This makes it so the page always updates!

### How to test
<!-- Step-by-step instructions on how to test -->
Create a full filled out report
Go to Review Submit and see now error message at the top
Go to the first page on MCPAR
empty out a field, tab away, and immediately hit the review submit page in the side bar
See the error message pop in
Go back to the first page
Fill in the emptied field and then click the review submit page in the sidebar
Watch the error message disappear correctly!


### Important updates
<!-- Any changed dependencies, .env files, local configs, etc. and
instructions for other engineers, e.g. requires new installs in directories -->

### Author checklist
<!-- Complete the following before marking ready for review -->
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated the documentation, if necessary
