### PR TITLE
Refactoring Repeated Code into a Single Utility

### DIFF
--- a/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
@@ -106,14 +106,14 @@ export function getEntityTableComponents(
   return entities?.map((entity, idx) => {
     const {
       report_programName,
-      eligibilityGroup,
+      mlrEligibilityGroup,
       reportingPeriod,
       report_planName,
     } = getEntityDetailsMLR(entity);
 
     const programInfo = [
       report_programName,
-      eligibilityGroup(),
+      mlrEligibilityGroup,
       reportingPeriod,
       report_planName,
     ];

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -72,7 +72,7 @@ export function renderModalOverlayTableBody(
   switch (reportType) {
     case ReportType.MLR:
       return entities.map((entity, idx) => {
-        const { report_programName, eligibilityGroup, reportingPeriod } =
+        const { report_programName, mlrEligibilityGroup, reportingPeriod } =
           getEntityDetailsMLR(entity);
         return (
           <Tr key={idx}>
@@ -85,7 +85,7 @@ export function renderModalOverlayTableBody(
             <Td>
               <Text>
                 {report_programName} <br />
-                {renderHtml(eligibilityGroup())} <br />
+                {renderHtml(mlrEligibilityGroup)} <br />
                 {reportingPeriod} <br />
                 {entity.report_planName ?? "Not entered"}
               </Text>

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -4,7 +4,7 @@ import { EntityStatusIcon } from "components";
 // types
 import { AnyObject, EntityShape } from "types";
 // utils
-import { renderHtml } from "utils/other/rendering";
+import { eligibilityGroup, renderHtml } from "utils";
 // assets
 import deleteIcon from "assets/icons/icon_cancel_x_circle.png";
 
@@ -19,16 +19,10 @@ export const EntityRow = ({
   const { report_programName, report_planName } = entity;
 
   const reportingPeriod = `${entity.report_reportingPeriodStartDate} to ${entity.report_reportingPeriodEndDate}`;
-  const eligibilityGroup = () => {
-    if (entity["report_eligibilityGroup-otherText"]) {
-      return entity["report_eligibilityGroup-otherText"];
-    }
-    return entity.report_eligibilityGroup[0].value;
-  };
 
   const programInfo = [
     report_programName,
-    eligibilityGroup(),
+    eligibilityGroup(entity),
     reportingPeriod,
     report_planName,
   ];

--- a/services/ui-src/src/components/tables/MobileEntityRow.tsx
+++ b/services/ui-src/src/components/tables/MobileEntityRow.tsx
@@ -1,13 +1,12 @@
 // components
 import { Box, Button, Image, Text, Td, Tr } from "@chakra-ui/react";
+import { EntityStatusIcon } from "components";
 // types
 import { AnyObject, EntityShape } from "types";
 // utils
-import { parseCustomHtml } from "utils";
+import { eligibilityGroup, parseCustomHtml } from "utils";
 // assets
 import deleteIcon from "assets/icons/icon_cancel_x_circle.png";
-
-import { EntityStatusIcon } from "./EntityStatusIcon";
 
 export const MobileEntityRow = ({
   entity,
@@ -20,18 +19,12 @@ export const MobileEntityRow = ({
   const { editEntityButtonText, enterReportText, tableHeader } = verbiage;
 
   const reportingPeriod = `${entity.report_reportingPeriodStartDate} to ${entity.report_reportingPeriodEndDate}`;
-  const eligibilityGroup = () => {
-    if (entity["report_eligibilityGroup-otherText"]) {
-      return entity["report_eligibilityGroup-otherText"];
-    }
-    return entity.report_eligibilityGroup[0].value;
-  };
 
   const { report_programName, report_planName } = entity;
 
   const programInfo = [
     report_programName,
-    eligibilityGroup(),
+    eligibilityGroup(entity),
     reportingPeriod,
     report_planName,
   ];
@@ -91,7 +84,7 @@ export const MobileEntityRow = ({
 };
 
 interface Props {
-  entity: AnyObject;
+  entity: EntityShape;
   verbiage: AnyObject;
   locked?: boolean;
   openAddEditEntityModal?: Function;

--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -1,5 +1,9 @@
 import { Box, Link, Text } from "@chakra-ui/react";
+// types
 import { AnyObject, Choice, EntityShape, FieldChoice, FormField } from "types";
+// utils
+import { eligibilityGroup } from "utils";
+// verbiage
 import verbiage from "verbiage/pages/mcpar/mcpar-export";
 
 // checks for type of data cell to be render and calls the appropriate renderer
@@ -258,17 +262,12 @@ export const getEntityDetailsMLR = (entity: EntityShape) => {
   const { report_programName, report_planName } = entity;
 
   const reportingPeriod = `${entity.report_reportingPeriodStartDate} to ${entity.report_reportingPeriodEndDate}`;
-  const eligibilityGroup = () => {
-    if (entity["report_eligibilityGroup-otherText"]) {
-      return entity["report_eligibilityGroup-otherText"];
-    }
-    return entity.report_eligibilityGroup[0].value;
-  };
+  const mlrEligibilityGroup = eligibilityGroup(entity);
 
   return {
     report_programName,
     reportingPeriod,
-    eligibilityGroup,
+    mlrEligibilityGroup,
     report_planName,
   };
 };

--- a/services/ui-src/src/utils/other/rendering.ts
+++ b/services/ui-src/src/utils/other/rendering.ts
@@ -1,7 +1,16 @@
 import React from "react";
+import { EntityShape } from "types";
 
 // render '<' special character
 export const renderHtml = (rawHTML: string) =>
   React.createElement("span", {
     dangerouslySetInnerHTML: { __html: rawHTML },
   });
+
+// return MLR eligibility group text
+export const eligibilityGroup = (entity: EntityShape) => {
+  if (entity["report_eligibilityGroup-otherText"]) {
+    return entity["report_eligibilityGroup-otherText"];
+  }
+  return entity.report_eligibilityGroup[0].value;
+};


### PR DESCRIPTION
### Description

For `MLR` reports, the eligibility group field is being rendered functionally and the code for it is used across three separate files. This PR refactors that function into a single utility for reusability (and for `CodeClimate` to be happier)

### Related ticket(s)

N/A

---
### How to test

N/A

### Important updates

N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
