### PR TITLE
`overlayForm` should have adminDisabled applied

### DIFF
--- a/services/ui-src/src/forms/mlr/mlr.json
+++ b/services/ui-src/src/forms/mlr/mlr.json
@@ -438,6 +438,7 @@
       },
       "overlayForm": {
         "id": "mlrd-overlay",
+        "adminDisabled": true,
         "fields": [
           {
             "id": "mlrSection1Header",


### PR DESCRIPTION
### Description
Tiny PR to fix a regression.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2543

---
### How to test
1. Create MLR report
2. View it as admin
3. "Enter MLR" calculations overlay should all be disabled.

### Important updates
None.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
