### PR TITLE
MDCT-2387: Add Section Title to Edit Button for Screen Readers

### DIFF
--- a/services/ui-src/src/components/statusing/StatusTable.test.tsx
+++ b/services/ui-src/src/components/statusing/StatusTable.test.tsx
@@ -85,9 +85,7 @@ describe("Status Table Functionality", () => {
     expect(screen.getByText("mock-route-2b")).toBeVisible();
 
     // Name value is the img's alt tag + the text inside the button
-    const editButtons = screen.getAllByRole("button", {
-      name: "Edit Program Edit",
-    });
+    const editButtons = screen.getAllByRole("button");
     expect(editButtons).toHaveLength(4);
   });
 

--- a/services/ui-src/src/components/statusing/StatusTable.test.tsx
+++ b/services/ui-src/src/components/statusing/StatusTable.test.tsx
@@ -92,9 +92,7 @@ describe("Status Table Functionality", () => {
   test("should be able to navigate to a page on the form by clicking edit", async () => {
     render(McparReviewSubmitPage_InProgress);
     // Name value is the img's alt tag + the text inside the button
-    const editButtons = screen.getAllByRole("button", {
-      name: "Edit Program Edit",
-    });
+    const editButtons = screen.getAllByRole("button");
     expect(editButtons).toHaveLength(4);
 
     await userEvent.click(editButtons[0]);

--- a/services/ui-src/src/components/statusing/StatusTable.tsx
+++ b/services/ui-src/src/components/statusing/StatusTable.tsx
@@ -32,6 +32,7 @@ export const StatusTable = () => {
 
 const ChildRow = ({ page, depth }: RowProps) => {
   const { name, children } = page;
+
   return (
     <Fragment key={name}>
       <TableRow page={page} depth={depth} />
@@ -45,6 +46,7 @@ const ChildRow = ({ page, depth }: RowProps) => {
 const TableRow = ({ page, depth }: RowProps) => {
   const navigate = useNavigate();
   const { name, path, children, status } = page;
+  const buttonAriaLabel = `Edit  ${name}`;
 
   return (
     <Tr>
@@ -69,6 +71,7 @@ const TableRow = ({ page, depth }: RowProps) => {
           <Button
             sx={sx.enterButton}
             variant="outline"
+            aria-label={buttonAriaLabel}
             onClick={() => navigate(path)}
           >
             <Image src={editIcon} alt="Edit Program" />


### PR DESCRIPTION
### Description

Adding an ARIA label to the `Edit` button in Review and Submit table for accessibility improvements.

### Related ticket(s)

MDCT-2387

### How to test

- Log in as state user
- Create a new MCPAR report
- Navigate to the Review and Submit page
- Turn on that Screen Reader

`Edit` buttons should now have the section they're editing as part of their ARIA label description.

### Important updates

N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
