### PR TITLE
Deploy User Pool Attributes

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -135,6 +135,9 @@ resources:
             AttributeDataType: String
             Mutable: true
             Required: false
+            StringAttributeConstraints:
+              MinLength: 0
+              MaxLength: 2048
     CognitoUserPoolClient:
       Type: AWS::Cognito::UserPoolClient
       Properties:


### PR DESCRIPTION
### Description

Matching `custom:reports` attribute to how it is set up in AWS.

### Related ticket(s)

N/A

---
### How to test

N/A

### Important updates

N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
