### PR TITLE
allow default browser print header/footer to show during pdf printing

### DIFF
--- a/services/ui-src/src/styles/index.scss
+++ b/services/ui-src/src/styles/index.scss
@@ -133,12 +133,3 @@ button {
     @include tabbed-focus;
   }
 }
-
-@media print {  
-  @page {
-    margin: 0px;  //this will hide the print header & footer.
-  } 
-  html {
-      margin: 30px; //this adds back missing margin for the print page
-  }
-}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
We previously removed the default browser print header/footer in #11181. However, after further review, product/design have requested that they be added back in because of some other issues they are concerned about. 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2292

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Create a pdf on `/mcpar/export` and print out. It should have browser header/footer and no text should be clipped.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
