### PR TITLE
MDCT-2420: Disable All Fields + Buttons if MLR Report is Locked

### DIFF
--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -50,7 +50,8 @@ export const ChoiceListField = ({
   const form = useFormContext();
   const fieldIsRegistered = name in form.getValues();
 
-  const shouldDisableChildFields = userIsAdmin && !!props?.disabled;
+  const shouldDisableChildFields =
+    (userIsAdmin && !!props?.disabled) || report?.locked;
 
   // set initial display value to form state field value or hydration value
   const hydrationValue = props?.hydrate;

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -34,6 +34,9 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
   const reportType = report?.reportType;
   const reportFieldDataEntities = report?.fieldData[entityType] || [];
 
+  // is MLR report in a LOCKED state
+  const isLocked = report?.locked;
+
   const dashTitle = `${verbiage.dashboardTitle}${
     verbiage.countEntitiesInTitle ? ` ${reportFieldDataEntities.length}` : ""
   }`;
@@ -134,6 +137,7 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
                         key={entityIndex}
                         entity={entity}
                         verbiage={verbiage}
+                        locked={isLocked}
                         openAddEditEntityModal={openAddEditEntityModal}
                         openDeleteEntityModal={openDeleteEntityModal}
                         openEntityDetailsOverlay={openEntityDetailsOverlay}
@@ -143,6 +147,7 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
                         key={entity.id}
                         entity={entity}
                         verbiage={verbiage}
+                        locked={isLocked}
                         openAddEditEntityModal={openAddEditEntityModal}
                         openDeleteEntityModal={openDeleteEntityModal}
                         openEntityDetailsOverlay={openEntityDetailsOverlay}
@@ -153,6 +158,7 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
             )}
             <Button
               sx={sx.addEntityButton}
+              disabled={isLocked}
               onClick={() => openAddEditEntityModal()}
             >
               {verbiage.addEntityButtonText}

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -10,6 +10,7 @@ import unfinishedIcon from "assets/icons/icon_error_circle_bright.png";
 export const EntityRow = ({
   entity,
   verbiage,
+  locked,
   openAddEditEntityModal,
   openDeleteEntityModal,
   openEntityDetailsOverlay,
@@ -56,7 +57,11 @@ export const EntityRow = ({
       </Td>
       <Td sx={sx.editButton}>
         {openAddEditEntityModal && (
-          <Button variant="none" onClick={() => openAddEditEntityModal(entity)}>
+          <Button
+            variant="none"
+            disabled={locked}
+            onClick={() => openAddEditEntityModal(entity)}
+          >
             {verbiage.editEntityButtonText}
           </Button>
         )}
@@ -67,6 +72,7 @@ export const EntityRow = ({
             onClick={() => openEntityDetailsOverlay(entity)}
             variant="outline"
             size="sm"
+            disabled={locked}
           >
             {verbiage.enterReportText}
           </Button>
@@ -77,6 +83,7 @@ export const EntityRow = ({
           <Button
             sx={sx.deleteButton}
             onClick={() => openDeleteEntityModal(entity)}
+            disabled={locked}
           >
             <Image src={deleteIcon} alt="delete icon" boxSize="3xl" />
           </Button>
@@ -89,6 +96,7 @@ export const EntityRow = ({
 interface Props {
   entity: EntityShape;
   verbiage: AnyObject;
+  locked?: boolean;
   openAddEditEntityModal?: Function;
   openDeleteEntityModal?: Function;
   openEntityDetailsOverlay?: Function;
@@ -141,7 +149,7 @@ const sx = {
   deleteButton: {
     padding: "0",
     background: "white",
-    "&:hover": {
+    "&:hover:disabled": {
       background: "white",
     },
   },

--- a/services/ui-src/src/components/tables/MobileEntityRow.tsx
+++ b/services/ui-src/src/components/tables/MobileEntityRow.tsx
@@ -11,6 +11,7 @@ import unfinishedIcon from "assets/icons/icon_error_circle_bright.png";
 export const MobileEntityRow = ({
   entity,
   verbiage,
+  locked,
   openAddEditEntityModal,
   openDeleteEntityModal,
   openEntityDetailsOverlay,
@@ -54,6 +55,7 @@ export const MobileEntityRow = ({
               <Button
                 variant="none"
                 sx={sx.editButton}
+                disabled={locked}
                 onClick={() => openAddEditEntityModal(entity)}
               >
                 {editEntityButtonText}
@@ -65,6 +67,7 @@ export const MobileEntityRow = ({
                 variant="outline"
                 onClick={() => openEntityDetailsOverlay(entity)}
                 size="sm"
+                disabled={locked}
                 sx={sx.enterButton}
               >
                 {enterReportText}
@@ -74,6 +77,7 @@ export const MobileEntityRow = ({
               <Button
                 sx={sx.deleteButton}
                 onClick={() => openDeleteEntityModal(entity)}
+                disabled={locked}
               >
                 <Image src={deleteIcon} alt="delete icon" boxSize="3xl" />
               </Button>
@@ -88,6 +92,7 @@ export const MobileEntityRow = ({
 interface Props {
   entity: AnyObject;
   verbiage: AnyObject;
+  locked?: boolean;
   openAddEditEntityModal?: Function;
   openDeleteEntityModal?: Function;
   openEntityDetailsOverlay?: Function;
@@ -139,7 +144,7 @@ const sx = {
   deleteButton: {
     background: "none",
     padding: "0",
-    "&:hover": {
+    "&:hover:disabled": {
       background: "white",
     },
   },


### PR DESCRIPTION
### Description

If an MLR report is in a `Locked` state, all of its action buttons and fields should be disabled. 

### Related ticket(s)

MDCT-2420

---
### How to test

- Log in as a state user
- Create a new MLR report
- Submit the report

Verify that all fields and buttons are disabled ✨ 

- Log in as an admin user
- Navigate to the submitted report

Ditto, everything is now disabled.

### Important updates

N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
