### PR TITLE
Swap first-child to first-of-type in footer

### DIFF
--- a/services/ui-src/src/components/layout/Footer.tsx
+++ b/services/ui-src/src/components/layout/Footer.tsx
@@ -241,7 +241,7 @@ const sx = {
   link: {
     margin: "0.5rem 0",
     ".desktop &": {
-      "&:first-child": {
+      "&:first-of-type": {
         paddingRight: ".5rem",
         borderRight: "1px solid",
         borderColor: "palette.white",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
See title

But also, it simply gets rid of this error when the footer renders on the page.
![Screenshot 2023-05-03 at 4 48 04 PM](https://user-images.githubusercontent.com/19439679/236046119-0247cf5a-dcb5-4b12-9340-118da5225484.png)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2413

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Look at the footer and see if it looks funny. It shouldn't look funny

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary

