### PR TITLE
[MDCT-2411] - Drawers + Modals saving too often

### DIFF
--- a/services/ui-src/src/components/modals/AddEditEntityModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.test.tsx
@@ -148,14 +148,24 @@ describe("Test AddEditEntityModal functionality", () => {
       },
     };
 
-    mockUpdateCallPayload.fieldData.accessMeasures.push({
-      id: "mock-id-2",
-      "mock-modal-text-field": "mock input 2",
-    });
+    mockUpdateCallPayload.fieldData.accessMeasures = [
+      {
+        id: "mock-id-1",
+        "mock-modal-text-field": "mock input 2",
+      },
+    ];
     await expect(mockUpdateReport).toHaveBeenCalledWith(
       mockReportKeys,
       mockUpdateCallPayload
     );
+    await expect(mockCloseHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test("Doesn't edit an existing entity if no update was made", async () => {
+    await render(modalComponentWithSelectedEntity);
+    const submitButton = screen.getByRole("button", { name: "Save" });
+    await userEvent.click(submitButton);
+    await expect(mockUpdateReport).toHaveBeenCalledTimes(0);
     await expect(mockCloseHandler).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/ui-src/src/components/modals/AddEditEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.tsx
@@ -12,7 +12,7 @@ import {
   isFieldElement,
   ReportStatus,
 } from "types";
-import { filterFormData, useUser } from "utils";
+import { entityWasUpdated, filterFormData, useUser } from "utils";
 
 export const AddEditEntityModal = ({
   entityType,
@@ -42,7 +42,7 @@ export const AddEditEntityModal = ({
       },
       fieldData: {},
     };
-    const currentEntities = report?.fieldData?.[entityType] || [];
+    const currentEntities = [...(report?.fieldData?.[entityType] || [])];
     const filteredFormData = filterFormData(
       enteredData,
       form.fields.filter(isFieldElement)
@@ -60,13 +60,18 @@ export const AddEditEntityModal = ({
         ...filteredFormData,
       };
       dataToWrite.fieldData = { [entityType]: updatedEntities };
+      const shouldSave = entityWasUpdated(
+        report?.fieldData?.[entityType][selectedEntityIndex],
+        updatedEntities[selectedEntityIndex]
+      );
+      if (shouldSave) await updateReport(reportKeys, dataToWrite);
     } else {
       // create new entity
       dataToWrite.fieldData = {
         [entityType]: [...currentEntities, { id: uuid(), ...filteredFormData }],
       };
+      await updateReport(reportKeys, dataToWrite);
     }
-    await updateReport(reportKeys, dataToWrite);
     setSubmitting(false);
     modalDisclosure.onClose();
   };

--- a/services/ui-src/src/components/reports/DrawerReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.test.tsx
@@ -158,6 +158,36 @@ describe("Test DrawerReportPage with entities", () => {
     await userEvent.click(saveAndCloseButton);
     expect(mockMcparReportContext.updateReport).toHaveBeenCalledTimes(0);
   });
+
+  it("Submit sidedrawer doesn't autosave if no change was made by State User", async () => {
+    mockedUseUser.mockReturnValue(mockStateUser);
+    const visibleEntityText =
+      mockMcparReportContext.report.fieldData.plans[0].name;
+    expect(screen.getByText(visibleEntityText)).toBeVisible();
+    const launchDrawerButton = screen.getAllByText("Enter")[0];
+    await userEvent.click(launchDrawerButton);
+    expect(screen.getByRole("dialog")).toBeVisible();
+    const textField = await screen.getByLabelText("mock drawer text field");
+    expect(textField).toBeVisible();
+    const saveAndCloseButton = screen.getByText(saveAndCloseText);
+    await userEvent.click(saveAndCloseButton);
+    expect(mockMcparReportContext.updateReport).toHaveBeenCalledTimes(0);
+  });
+
+  it("Submit sidedrawer doesn't autosave if no change was made by State Rep", async () => {
+    mockedUseUser.mockReturnValue(mockStateRep);
+    const visibleEntityText =
+      mockMcparReportContext.report.fieldData.plans[0].name;
+    expect(screen.getByText(visibleEntityText)).toBeVisible();
+    const launchDrawerButton = screen.getAllByText("Enter")[0];
+    await userEvent.click(launchDrawerButton);
+    expect(screen.getByRole("dialog")).toBeVisible();
+    const textField = await screen.getByLabelText("mock drawer text field");
+    expect(textField).toBeVisible();
+    const saveAndCloseButton = screen.getByText(saveAndCloseText);
+    await userEvent.click(saveAndCloseButton);
+    expect(mockMcparReportContext.updateReport).toHaveBeenCalledTimes(0);
+  });
 });
 
 describe("Test DrawerReportPage with completed entity", () => {

--- a/services/ui-src/src/components/reports/DrawerReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.test.tsx
@@ -159,7 +159,7 @@ describe("Test DrawerReportPage with entities", () => {
     expect(mockMcparReportContext.updateReport).toHaveBeenCalledTimes(0);
   });
 
-  it("Submit sidedrawer doesn't autosave if no change was made by State User", async () => {
+  it("Submit sidedrawer doesn't save if no change was made by State User", async () => {
     mockedUseUser.mockReturnValue(mockStateUser);
     const visibleEntityText =
       mockMcparReportContext.report.fieldData.plans[0].name;
@@ -174,7 +174,7 @@ describe("Test DrawerReportPage with entities", () => {
     expect(mockMcparReportContext.updateReport).toHaveBeenCalledTimes(0);
   });
 
-  it("Submit sidedrawer doesn't autosave if no change was made by State Rep", async () => {
+  it("Submit sidedrawer doesn't save if no change was made by State Rep", async () => {
     mockedUseUser.mockReturnValue(mockStateRep);
     const visibleEntityText =
       mockMcparReportContext.report.fieldData.plans[0].name;

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -72,7 +72,11 @@ export const DrawerReportPage = ({ route }: Props) => {
       };
       let newEntities = currentEntities;
       newEntities[selectedEntityIndex] = newEntity;
-      if (entityWasUpdated(entities[selectedEntityIndex], newEntity)) {
+      const shouldSave = entityWasUpdated(
+        entities[selectedEntityIndex],
+        newEntity
+      );
+      if (shouldSave) {
         const dataToWrite = {
           metadata: {
             status: ReportStatus.IN_PROGRESS,

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -15,7 +15,12 @@ import {
   ReportPageIntro,
 } from "components";
 // utils
-import { filterFormData, parseCustomHtml, useUser } from "utils";
+import {
+  entityWasUpdated,
+  filterFormData,
+  parseCustomHtml,
+  useUser,
+} from "utils";
 import {
   AnyObject,
   EntityShape,
@@ -67,16 +72,18 @@ export const DrawerReportPage = ({ route }: Props) => {
       };
       let newEntities = currentEntities;
       newEntities[selectedEntityIndex] = newEntity;
-      const dataToWrite = {
-        metadata: {
-          status: ReportStatus.IN_PROGRESS,
-          lastAlteredBy: full_name,
-        },
-        fieldData: {
-          [entityType]: newEntities,
-        },
-      };
-      await updateReport(reportKeys, dataToWrite);
+      if (entityWasUpdated(entities[selectedEntityIndex], newEntity)) {
+        const dataToWrite = {
+          metadata: {
+            status: ReportStatus.IN_PROGRESS,
+            lastAlteredBy: full_name,
+          },
+          fieldData: {
+            [entityType]: newEntities,
+          },
+        };
+        await updateReport(reportKeys, dataToWrite);
+      }
       setSubmitting(false);
     }
     onClose();

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
@@ -27,6 +27,8 @@ jest.mock("react-router-dom", () => ({
 jest.mock("utils/auth/useUser");
 const mockedUseUser = useUser as jest.MockedFunction<typeof useUser>;
 
+window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
 const mockReportContextWithoutEntities = {
   ...mockMcparReportContext,
   report: undefined,

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
@@ -11,6 +11,7 @@ import {
   mockMcparReportContext,
   mockStateUser,
   RouterWrappedComponent,
+  mockStateRep,
 } from "utils/testing/setupJest";
 // constants
 import { saveAndCloseText } from "../../constants";
@@ -124,6 +125,26 @@ describe("Test ModalDrawerReportPage with entities", () => {
     const saveAndCloseButton = screen.getByText(saveAndCloseText);
     await userEvent.click(saveAndCloseButton);
     expect(mockMcparReportContext.updateReport).toHaveBeenCalledTimes(1);
+  });
+
+  it("Submit sidedrawer doesn't autosave if no change was made by State User", async () => {
+    mockedUseUser.mockReturnValue(mockStateUser);
+    const launchDrawerButton = screen.getByText(enterEntityDetailsButtonText);
+    await userEvent.click(launchDrawerButton);
+    expect(screen.getByRole("dialog")).toBeVisible();
+    const saveAndCloseButton = screen.getByText(saveAndCloseText);
+    await userEvent.click(saveAndCloseButton);
+    expect(mockMcparReportContext.updateReport).toHaveBeenCalledTimes(0);
+  });
+
+  it("Submit sidedrawer doesn't autosave if no change was made by State Rep", async () => {
+    mockedUseUser.mockReturnValue(mockStateRep);
+    const launchDrawerButton = screen.getByText(enterEntityDetailsButtonText);
+    await userEvent.click(launchDrawerButton);
+    expect(screen.getByRole("dialog")).toBeVisible();
+    const saveAndCloseButton = screen.getByText(saveAndCloseText);
+    await userEvent.click(saveAndCloseButton);
+    expect(mockMcparReportContext.updateReport).toHaveBeenCalledTimes(0);
   });
 });
 

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -16,6 +16,7 @@ import {
   getFormattedEntityData,
   createRepeatedFields,
   useUser,
+  entityWasUpdated,
 } from "utils";
 // types
 import {
@@ -126,16 +127,23 @@ export const ModalDrawerReportPage = ({ route }: Props) => {
       };
       let newEntities = currentEntities;
       newEntities[selectedEntityIndex] = newEntity;
-      const dataToWrite = {
-        metadata: {
-          status: ReportStatus.IN_PROGRESS,
-          lastAlteredBy: full_name,
-        },
-        fieldData: {
-          [entityType]: newEntities,
-        },
-      };
-      await updateReport(reportKeys, dataToWrite);
+      if (
+        entityWasUpdated(
+          reportFieldDataEntities[selectedEntityIndex],
+          newEntity
+        )
+      ) {
+        const dataToWrite = {
+          metadata: {
+            status: ReportStatus.IN_PROGRESS,
+            lastAlteredBy: full_name,
+          },
+          fieldData: {
+            [entityType]: newEntities,
+          },
+        };
+        await updateReport(reportKeys, dataToWrite);
+      }
       setSubmitting(false);
     }
     closeDrawer();

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -113,7 +113,7 @@ export const ModalDrawerReportPage = ({ route }: Props) => {
         state: state,
         id: report?.id,
       };
-      const currentEntities = reportFieldDataEntities;
+      const currentEntities = [...(report?.fieldData[entityType] || [])];
       const selectedEntityIndex = report?.fieldData[entityType].findIndex(
         (entity: EntityShape) => entity.id === selectedEntity?.id
       );
@@ -127,12 +127,11 @@ export const ModalDrawerReportPage = ({ route }: Props) => {
       };
       let newEntities = currentEntities;
       newEntities[selectedEntityIndex] = newEntity;
-      if (
-        entityWasUpdated(
-          reportFieldDataEntities[selectedEntityIndex],
-          newEntity
-        )
-      ) {
+      const shouldSave = entityWasUpdated(
+        reportFieldDataEntities[selectedEntityIndex],
+        newEntity
+      );
+      if (shouldSave) {
         const dataToWrite = {
           metadata: {
             status: ReportStatus.IN_PROGRESS,

--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -97,9 +97,4 @@ export const getFormattedEntityData = (
 export const entityWasUpdated = (
   originalEntity: EntityShape,
   newEntity: AnyObject
-) => {
-  return (
-    Object.entries(originalEntity).toString() !==
-    Object.entries(newEntity).toString()
-  );
-};
+) => JSON.stringify(originalEntity) !== JSON.stringify(newEntity);

--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -93,3 +93,13 @@ export const getFormattedEntityData = (
       return {};
   }
 };
+
+export const entityWasUpdated = (
+  originalEntity: EntityShape,
+  newEntity: AnyObject
+) => {
+  return (
+    Object.entries(originalEntity).toString() !==
+    Object.entries(newEntity).toString()
+  );
+};


### PR DESCRIPTION
### Description
Drawers and Modal drawers are just saving wayyyy too often. Even if a user hasn't actually made a change. This updates that so now you have to make a change before it saves!


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2411

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

- ./dev local
- Create a report
- Create a plan
- Go to Section D
- Fill out a Drawer and see it save!
- Reopen the Drawer and see it not save when you don't edit anything!
- Do the same for modalDrawers (Access Measures, Quality Measures, Sanctions)
- See modals do the same! (Access Measures, Quality Measures, Sanctions)

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---
