### PR TITLE
Add Return Home Link to Get Started Page

### DIFF
--- a/services/ui-src/src/components/pages/GetStarted/ReportGetStartedPage.tsx
+++ b/services/ui-src/src/components/pages/GetStarted/ReportGetStartedPage.tsx
@@ -1,16 +1,25 @@
 // components
-import { Box, Button, Image, Heading, Text, Flex } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  Link,
+  Image,
+  Heading,
+  Text,
+  Flex,
+} from "@chakra-ui/react";
 import {
   Table,
   InfoSection,
   PageTemplate,
   SpreadsheetWidget,
 } from "components";
-import { useNavigate } from "react-router-dom";
+import { Link as RouterLink, useNavigate } from "react-router-dom";
 // verbiage
 import mcparVerbiage from "verbiage/pages/mcpar/mcpar-get-started";
 import mlrVerbiage from "verbiage/pages/mlr/mlr-get-started";
 // assets
+import arrowLeftIcon from "assets/icons/icon_arrow_left_blue.png";
 import nextIcon from "assets/icons/icon_next_white.png";
 import NavigationSectionsImage from "assets/other/nav_sections.png";
 import NavigationSectionsSubmissionImage from "assets/other/nav_sections_review_submit.png";
@@ -29,89 +38,95 @@ export const ReportGetStartedPage = ({ reportType }: Props) => {
   const [section1, section2, section3] = body.sections;
 
   return (
-    <PageTemplate sx={sx.layout}>
-      <Box sx={sx.leadTextBox}>
-        <Heading as="h1" sx={sx.headerText}>
-          {intro.header}
-        </Heading>
-      </Box>
-      <div>
-        <InfoSection content={section1}>
-          <Flex sx={sx.sectionContent}>
-            <Box sx={sx.widgetContainer}>
-              <Text sx={sx.widgetTitle}>{section1.widget?.title}</Text>
-              <Box>
-                {section1.widget?.descriptionList.map(
-                  (description: string, index: number) => (
-                    <Text key={index}>{description}</Text>
-                  )
-                )}
-              </Box>
-            </Box>
-          </Flex>
-        </InfoSection>
-        <InfoSection content={section2}>
-          <Flex sx={sx.sectionContent}>
-            <Box>
-              <Image
-                src={NavigationSectionsImage}
-                alt={section2.img?.alt}
-                sx={sx.image}
-              />
-              <Text sx={sx.additionalInfo}>{section2.img?.description}</Text>
-            </Box>
-            <Box>
-              <SpreadsheetWidget description={section2.spreadsheet!} />
-              <Text sx={sx.additionalInfo}>{section2.additionalInfo}</Text>
-            </Box>
-          </Flex>
-          {section2.table && (
+    <Box>
+      <Link as={RouterLink} to="/" sx={sx.returnLink}>
+        <Image src={arrowLeftIcon} alt="Arrow left" className="returnIcon" />
+        Return Home
+      </Link>
+      <PageTemplate sx={sx.layout}>
+        <Box sx={sx.leadTextBox}>
+          <Heading as="h1" sx={sx.headerText}>
+            {intro.header}
+          </Heading>
+        </Box>
+        <div>
+          <InfoSection content={section1}>
             <Flex sx={sx.sectionContent}>
-              <Box>
-                <Heading sx={sx.smallSectionHeading} size={"sm"}>
-                  {section2.tableHeading}
-                </Heading>
-                <Table
-                  border={true}
-                  sxOverride={sx.tableHeader}
-                  content={section2.table}
-                ></Table>
+              <Box sx={sx.widgetContainer}>
+                <Text sx={sx.widgetTitle}>{section1.widget?.title}</Text>
+                <Box>
+                  {section1.widget?.descriptionList.map(
+                    (description: string, index: number) => (
+                      <Text key={index}>{description}</Text>
+                    )
+                  )}
+                </Box>
               </Box>
             </Flex>
-          )}
-          {section2.autosaveNotice && section2.autosaveHeading && (
+          </InfoSection>
+          <InfoSection content={section2}>
             <Flex sx={sx.sectionContent}>
               <Box>
-                <Heading sx={sx.smallSectionHeading} size={"sm"}>
-                  {section2.autosaveHeading}
-                </Heading>
-                <Text>{section2.autosaveNotice}</Text>
+                <Image
+                  src={NavigationSectionsImage}
+                  alt={section2.img?.alt}
+                  sx={sx.image}
+                />
+                <Text sx={sx.additionalInfo}>{section2.img?.description}</Text>
+              </Box>
+              <Box>
+                <SpreadsheetWidget description={section2.spreadsheet!} />
+                <Text sx={sx.additionalInfo}>{section2.additionalInfo}</Text>
               </Box>
             </Flex>
-          )}
-        </InfoSection>
-        <InfoSection content={section3}>
-          <Flex sx={sx.sectionContent}>
-            <Box>
-              <Image
-                src={NavigationSectionsSubmissionImage}
-                alt={section3.img?.alt}
-                sx={sx.image}
-              />
-            </Box>
-          </Flex>
-        </InfoSection>
-      </div>
-      <Box sx={sx.pageLinkContainer}>
-        <Button
-          sx={sx.pageLink}
-          onClick={() => navigate(pageLink.route)}
-          rightIcon={<Image src={nextIcon} alt="Link Icon" height="1rem" />}
-        >
-          {pageLink.text}
-        </Button>
-      </Box>
-    </PageTemplate>
+            {section2.table && (
+              <Flex sx={sx.sectionContent}>
+                <Box>
+                  <Heading sx={sx.smallSectionHeading} size={"sm"}>
+                    {section2.tableHeading}
+                  </Heading>
+                  <Table
+                    border={true}
+                    sxOverride={sx.tableHeader}
+                    content={section2.table}
+                  ></Table>
+                </Box>
+              </Flex>
+            )}
+            {section2.autosaveNotice && section2.autosaveHeading && (
+              <Flex sx={sx.sectionContent}>
+                <Box>
+                  <Heading sx={sx.smallSectionHeading} size={"sm"}>
+                    {section2.autosaveHeading}
+                  </Heading>
+                  <Text>{section2.autosaveNotice}</Text>
+                </Box>
+              </Flex>
+            )}
+          </InfoSection>
+          <InfoSection content={section3}>
+            <Flex sx={sx.sectionContent}>
+              <Box>
+                <Image
+                  src={NavigationSectionsSubmissionImage}
+                  alt={section3.img?.alt}
+                  sx={sx.image}
+                />
+              </Box>
+            </Flex>
+          </InfoSection>
+        </div>
+        <Box sx={sx.pageLinkContainer}>
+          <Button
+            sx={sx.pageLink}
+            onClick={() => navigate(pageLink.route)}
+            rightIcon={<Image src={nextIcon} alt="Link Icon" height="1rem" />}
+          >
+            {pageLink.text}
+          </Button>
+        </Box>
+      </PageTemplate>
+    </Box>
   );
 };
 
@@ -123,6 +138,27 @@ const sx = {
   layout: {
     ".contentFlex": {
       marginTop: "3.5rem",
+    },
+  },
+  returnLink: {
+    display: "flex",
+    width: "8.5rem",
+    marginTop: "1.5rem",
+    svg: {
+      height: "1.375rem",
+      width: "1.375rem",
+      marginTop: "-0.125rem",
+      marginRight: ".5rem",
+    },
+    textDecoration: "none",
+    _hover: {
+      textDecoration: "underline",
+    },
+    ".returnIcon": {
+      width: "1.25rem",
+      height: "1.25rem",
+      marginTop: "0.25rem",
+      marginRight: "0.5rem",
     },
   },
   leadTextBox: {


### PR DESCRIPTION
### Description

Added a `Return Home` link to the report get started page, matching the report dashboard.

### Related ticket(s)

N/A

---
### How to test

- Log in as a state user
- Click on `Enter MCPAR`

There should be a **Return Home** button on the top-left corner. On click, it should take you back to the MCR landing page.

### Important updates

N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
