### PR TITLE
Retain target attribute when sanitizing html

### DIFF
--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { sanitize } from "dompurify";
+import { addHook, sanitize } from "dompurify";
 import parse from "html-react-parser";
 // components
 import { Link as RouterLink } from "react-router-dom";
@@ -46,6 +46,11 @@ export const parseCustomHtml = (element: CustomHtmlElement[] | string) => {
 
 // sanitize and parse html to react elements
 export const sanitizeAndParseHtml = (html: string) => {
+  addHook("afterSanitizeAttributes", (node) => {
+    if ("target" in node) {
+      node.setAttribute("target", "_blank");
+    }
+  });
   const sanitizedHtml = sanitize(html);
   const parsedHtml = parse(sanitizedHtml);
   return parsedHtml;


### PR DESCRIPTION
## Summary
Super small PR, modifies the verbiage sanitization to allow `target` attributes to pass. This forces all links in forms to open in a new tab.

### How to test
1. Create new MLR form
2. Click on any link in a form field (Add/Edit submission field has one)
3. Verify that it opens in a new window

### Important updates
<!-- Any changed dependencies, .env files, local configs, etc. and
instructions for other engineers, e.g. requires new installs in directories -->

### Author checklist
<!-- Complete the following before marking ready for review -->
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated the documentation, if necessary
