### PR TITLE
MDCT-2343: MLR Dashboard Accordions (State and Admin Users)

### DIFF
--- a/services/ui-src/src/components/accordions/InstructionsAccordion.tsx
+++ b/services/ui-src/src/components/accordions/InstructionsAccordion.tsx
@@ -6,7 +6,7 @@ import { AnyObject } from "types";
 // utils
 import { sanitizeAndParseHtml } from "utils";
 
-export const FormIntroAccordion = ({ verbiage, ...props }: Props) => {
+export const InstructionsAccordion = ({ verbiage, ...props }: Props) => {
   const { buttonLabel, intro, list, text } = verbiage;
   return (
     <Accordion allowToggle={true} allowMultiple={true} sx={sx.root} {...props}>

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -1,7 +1,7 @@
 // accordions
 export { AccordionItem } from "./accordions/AccordionItem";
 export { FaqAccordion } from "./accordions/FaqAccordion";
-export { FormIntroAccordion } from "./accordions/FormIntroAccordion";
+export { InstructionsAccordion } from "./accordions/InstructionsAccordion";
 export { TemplateCardAccordion } from "./accordions/TemplateCardAccordion";
 // alerts
 export { Alert } from "./alerts/Alert";

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -14,7 +14,7 @@ import {
 import {
   AddEditReportModal,
   DashboardTable,
-  FormIntroAccordion,
+  InstructionsAccordion,
   ErrorAlert,
   MobileDashboardTable,
   PageTemplate,
@@ -207,7 +207,7 @@ export const DashboardPage = ({ reportType }: Props) => {
           {intro.header}
         </Heading>
         {reportType === "MLR" && (
-          <FormIntroAccordion
+          <InstructionsAccordion
             verbiage={
               userIsStateUser || userIsStateRep
                 ? accordion.MLR.stateUserDashboard

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -13,12 +13,13 @@ import {
 } from "@chakra-ui/react";
 import {
   AddEditReportModal,
+  DashboardTable,
+  FormIntroAccordion,
   ErrorAlert,
+  MobileDashboardTable,
   PageTemplate,
   ReportContext,
 } from "components";
-import { DashboardTable } from "./DashboardTable";
-import { MobileDashboardTable } from "./MobileDashboardTable";
 import { Spinner } from "@cmsgov/design-system";
 // forms
 import { mcparReportJson } from "forms/mcpar";
@@ -34,6 +35,7 @@ import {
 // verbiage
 import mcparVerbiage from "verbiage/pages/mcpar/mcpar-dashboard";
 import mlrVerbiage from "verbiage/pages/mlr/mlr-dashboard";
+import accordion from "verbiage/pages/accordion";
 // assets
 import arrowLeftIcon from "assets/icons/icon_arrow_left_blue.png";
 
@@ -204,6 +206,15 @@ export const DashboardPage = ({ reportType }: Props) => {
         <Heading as="h1" sx={sx.headerText}>
           {intro.header}
         </Heading>
+        {reportType === "MLR" && (
+          <FormIntroAccordion
+            verbiage={
+              userIsStateUser || userIsStateRep
+                ? accordion.MLR.stateUserDashboard
+                : accordion.MLR.adminDashboard
+            }
+          />
+        )}
         {parseCustomHtml(intro.body)}
       </Box>
       <Box sx={sx.bodyBox}>

--- a/services/ui-src/src/components/reports/ReportPageIntro.tsx
+++ b/services/ui-src/src/components/reports/ReportPageIntro.tsx
@@ -1,6 +1,6 @@
 // components
 import { Box, Heading } from "@chakra-ui/react";
-import { FormIntroAccordion, SpreadsheetWidget } from "components";
+import { InstructionsAccordion, SpreadsheetWidget } from "components";
 // utils
 import { parseCustomHtml } from "utils";
 import { AnyObject } from "types";
@@ -15,7 +15,7 @@ export const ReportPageIntro = ({ text, accordion, ...props }: Props) => {
       <Heading as="h2" sx={sx.subsectionHeading}>
         {subsection}
       </Heading>
-      {accordion && <FormIntroAccordion verbiage={accordion} />}
+      {accordion && <InstructionsAccordion verbiage={accordion} />}
       {spreadsheet && (
         <Box sx={sx.spreadsheetWidgetBox}>
           <SpreadsheetWidget description={spreadsheet} />

--- a/services/ui-src/src/verbiage/pages/accordion.ts
+++ b/services/ui-src/src/verbiage/pages/accordion.ts
@@ -1,5 +1,23 @@
 export default {
   MLR: {
+    adminDashboard: {
+      buttonLabel: "Instructions",
+      intro:
+        '<b>State User Instructions</b><br/><br/>As described at <a href="https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-B/section-438.74" target="_blank" aria-label="Link opens in new tab">42 CFR § 438.74</a>, states are required to report summary Medical Loss Ratio (MLR) reports to the Centers for Medicare & Medicaid Services (CMS). The summary MLR report submission coincides with the state’s submission of the annual base rate certification. The summary reports are based on the plans’ annual MLR reports to the state required under <a href="https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)" target="_blank" aria-label="Link opens in new tab">42 CFR § 438.8(k)</a>. If the state needs to revise MLR reports previously submitted using the online form, ask your CMS contact to reopen the related submission, which will change it to an “In revision” status. If the state needs to revise MLR reports previously submitted using the Excel Workbook or other format, reach out to your CMS contact to discuss next steps. <a href="https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#MLR" target="_blank" aria-label="Link opens in new tab">Learn more</a>. <br/> <br/> <b>CMS Admin Instructions</b>',
+      list: [
+        `To allow a state to make corrections or edits to a submission use "Unlock" to release the submission. The status will change to "In revision".`,
+        "Submission count is shown in the # column. Submissions started and submitted once have a count of 1. When a state resubmits a previous submission, the count increases by 1.",
+        `To archive a submission and hide it from a state's dashboard, use "Archive".`,
+      ],
+      text: "",
+    },
+    stateUserDashboard: {
+      buttonLabel: "Instructions",
+      intro:
+        'As described at <a href="https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-B/section-438.74" target="_blank" aria-label="Link opens in new tab">42 CFR § 438.74</a>, states are required to report summary Medical Loss Ratio (MLR) reports to the Centers for Medicare & Medicaid Services (CMS). The summary MLR report submission coincides with the state’s submission of the annual base rate certification. The summary reports are based on the plans’ annual MLR reports to the state required under <a href="https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)" target="_blank" aria-label="Link opens in new tab">42 CFR § 438.8(k)</a>. If the state needs to revise MLR reports previously submitted using the online form, ask your CMS contact to reopen the related submission, which will change it to an “In revision” status. If the state needs to revise MLR reports previously submitted using the Excel Workbook or other format, reach out to your CMS contact to discuss next steps. <a href="https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#MLR" target="_blank" aria-label="Link opens in new tab">Learn more</a>.',
+      list: [],
+      text: "",
+    },
     formIntro: {
       buttonLabel: "Instructions",
       intro:

--- a/services/ui-src/src/verbiage/pages/mlr/mlr-dashboard.ts
+++ b/services/ui-src/src/verbiage/pages/mlr/mlr-dashboard.ts
@@ -4,16 +4,12 @@ export default {
     body: [
       {
         type: "text",
-        content:
-          'States must provide summary MLR report data at the plan level. The summary reports are based on the plans\' annual MLR reports to state under 42 CFR 438.8(k). If the report is a resubmission, ask your CMS contact to reopen the related report, which will then be "In revision" status.',
+        content: "",
       },
       {
         type: "externalLink",
-        content: "Learn more",
-        props: {
-          href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#MLR",
-          target: "_blank",
-        },
+        content: "",
+        props: {},
       },
     ],
   },


### PR DESCRIPTION
### Description

Added `Instructions` accordions to the state and admin user types' MLR dashboards, each with separate verbiage options.

### Related ticket(s)

MDCT-2343

---
### How to test

Log in as a State User and as an Admin, view their `Instructions` accordions on `/mlr/` ✨ 

### Important updates

N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
