### PR TITLE
MLR export page 1

### DIFF
--- a/services/ui-src/src/components/export/ExportedReportFieldRow.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldRow.test.tsx
@@ -54,6 +54,20 @@ const dynamicRow = (
   </ReportContext.Provider>
 );
 
+const noHintRow = (
+  <ReportContext.Provider value={mockMcparReportContext}>
+    <Table sx={{}}>
+      <tbody>
+        <ExportedReportFieldRow
+          formField={field}
+          pageType="drawer"
+          showHintText={false}
+        />
+      </tbody>
+    </Table>
+  </ReportContext.Provider>
+);
+
 describe("ExportedReportFieldRow", () => {
   test("Is present", async () => {
     render(exportRow);
@@ -71,6 +85,18 @@ describe("ExportedReportFieldRow", () => {
     render(dynamicRow);
     const row = screen.getByTestId("exportRow");
     expect(row).toBeVisible();
+  });
+
+  test("displays hint text by default", async () => {
+    render(exportRow);
+    const hint = screen.getByText("hint");
+    expect(hint).toBeVisible();
+  });
+
+  test("hides hint text when appropriate", async () => {
+    render(noHintRow);
+    const hint = screen.queryByText(/hint/);
+    expect(hint).not.toBeInTheDocument();
   });
 });
 

--- a/services/ui-src/src/components/export/ExportedReportFieldRow.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldRow.test.tsx
@@ -26,7 +26,7 @@ const fieldWithLabel = {
 
 const exportRow = (
   <ReportContext.Provider value={mockMcparReportContext}>
-    <Table sx={{}}>
+    <Table>
       <tbody>
         <ExportedReportFieldRow formField={field} pageType="drawer" />
       </tbody>
@@ -36,7 +36,7 @@ const exportRow = (
 
 const otherTextRow = (
   <ReportContext.Provider value={mockMcparReportContext}>
-    <Table sx={{}}>
+    <Table>
       <tbody>
         <ExportedReportFieldRow formField={otherTextField} pageType="drawer" />
       </tbody>
@@ -46,7 +46,7 @@ const otherTextRow = (
 
 const dynamicRow = (
   <ReportContext.Provider value={mockMcparReportContext}>
-    <Table sx={{}}>
+    <Table>
       <tbody>
         <ExportedReportFieldRow formField={fieldWithLabel} pageType="drawer" />
       </tbody>
@@ -56,7 +56,7 @@ const dynamicRow = (
 
 const noHintRow = (
   <ReportContext.Provider value={mockMcparReportContext}>
-    <Table sx={{}}>
+    <Table>
       <tbody>
         <ExportedReportFieldRow
           formField={field}

--- a/services/ui-src/src/components/export/ExportedReportFieldRow.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldRow.tsx
@@ -12,6 +12,7 @@ export const ExportedReportFieldRow = ({
   pageType,
   entityType,
   parentFieldCheckedChoiceIds,
+  showHintText = true,
 }: Props) => {
   const { report } = useContext(ReportContext);
   const reportData = report?.fieldData;
@@ -42,7 +43,7 @@ export const ExportedReportFieldRow = ({
                   : formField?.props?.label}
               </Text>
             )}
-            {formFieldInfo.hint && (
+            {showHintText && formFieldInfo.hint && (
               <Box sx={sx.fieldHint}>{parseCustomHtml(formFieldInfo.hint)}</Box>
             )}
           </Box>
@@ -72,6 +73,7 @@ export interface Props {
   pageType: string;
   entityType?: string;
   parentFieldCheckedChoiceIds?: string[];
+  showHintText?: boolean;
 }
 
 const sx = {

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.test.tsx
@@ -9,7 +9,11 @@ import {
 } from "utils/testing/setupJest";
 import { ReportContext } from "components";
 import { ExportedReportFieldTable } from "./ExportedReportFieldTable";
-import { DrawerReportPageShape } from "types";
+import {
+  DrawerReportPageShape,
+  ReportContextShape,
+  StandardReportPageShape,
+} from "types";
 
 // Contexts
 const reportJsonFields = [{ ...mockNestedFormField, id: "parent" }];
@@ -22,12 +26,14 @@ const nestedParent = mockNestedFormField;
 nestedParent.props.choices[2].children = [{ ...mockFormField, id: "child" }];
 
 const mockStandardContext = { ...mockMcparReportContext };
+mockStandardContext.report = { ...mockStandardContext.report };
 mockStandardContext.report.fieldData = {
   ...mockStandardContext.report.fieldData,
   ...fieldData,
 };
 
 const mockDrawerContext = { ...mockMcparReportContext };
+mockMcparReportContext.report = { ...mockMcparReportContext.report };
 mockDrawerContext.report.fieldData = {
   ...mockDrawerContext.report.fieldData,
   plans: [
@@ -77,6 +83,61 @@ const emptyTableComponent = (
     <ExportedReportFieldTable section={mockEmptyPageJson} />
   </ReportContext.Provider>
 );
+
+const noHintContext = {
+  report: {
+    reportType: "MLR",
+  },
+} as ReportContextShape;
+
+const noHintSection = {
+  form: {
+    id: "apoc",
+    fields: [
+      {
+        id: "mockFieldId",
+        props: {
+          label: "X. Mock Field label",
+          hint: "Mock Hint Text",
+        },
+      },
+    ],
+  },
+} as unknown as StandardReportPageShape;
+
+const noHintComponent = (
+  <ReportContext.Provider value={noHintContext}>
+    <ExportedReportFieldTable section={noHintSection} />
+  </ReportContext.Provider>
+);
+
+const hintContext = {
+  report: {
+    reportType: "MLR",
+  },
+} as ReportContextShape;
+
+const hintSection = {
+  form: {
+    id: "not-apoc",
+    fields: [
+      {
+        id: "mockFieldId",
+        props: {
+          label: "X. Mock Field label",
+          hint: "Mock Hint Text",
+        },
+      },
+    ],
+  },
+} as unknown as StandardReportPageShape;
+
+const hintComponent = (
+  <ReportContext.Provider value={hintContext}>
+    <ExportedReportFieldTable section={hintSection} />
+  </ReportContext.Provider>
+);
+
 describe("ExportedReportFieldRow", () => {
   test("Is present", async () => {
     render(exportedStandardTableComponent);
@@ -94,6 +155,18 @@ describe("ExportedReportFieldRow", () => {
     render(emptyTableComponent);
     const row = screen.getByTestId("exportTable");
     expect(row).toBeVisible();
+  });
+
+  test("shows the hint text in most cases", async () => {
+    render(hintComponent);
+    const hint = screen.queryByText(/Mock Hint Text/);
+    expect(hint).toBeVisible();
+  });
+
+  test("hides the hint text within the Primary Contact section of MLR", async () => {
+    render(noHintComponent);
+    const hint = screen.queryByText(/Mock Hint Text/);
+    expect(hint).not.toBeInTheDocument();
   });
 });
 

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.test.tsx
@@ -6,14 +6,11 @@ import {
   mockNestedFormField,
   mockMcparReportContext,
   mockStandardReportPageJson,
+  mockMlrReportContext,
 } from "utils/testing/setupJest";
 import { ReportContext } from "components";
 import { ExportedReportFieldTable } from "./ExportedReportFieldTable";
-import {
-  DrawerReportPageShape,
-  ReportContextShape,
-  StandardReportPageShape,
-} from "types";
+import { DrawerReportPageShape } from "types";
 
 // Contexts
 const reportJsonFields = [{ ...mockNestedFormField, id: "parent" }];
@@ -65,6 +62,37 @@ const mockEmptyPageJson = {
     fields: [],
   },
 };
+const noHintJson = {
+  ...mockStandardReportPageJson,
+  form: {
+    id: "apoc",
+    fields: [
+      {
+        ...mockFormField,
+        props: {
+          label: "X. Mock Field label",
+          hint: "Mock Hint Text",
+        },
+      },
+    ],
+  },
+};
+
+const hintJson = {
+  ...mockStandardReportPageJson,
+  form: {
+    id: "not-apoc",
+    fields: [
+      {
+        ...mockFormField,
+        props: {
+          label: "X. Mock Field label",
+          hint: "Mock Hint Text",
+        },
+      },
+    ],
+  },
+};
 
 const exportedStandardTableComponent = (
   <ReportContext.Provider value={mockStandardContext}>
@@ -84,57 +112,15 @@ const emptyTableComponent = (
   </ReportContext.Provider>
 );
 
-const noHintContext = {
-  report: {
-    reportType: "MLR",
-  },
-} as ReportContextShape;
-
-const noHintSection = {
-  form: {
-    id: "apoc",
-    fields: [
-      {
-        id: "mockFieldId",
-        props: {
-          label: "X. Mock Field label",
-          hint: "Mock Hint Text",
-        },
-      },
-    ],
-  },
-} as unknown as StandardReportPageShape;
-
 const noHintComponent = (
-  <ReportContext.Provider value={noHintContext}>
-    <ExportedReportFieldTable section={noHintSection} />
+  <ReportContext.Provider value={mockMlrReportContext}>
+    <ExportedReportFieldTable section={noHintJson} />
   </ReportContext.Provider>
 );
 
-const hintContext = {
-  report: {
-    reportType: "MLR",
-  },
-} as ReportContextShape;
-
-const hintSection = {
-  form: {
-    id: "not-apoc",
-    fields: [
-      {
-        id: "mockFieldId",
-        props: {
-          label: "X. Mock Field label",
-          hint: "Mock Hint Text",
-        },
-      },
-    ],
-  },
-} as unknown as StandardReportPageShape;
-
 const hintComponent = (
-  <ReportContext.Provider value={hintContext}>
-    <ExportedReportFieldTable section={hintSection} />
+  <ReportContext.Provider value={mockMlrReportContext}>
+    <ExportedReportFieldTable section={hintJson} />
   </ReportContext.Provider>
 );
 

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
@@ -12,6 +12,7 @@ import {
   ReportShape,
   FormLayoutElement,
   isFieldElement,
+  ReportType,
 } from "types";
 // verbiage
 import verbiage from "verbiage/pages/mcpar/mcpar-export";
@@ -38,6 +39,11 @@ export const ExportedReportFieldTable = ({ section }: Props) => {
     ? twoColumnHeaderItems
     : threeColumnHeaderItems;
 
+  // The hint text is hidden for MLR page 1 (Point of Contact)
+  const reportType = report?.reportType as ReportType;
+  const hideHintText =
+    reportType === ReportType.MLR && section.form?.id === "apoc";
+
   return (
     <Table
       sx={sx.root}
@@ -47,7 +53,13 @@ export const ExportedReportFieldTable = ({ section }: Props) => {
       }}
       data-testid="exportTable"
     >
-      {renderFieldTableBody(formFields!, pageType!, report, entityType)}
+      {renderFieldTableBody(
+        formFields!,
+        pageType!,
+        report,
+        !hideHintText,
+        entityType
+      )}
     </Table>
   );
 };
@@ -56,6 +68,7 @@ export const renderFieldTableBody = (
   formFields: (FormField | FormLayoutElement)[],
   pageType: string,
   report: ReportShape | undefined,
+  showHintText: boolean,
   entityType?: string
 ) => {
   const tableRows: ReactElement[] = [];
@@ -71,6 +84,7 @@ export const renderFieldTableBody = (
         pageType={pageType}
         entityType={entityType}
         parentFieldCheckedChoiceIds={parentFieldCheckedChoiceIds}
+        showHintText={showHintText}
       />
     );
     // for drawer pages, render nested child field if any entity has a checked parent choice
@@ -130,6 +144,7 @@ export const renderFieldTableBody = (
 
 export interface Props {
   section: StandardReportPageShape | DrawerReportPageShape;
+  showHintText?: boolean;
 }
 
 const sx = {

--- a/services/ui-src/src/forms/mlr/mlr.json
+++ b/services/ui-src/src/forms/mlr/mlr.json
@@ -12,9 +12,8 @@
       "verbiage": {
         "intro": {
           "section": "Section A: Program Information",
-          "subsection": "Point of Contact",
-          "spreadsheet": "Program Information",
-          "exportSection": "Information for Primary Contact"
+          "subsection": "Information for Primary Contact",
+          "spreadsheet": "Program Information"
         }
       },
       "form": {


### PR DESCRIPTION
### Description
Complete page 1 of the MLR PDF export. It was already in place and rendering almost how we wanted, thanks to prior work.

The main change here is to hide the question hint text; currently it is shown for all tables in all reports. Now, it is hidden (only) for the Primary Contact Information table of the MLR report.

There is also a small verbiage change.

### Related ticket(s)
MDCT-2309

---
### How to test
Create and fill out an MLR report, then view the PDF preview. You will see no gray explanatory text in the table on the first page. Other tables in the report will still have hint text.

Optionally, view the PDF export for a MCPAR report. It will still have hint text everywhere.

### Important updates
n/a

---
### Author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
