### PR TITLE
Make number validation more strict

### DIFF
--- a/services/app-api/utils/validation/completionSchemas.ts
+++ b/services/app-api/utils/validation/completionSchemas.ts
@@ -43,6 +43,9 @@ const valueCleaningNumberSchema = (value: string, charsToReplace: RegExp) => {
   });
 };
 
+/** This regex must be at least as permissive as the one in ui-src */
+const validNumberRegex = /^\.$|[0-9]/;
+
 // NUMBER - Number or Valid Strings
 export const number = () =>
   string()
@@ -50,7 +53,6 @@ export const number = () =>
     .test({
       message: error.INVALID_NUMBER_OR_NA,
       test: (value) => {
-        const validNumberRegex = /[0-9,.]/;
         if (value) {
           const isValidStringValue = validNAValues.includes(value);
           const isValidNumberValue = validNumberRegex.test(value);

--- a/services/app-api/utils/validation/schemaMap.ts
+++ b/services/app-api/utils/validation/schemaMap.ts
@@ -30,12 +30,14 @@ const valueCleaningNumberSchema = (value: string, charsToReplace: RegExp) => {
   });
 };
 
+/** This regex must be at least as permissive as the one in ui-src */
+const validNumberRegex = /^\.$|[0-9]/;
+
 // NUMBER - Number or Valid Strings
 export const number = () =>
   string().test({
     message: error.INVALID_NUMBER_OR_NA,
     test: (value) => {
-      const validNumberRegex = /[0-9,.]/;
       if (value) {
         const isValidStringValue = validNAValues.includes(value);
         const isValidNumberValue = validNumberRegex.test(value);

--- a/services/ui-src/src/utils/other/mask.test.ts
+++ b/services/ui-src/src/utils/other/mask.test.ts
@@ -1,6 +1,6 @@
 import {
   convertToCommaSeparatedString,
-  validCustomMask,
+  isValidCustomMask,
   isValidNumericalString,
   maskValue,
   convertToCommaSeparatedRatioString,
@@ -40,8 +40,8 @@ const ratioMaskAcceptableTestCases = [
 
 describe("Test validCustomMask", () => {
   test("Check if good and bad mask values return accurately", () => {
-    const commaSeparated = validCustomMask("comma-separated");
-    const badMask = validCustomMask("cherry-tree");
+    const commaSeparated = isValidCustomMask("comma-separated");
+    const badMask = isValidCustomMask("cherry-tree");
     expect(commaSeparated).toEqual("comma-separated");
     expect(badMask).toBeFalsy();
   });

--- a/services/ui-src/src/utils/other/mask.test.ts
+++ b/services/ui-src/src/utils/other/mask.test.ts
@@ -5,6 +5,7 @@ import {
   maskValue,
   convertToCommaSeparatedRatioString,
 } from "utils";
+import { customMaskMap } from "./mask";
 
 const commaSeparatedMaskAcceptableTestCases = [
   { test: "0....0123", expected: "0.01" },
@@ -15,6 +16,7 @@ const commaSeparatedMaskAcceptableTestCases = [
   { test: ".05", expected: "0.05" },
   { test: ".5", expected: "0.5" },
   { test: "0.05", expected: "0.05" },
+  { test: "0.0", expected: "0" },
   { test: "1,234.00", expected: "1,234" },
   { test: "1,234", expected: "1,234" },
   { test: "1234", expected: "1,234" },
@@ -42,8 +44,14 @@ describe("Test validCustomMask", () => {
   test("Check if good and bad mask values return accurately", () => {
     const commaSeparated = isValidCustomMask("comma-separated");
     const badMask = isValidCustomMask("cherry-tree");
-    expect(commaSeparated).toEqual("comma-separated");
-    expect(badMask).toBeFalsy();
+    expect(commaSeparated).toBe(true);
+    expect(badMask).toBe(false);
+  });
+
+  test("Check if all custom masks have validation functions", () => {
+    for (let maskFunction of Object.values(customMaskMap)) {
+      expect(typeof maskFunction).toBe("function");
+    }
   });
 });
 

--- a/services/ui-src/src/utils/other/mask.tsx
+++ b/services/ui-src/src/utils/other/mask.tsx
@@ -5,16 +5,17 @@ export const customMaskMap = {
 };
 
 // returns whether a given mask is a valid custom mask
-export const validCustomMask = (maskName: string | undefined) => {
-  const result = Object.keys(customMaskMap).includes(maskName!)
-    ? maskName
-    : undefined;
-  return result;
+export const isValidCustomMask = (
+  maskName: string | undefined
+): maskName is keyof typeof customMaskMap => {
+  return (
+    maskName !== undefined && Object.keys(customMaskMap).includes(maskName)
+  );
 };
 
 // if mask specified, but not a custom mask, return mask as assumed CMSDS mask
 export const validCmsdsMask = (maskName: string | undefined) => {
-  const result = validCustomMask(maskName) ? undefined : maskName;
+  const result = isValidCustomMask(maskName) ? undefined : maskName;
   return result;
 };
 
@@ -99,9 +100,9 @@ export function maskValue(
 }
 
 // if valid custom mask, return masked value; else return value
-export const applyCustomMask = (value: any, maskName: any): string => {
+export const applyCustomMask = (value: string, maskName: any): string => {
   let formattedValue: string;
-  if (value && validCustomMask(maskName)) {
+  if (value && isValidCustomMask(maskName)) {
     formattedValue = maskValue(value, maskName);
   } else formattedValue = value;
   return formattedValue.toString();

--- a/services/ui-src/src/utils/other/mask.tsx
+++ b/services/ui-src/src/utils/other/mask.tsx
@@ -94,7 +94,7 @@ export function maskValue(
   mask: keyof typeof customMaskMap
 ): string {
   const selectedCustomMask = customMaskMap[mask];
-  if (isValidNumericalString(value) && selectedCustomMask) {
+  if (isValidNumericalString(value)) {
     return selectedCustomMask(value);
   } else return value;
 }

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -32,6 +32,15 @@ const valueCleaningNumberSchema = (value: string, charsToReplace: RegExp) => {
   });
 };
 
+/**
+ * We can afford to be very permissive with this regex. As long as the
+ * value contains a digit, we can be confident that it ran through the
+ * frontend masking logic. We also allow a single dot: if the user
+ * types a dot, they are quite likely about to type a digit also.
+ * We don't want to flash an angry error message before they do so.
+ */
+const validNumberRegex = /^\.$|[0-9]/;
+
 // NUMBER - Number or Valid Strings
 export const number = () =>
   string()
@@ -39,7 +48,6 @@ export const number = () =>
     .test({
       message: error.INVALID_NUMBER_OR_NA,
       test: (value) => {
-        const validNumberRegex = /[0-9,.]/;
         if (value) {
           const isValidStringValue = validNAValues.includes(value);
           const isValidNumberValue = validNumberRegex.test(value);


### PR DESCRIPTION
### Description
This change ensures that all fields of type `number` will have well-formatted values.

Every numeric value goes through 5 layers of validation:
1. We use a CMS Design System input for number fields. If the `mask` property is set to a value CMS recognizes, it will be auto-formatted on blur. This happens before our `onBlur` handler can fire, and happens _only_ if the value contains a digit<sup>1</sup>.
3. We have a set of custom masks (`comma-separated`, `ratio`, and `percentage`) that execute on blur. These will auto-format the fields that CMS doesn't. This also happens _only_ if the value contains a digit.
4. We run the value through our `yup`-based schema validation.
5. When it hits the backend, we run it through another `yup` schema for validity
6. And we run it through _another_ schema for completeness / statusing

This commit changes all 3 `yup` schemas from `must contain a digit, comma, or dot` to `must contain a digit, or be a single dot`. Any number that was auto-formatted by a mask in step 1 or 2 will definitely pass this check. Any string that sneaked by the masking by containing no digits will instantly show an error to the user; the only way to proceed will be to enter a digit, which will then trigger the masking<sup>2</sup>.

A single dot is also allowed, so that a user can enter `.5` without an angry error message flashing before they type the second character. In theory we could change the masking so that it also fires here, but that change would be a lot more involved than it sounds. Frankly, I don't think it would be worth doing: the risk of users entering only a dot seems very low, and low-impact, in comparison to the risk of me making a mistake while changing the masking logic. Regardless, a single dot would be allowed today, so this change is at least not doing any harm.

<sup>1</sup> For certain masks, such as `zip`, this happens only if the value contains _several_ digits. But we don't use those masks in our application, as of today. https://design.cms.gov/components/text-field/masked-field/

<sup>2</sup> This is only true since we don't use masks such as `zip`. It is possible we could use such masks in the future, so this is a gap in today's work. Our current setup makes guaranteeing a different number of digits for different input types a bit of a challenge, so I am fine with this gap for now.

### Related ticket(s)
MDCT-2391

---
### How to test
1. Find a numeric field somewhere in MCPAR or MLR.
2. Try to enter some different kinds of strings in there.
   * If you enter any string that doesn't contain a digit, you should see errors that prevent saving.
   * If you enter any poorly-formatted number, you should see it reformatted on blur.

One edge case worth mentioning is the sanction dollar amount in MCPAR section D. This is the only numeric field in MCPAR which uses a built-in CMS mask (`currency`) rather than a custom mask.

### Important updates
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
