### PR TITLE
[MDCT-2439] Blank question H on report unlock

### DIFF
--- a/services/app-api/handlers/reports/release.ts
+++ b/services/app-api/handlers/reports/release.ts
@@ -158,6 +158,8 @@ export const releaseReport = handler(async (event) => {
         value: "Yes, this is a resubmission",
       },
     ],
+    versionControlDescription: null,
+    "versionControlDescription-otherText": null,
   };
 
   const newReportMetadata: MLRReportMetadata = {

--- a/tests/cypress/tests/e2e/mlr/release.feature
+++ b/tests/cypress/tests/e2e/mlr/release.feature
@@ -9,6 +9,21 @@ Feature: MLR E2E Form Submission
         Given I am logged in as a state user
         Then the report will have the correct content pre-filled
 
+    Scenario: Question H is always blanked on unlock
+        Given I am logged in as an state user
+        When I create, fill, and submit a report
+        Then the report is submitted successfully
+        Given I am logged in as an admin user
+        Then I unlock a report
+        Given I am logged in as a state user
+        Then the report will have the correct content pre-filled
+        When I fill and re-submit that report
+        Given I am logged in as an admin user
+        Then I unlock a report
+        Given I am logged in as a state user
+        Then the report will have the correct content pre-filled
+
+
     Scenario: A report cannot be unlocked if it is archived.
         Given I am logged in as an state user
         When I create, fill, and submit a report
@@ -22,3 +37,4 @@ Feature: MLR E2E Form Submission
         When I create, fill but don't submit a report
         Given I am logged in as an admin user
         Then I cannot unlock that report
+

--- a/tests/cypress/tests/e2e/mlr/release.stepdef.js
+++ b/tests/cypress/tests/e2e/mlr/release.stepdef.js
@@ -24,6 +24,7 @@ When("I create, fill, and submit a report", () => {
   //Using the mlr.json as a guide, traverse all the routes/forms and fill it out dynamically
   traverseRoutes(template.routes);
 
+  cy.wait(2000);
   //Submit the program
   cy.get('button:contains("Submit MLR")').focus().click();
   cy.get('[data-testid="modal-submit-button"]').focus().click();
@@ -106,6 +107,9 @@ Then("the report will have the correct content pre-filled", () => {
     "have.value",
     "District of Columbia"
   );
+  cy.get('input[type="checkbox"]').each((e) => {
+    cy.wrap(e).should("not.be.checked");
+  });
   cy.findByText("Other, specify").parent().click();
   cy.get('textarea[name="versionControlDescription-otherText"').should("exist");
   cy.findByText("Revise state contact information").parent().click();
@@ -134,4 +138,23 @@ When("I create, fill but don't submit a report", () => {
 
   //Using the mcpar.json as a guide, traverse all the routes/forms and fill it out dynamically
   traverseRoutes(template.routes);
+});
+
+When("I fill and re-submit that report", () => {
+  cy.visit(`/mlr`);
+  cy.findByText(programName)
+    .last()
+    .parent()
+    .find('button:contains("Enter")')
+    .focus()
+    .click();
+
+  cy.findByText("Revise state contact information").parent().click();
+  cy.get('button:contains("Continue")').focus().click();
+  cy.get('button:contains("Continue")').focus().click();
+
+  cy.wait(2000);
+  //Submit the program
+  cy.get('button:contains("Submit MLR")').focus().click();
+  cy.get('[data-testid="modal-submit-button"]').focus().click();
 });


### PR DESCRIPTION
### Description
Question H should _always_ be blanked on unlock, no matter what checkbox is selected.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2439

---
### How to test
1. Create and fill a new MLR report
2. Submit the report
3. Select an option for question H
4. Submit the report
5. Unlock the report again
6. Verify that no checkbox options for question H are selected.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
