### PR TITLE
Disable the add program reporting button for admin

### DIFF
--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -16,7 +16,7 @@ import {
 import { EntityShape, EntityType, ModalOverlayReportPageShape } from "types";
 
 // utils
-import { useBreakpoint } from "utils";
+import { useBreakpoint, useUser } from "utils";
 
 // verbiage
 import accordionVerbiage from "../../verbiage/pages/accordion";
@@ -33,9 +33,12 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
   const { report } = useContext(ReportContext);
   const reportType = report?.reportType;
   const reportFieldDataEntities = report?.fieldData[entityType] || [];
-
+  const { userIsAdmin, userIsApprover, userIsHelpDeskUser } =
+    useUser().user ?? {};
+  const isAdminUserType = userIsAdmin || userIsApprover || userIsHelpDeskUser;
+  const formIsDisabled = isAdminUserType && route.modalForm?.adminDisabled;
   // is MLR report in a LOCKED state
-  const isLocked = report?.locked;
+  const isLocked = report?.locked || formIsDisabled;
 
   const dashTitle = `${verbiage.dashboardTitle}${
     verbiage.countEntitiesInTitle ? ` ${reportFieldDataEntities.length}` : ""


### PR DESCRIPTION
### Description
Sometimes you miss a bit of AC on a ticket going straight to val. This is one of those times.

Disables the "Add program reporting button" for admin, approver, and help desk users.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2453

---
### How to test
Open any MLR report as an admin, and verify the button is disabled on the modal overlay page.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
