### PR TITLE
add internal user

### DIFF
--- a/services/app-api/utils/types/users.ts
+++ b/services/app-api/utils/types/users.ts
@@ -3,6 +3,7 @@
 export enum UserRoles {
   ADMIN = "mdctmcr-bor", // "MDCT MCR Business Owner Representative"
   HELP_DESK = "mdctmcr-help-desk", // "MDCT MCR Help Desk"
+  INTERNAL = "mdctmcr-internal-user", // "MDCT MCR Internal User"
   APPROVER = "mdctmcr-approver", // "MDCT MCR Approver"
   STATE_REP = "mdctmcr-state-rep", // "MDCT MCR State Representative"
   STATE_USER = "mdctmcr-state-user", // "MDCT MCR State User"
@@ -17,6 +18,7 @@ export interface MCRUser {
   userRole?: string;
   userIsAdmin?: boolean;
   userIsHelpDeskUser?: boolean;
+  userIsInternalUser?: boolean;
   userIsApprover?: boolean;
   userIsStateRep?: boolean;
   userIsStateUser?: boolean;

--- a/services/ui-auth/libs/users.json
+++ b/services/ui-auth/libs/users.json
@@ -125,6 +125,31 @@
     ]
   },
   {
+    "username": "internaluser@test.com",
+    "attributes": [
+      {
+        "Name": "email",
+        "Value": "internaluser@test.com"
+      },
+      {
+        "Name": "given_name",
+        "Value": "Inside"
+      },
+      {
+        "Name": "family_name",
+        "Value": "Cat"
+      },
+      {
+        "Name": "email_verified",
+        "Value": "true"
+      },
+      {
+        "Name": "custom:cms_roles",
+        "Value": "mdctmcr-internal-user"
+      }
+    ]
+  },
+  {
     "username": "staterep@test.com",
     "attributes": [
       {

--- a/services/ui-src/src/components/drawers/ReportDrawer.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawer.tsx
@@ -27,9 +27,14 @@ export const ReportDrawer = ({
   ...props
 }: Props) => {
   // determine if fields should be disabled (based on admin roles)
-  const { userIsAdmin, userIsApprover, userIsHelpDeskUser } =
-    useUser().user ?? {};
-  const isAdminTypeUser = userIsAdmin || userIsApprover || userIsHelpDeskUser;
+  const {
+    userIsAdmin,
+    userIsApprover,
+    userIsHelpDeskUser,
+    userIsInternalUser,
+  } = useUser().user ?? {};
+  const isAdminTypeUser =
+    userIsAdmin || userIsApprover || userIsHelpDeskUser || userIsInternalUser;
   const buttonText = isAdminTypeUser ? closeText : saveAndCloseText;
   const formFieldsExist = form.fields.length;
   return (

--- a/services/ui-src/src/components/forms/AdminDashSelector.tsx
+++ b/services/ui-src/src/components/forms/AdminDashSelector.tsx
@@ -15,8 +15,12 @@ export const AdminDashSelector = ({ verbiage }: Props) => {
   const navigate = useNavigate();
   const [reportSelected, setReportSelected] = useState<boolean>(false);
 
-  const { userIsAdmin, userIsApprover, userIsHelpDeskUser } =
-    useUser().user ?? {};
+  const {
+    userIsAdmin,
+    userIsApprover,
+    userIsHelpDeskUser,
+    userIsInternalUser,
+  } = useUser().user ?? {};
 
   // create radio options
   const reportChoices = [
@@ -52,7 +56,12 @@ export const AdminDashSelector = ({ verbiage }: Props) => {
     selectedReport = selectedReport.replace("report-", "").toLowerCase();
     localStorage.setItem("selectedReportType", selectedReport);
 
-    if (userIsAdmin || userIsApprover || userIsHelpDeskUser) {
+    if (
+      userIsAdmin ||
+      userIsApprover ||
+      userIsHelpDeskUser ||
+      userIsInternalUser
+    ) {
       const selectedState = formData["state"].value;
       localStorage.setItem("selectedState", selectedState);
     }

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -42,10 +42,15 @@ export const Form = ({
   const { fields, options } = formJson;
 
   // determine if fields should be disabled (based on admin roles )
-  const { userIsAdmin, userIsApprover, userIsHelpDeskUser } =
-    useUser().user ?? {};
+  const {
+    userIsAdmin,
+    userIsApprover,
+    userIsHelpDeskUser,
+    userIsInternalUser,
+  } = useUser().user ?? {};
   const { report } = useContext(ReportContext);
-  const isAdminTypeUser = userIsAdmin || userIsApprover || userIsHelpDeskUser;
+  const isAdminTypeUser =
+    userIsAdmin || userIsApprover || userIsHelpDeskUser || userIsInternalUser;
   const fieldInputDisabled =
     (isAdminTypeUser && formJson.adminDisabled) ||
     (report?.status === ReportStatus.SUBMITTED &&

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -8,6 +8,7 @@ import { ReportContext, DashboardPage } from "components";
 import {
   mockAdminUser,
   mockHelpDeskUser,
+  mockInternalUser,
   mockStateApprover,
   mockStateRep,
   mockNoUser,
@@ -228,6 +229,14 @@ describe("Test Dashboard report archiving privileges (desktop)", () => {
     expect(screen.queryByAltText("Archive")).toBeNull();
   });
 
+  test("Internal user cannot archive reports", async () => {
+    mockedUseUser.mockReturnValue(mockInternalUser);
+    await act(async () => {
+      await render(dashboardViewWithReports);
+    });
+    expect(screen.queryByAltText("Archive")).toBeNull();
+  });
+
   test("State approver cannot archive reports", async () => {
     mockedUseUser.mockReturnValue(mockStateApprover);
     await act(async () => {
@@ -281,6 +290,14 @@ describe("Test Dashboard report archiving privileges (mobile)", () => {
 
   test("Help desk user cannot archive reports", async () => {
     mockedUseUser.mockReturnValue(mockHelpDeskUser);
+    await act(async () => {
+      await render(dashboardViewWithReports);
+    });
+    expect(screen.queryByAltText("Archive")).toBeNull();
+  });
+
+  test("Internal user cannot archive reports", async () => {
+    mockedUseUser.mockReturnValue(mockInternalUser);
     await act(async () => {
       await render(dashboardViewWithReports);
     });

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -33,9 +33,14 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
   const { report } = useContext(ReportContext);
   const reportType = report?.reportType;
   const reportFieldDataEntities = report?.fieldData[entityType] || [];
-  const { userIsAdmin, userIsApprover, userIsHelpDeskUser } =
-    useUser().user ?? {};
-  const isAdminUserType = userIsAdmin || userIsApprover || userIsHelpDeskUser;
+  const {
+    userIsAdmin,
+    userIsApprover,
+    userIsHelpDeskUser,
+    userIsInternalUser,
+  } = useUser().user ?? {};
+  const isAdminUserType =
+    userIsAdmin || userIsApprover || userIsHelpDeskUser || userIsInternalUser;
   const formIsDisabled = isAdminUserType && route.modalForm?.adminDisabled;
   // is MLR report in a LOCKED state
   const isLocked = report?.locked || formIsDisabled;

--- a/services/ui-src/src/components/reports/ReportPageFooter.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.tsx
@@ -23,9 +23,14 @@ export const ReportPageFooter = ({
     report?.formTemplate.basePath
   );
 
-  const { userIsAdmin, userIsApprover, userIsHelpDeskUser } =
-    useUser().user ?? {};
-  const isAdminUserType = userIsAdmin || userIsApprover || userIsHelpDeskUser;
+  const {
+    userIsAdmin,
+    userIsApprover,
+    userIsHelpDeskUser,
+    userIsInternalUser,
+  } = useUser().user ?? {};
+  const isAdminUserType =
+    userIsAdmin || userIsApprover || userIsHelpDeskUser || userIsInternalUser;
   const formIsDisabled = isAdminUserType && form?.adminDisabled;
 
   return (

--- a/services/ui-src/src/types/users.ts
+++ b/services/ui-src/src/types/users.ts
@@ -3,6 +3,7 @@
 export enum UserRoles {
   ADMIN = "mdctmcr-bor", // "MDCT MCR Business Owner Representative"
   HELP_DESK = "mdctmcr-help-desk", // "MDCT MCR Help Desk"
+  INTERNAL = "mdctmcr-internal-user", // "MDCT MCR Internal User"
   APPROVER = "mdctmcr-approver", // "MDCT MCR Approver"
   STATE_REP = "mdctmcr-state-rep", // "MDCT MCR State Representative"
   STATE_USER = "mdctmcr-state-user", // "MDCT MCR State User"
@@ -17,6 +18,7 @@ export interface MCRUser {
   userRole?: string;
   userIsAdmin?: boolean;
   userIsHelpDeskUser?: boolean;
+  userIsInternalUser?: boolean;
   userIsApprover?: boolean;
   userIsStateRep?: boolean;
   userIsStateUser?: boolean;

--- a/services/ui-src/src/utils/auth/UserProvider.tsx
+++ b/services/ui-src/src/utils/auth/UserProvider.tsx
@@ -65,6 +65,7 @@ export const UserProvider = ({ children }: Props) => {
       const userCheck = {
         userIsAdmin: userRole === UserRoles.ADMIN,
         userIsHelpDeskUser: userRole === UserRoles.HELP_DESK,
+        userIsInternalUser: userRole === UserRoles.INTERNAL,
         userIsApprover: userRole === UserRoles.APPROVER,
         userIsStateRep: userRole === UserRoles.STATE_REP,
         userIsStateUser: userRole === UserRoles.STATE_USER,

--- a/services/ui-src/src/utils/testing/mockUsers.tsx
+++ b/services/ui-src/src/utils/testing/mockUsers.tsx
@@ -79,6 +79,23 @@ export const mockHelpDeskUser: UserContextShape = {
   getExpiration: () => {},
 };
 
+export const mockInternalUser: UserContextShape = {
+  user: {
+    userRole: UserRoles.INTERNAL,
+    email: "internaluser@test.com",
+    given_name: "Inside",
+    family_name: "Cat",
+    full_name: "Inside Cat",
+    state: undefined,
+    userIsInternalUser: true,
+  },
+  showLocalLogins: false,
+  logout: async () => {},
+  loginWithIDM: () => {},
+  updateTimeout: async () => {},
+  getExpiration: () => {},
+};
+
 export const mockAdminUser: UserContextShape = {
   user: {
     userRole: UserRoles.ADMIN,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The app now needs to support an 'Internal User' role, which has the exact same in-app permissions as the 'Help Desk' role. The difference between the two is that when provisioned access via IDM role request, Help Desk users gain IDM help desk permissions, and internal users do not. Having an Internal User role helps better guard user privacy.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2456

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. All tests are passing
2. You can log in as `internaluser@test.com` and have the same in-app permissions as a help desk user (read only access to all reports, but no write access of any kind).

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
