### PR TITLE
MDCT-2457 Pt. I: Add User Report Access Attribute

### DIFF
--- a/services/ui-auth/libs/users.json
+++ b/services/ui-auth/libs/users.json
@@ -175,10 +175,6 @@
       {
         "Name": "custom:cms_state",
         "Value": "MA"
-      },
-      {
-        "Name": "custom:reports",
-        "Value": "MCPAR,MLR,NAAAR"
       }
     ]
   },

--- a/services/ui-auth/libs/users.json
+++ b/services/ui-auth/libs/users.json
@@ -175,6 +175,10 @@
       {
         "Name": "custom:cms_state",
         "Value": "MA"
+      },
+      {
+        "Name": "custom:reports",
+        "Value": ["MCPAR", "MLR", "NAAAR"]
       }
     ]
   },
@@ -233,6 +237,10 @@
       {
         "Name": "custom:cms_state",
         "Value": "MN"
+      },
+      {
+        "Name": "custom:reports",
+        "Value": ["MCPAR", "MLR", "NAAAR"]
       }
     ]
   },
@@ -262,6 +270,10 @@
       {
         "Name": "custom:cms_state",
         "Value": "MA"
+      },
+      {
+        "Name": "custom:reports",
+        "Value": ["MCPAR", "MLR", "NAAAR"]
       }
     ]
   },
@@ -291,6 +303,10 @@
       {
         "Name": "custom:cms_state",
         "Value": "AL"
+      },
+      {
+        "Name": "custom:reports",
+        "Value": ["MCPAR", "MLR", "NAAAR"]
       }
     ]
   },
@@ -320,6 +336,10 @@
       {
         "Name": "custom:cms_state",
         "Value": "WY"
+      },
+      {
+        "Name": "custom:reports",
+        "Value": ["MCPAR", "MLR", "NAAAR"]
       }
     ]
   },
@@ -349,6 +369,10 @@
       {
         "Name": "custom:cms_state",
         "Value": "CA"
+      },
+      {
+        "Name": "custom:reports",
+        "Value": ["MCPAR", "MLR", "NAAAR"]
       }
     ]
   },
@@ -378,6 +402,10 @@
       {
         "Name": "custom:cms_state",
         "Value": "MI"
+      },
+      {
+        "Name": "custom:reports",
+        "Value": ["MCPAR", "MLR", "NAAAR"]
       }
     ]
   },
@@ -432,6 +460,10 @@
       {
         "Name": "custom:cms_state",
         "Value": "DC"
+      },
+      {
+        "Name": "custom:reports",
+        "Value": ["MCPAR", "MLR", "NAAAR"]
       }
     ]
   }

--- a/services/ui-auth/libs/users.json
+++ b/services/ui-auth/libs/users.json
@@ -178,7 +178,7 @@
       },
       {
         "Name": "custom:reports",
-        "Value": ["MCPAR", "MLR", "NAAAR"]
+        "Value": "MCPAR,MLR,NAAAR"
       }
     ]
   },
@@ -240,7 +240,7 @@
       },
       {
         "Name": "custom:reports",
-        "Value": ["MCPAR", "MLR", "NAAAR"]
+        "Value": "MCPAR,MLR,NAAAR"
       }
     ]
   },
@@ -273,7 +273,7 @@
       },
       {
         "Name": "custom:reports",
-        "Value": ["MCPAR", "MLR", "NAAAR"]
+        "Value": "MCPAR,MLR,NAAAR"
       }
     ]
   },
@@ -306,7 +306,7 @@
       },
       {
         "Name": "custom:reports",
-        "Value": ["MCPAR", "MLR", "NAAAR"]
+        "Value": "MCPAR,MLR,NAAAR"
       }
     ]
   },
@@ -339,7 +339,7 @@
       },
       {
         "Name": "custom:reports",
-        "Value": ["MCPAR", "MLR", "NAAAR"]
+        "Value": "MCPAR,MLR,NAAAR"
       }
     ]
   },
@@ -372,7 +372,7 @@
       },
       {
         "Name": "custom:reports",
-        "Value": ["MCPAR", "MLR", "NAAAR"]
+        "Value": "MCPAR,MLR,NAAAR"
       }
     ]
   },
@@ -405,7 +405,7 @@
       },
       {
         "Name": "custom:reports",
-        "Value": ["MCPAR", "MLR", "NAAAR"]
+        "Value": "MCPAR,MLR,NAAAR"
       }
     ]
   },
@@ -463,7 +463,7 @@
       },
       {
         "Name": "custom:reports",
-        "Value": ["MCPAR", "MLR", "NAAAR"]
+        "Value": "MCPAR,MLR,NAAAR"
       }
     ]
   }

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -131,6 +131,10 @@ resources:
             StringAttributeConstraints:
               MinLength: 0
               MaxLength: 256
+          - Name: reports
+            AttributeDataType: String
+            Mutable: true
+            Required: false
     CognitoUserPoolClient:
       Type: AWS::Cognito::UserPoolClient
       Properties:
@@ -211,6 +215,7 @@ resources:
           family_name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname
           custom:cms_roles: cmsRoles
           custom:cms_state: state
+          custom:reports: reports
         IdpIdentifiers:
           - IdpIdentifier
         ProviderDetails:

--- a/services/ui-src/src/utils/auth/UserProvider.tsx
+++ b/services/ui-src/src/utils/auth/UserProvider.tsx
@@ -60,6 +60,9 @@ export const UserProvider = ({ children }: Props) => {
       // "custom:cms_roles" is an string of concat roles so we need to check for the one applicable to MCR
       const cms_role = payload["custom:cms_roles"] as string;
       const userRole = cms_role.split(",").find((r) => r.includes("mdctmcr"));
+      // "custom:reports" is a string of concatenated reports so it is handled similarly to "custom:cms_roles"
+      const reports = payload["custom:reports"] as string;
+      const reportAccess = reports.split(",");
       const state = payload["custom:cms_state"] as string | undefined;
       const full_name = [given_name, " ", family_name].join("");
       const userCheck = {

--- a/services/ui-src/src/utils/auth/UserProvider.tsx
+++ b/services/ui-src/src/utils/auth/UserProvider.tsx
@@ -60,9 +60,6 @@ export const UserProvider = ({ children }: Props) => {
       // "custom:cms_roles" is an string of concat roles so we need to check for the one applicable to MCR
       const cms_role = payload["custom:cms_roles"] as string;
       const userRole = cms_role.split(",").find((r) => r.includes("mdctmcr"));
-      // "custom:reports" is a string of concatenated reports so it is handled similarly to "custom:cms_roles"
-      const reports = payload["custom:reports"] as string;
-      const reportAccess = reports.split(",");
       const state = payload["custom:cms_state"] as string | undefined;
       const full_name = [given_name, " ", family_name].join("");
       const userCheck = {


### PR DESCRIPTION
### Description

Adding a new attribute `custom:reports` to `users.json` to enable report access restrictions.

### Related ticket(s)

MDCT-2457

---
### How to test

N/A

### Important updates

`users.json` has new attributes for state users and state rep user.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
