### PR TITLE
MDCT-2457: Restrict MCPAR Report to State Users w/ Access to MCPAR

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -131,6 +131,10 @@ resources:
             StringAttributeConstraints:
               MinLength: 0
               MaxLength: 256
+          - Name: reports
+            AttributeDataType: String
+            Mutable: true
+            Required: false
     CognitoUserPoolClient:
       Type: AWS::Cognito::UserPoolClient
       Properties:
@@ -211,6 +215,7 @@ resources:
           family_name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname
           custom:cms_roles: cmsRoles
           custom:cms_state: state
+          custom:reports: reports
         IdpIdentifiers:
           - IdpIdentifier
         ProviderDetails:

--- a/services/ui-src/src/utils/auth/UserProvider.tsx
+++ b/services/ui-src/src/utils/auth/UserProvider.tsx
@@ -60,6 +60,9 @@ export const UserProvider = ({ children }: Props) => {
       // "custom:cms_roles" is an string of concat roles so we need to check for the one applicable to MCR
       const cms_role = payload["custom:cms_roles"] as string;
       const userRole = cms_role.split(",").find((r) => r.includes("mdctmcr"));
+      // "custom:reports" is a string of concatenated reports so it is handled similarly to "custom:cms_roles"
+      const reports = payload["custom:reports"] as string;
+      const reportAccess = reports.split(",");
       const state = payload["custom:cms_state"] as string | undefined;
       const full_name = [given_name, " ", family_name].join("");
       const userCheck = {


### PR DESCRIPTION
### Description

Only allow state users with SAML access to the `MCPAR` report to access it/

### Related ticket(s)

MDCT-2457

---
### How to test

[WIP]

### Important updates

[WIP]

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
