### PR TITLE
[MDCT-2469] - Some form fields should not accept `N/A`

### DIFF
--- a/services/app-api/utils/validation/completionSchemaMap.ts
+++ b/services/app-api/utils/validation/completionSchemaMap.ts
@@ -20,4 +20,6 @@ export const completionSchemaMap: any = {
   radioOptional: schema.radioOptional(),
   dynamic: schema.dynamic(),
   dynamicOptional: schema.dynamicOptional(),
+  validNumber: schema.validNumber(),
+  validNumberOptional: schema.validNumberOptional(),
 };

--- a/services/app-api/utils/validation/completionSchemas.test.ts
+++ b/services/app-api/utils/validation/completionSchemas.test.ts
@@ -1,5 +1,5 @@
 import { MixedSchema } from "yup/lib/mixed";
-import { number, ratio } from "./completionSchemas";
+import { number, ratio, validNumber } from "./completionSchemas";
 
 describe("Schemas", () => {
   const goodNumberTestCases = [
@@ -36,9 +36,24 @@ describe("Schemas", () => {
     "%@#$!ASDF",
   ];
 
+  const goodValidNumberTestCases = [1, "1", "100000", "1,000,000"];
+
+  const badValidNumberTestCases = ["N/A", "number", "foo"];
+
   const testNumberSchema = (
     schemaToUse: MixedSchema,
     testCases: Array<string>,
+    expectedReturn: boolean
+  ) => {
+    for (let testCase of testCases) {
+      let test = schemaToUse.isValidSync(testCase);
+      expect(test).toEqual(expectedReturn);
+    }
+  };
+
+  const testValidNumber = (
+    schemaToUse: MixedSchema,
+    testCases: Array<string | number>,
     expectedReturn: boolean
   ) => {
     for (let testCase of testCases) {
@@ -55,5 +70,10 @@ describe("Schemas", () => {
   test("Evaluate Number Schema using ratio scheme", () => {
     testNumberSchema(ratio(), goodRatioTestCases, true);
     testNumberSchema(ratio(), badRatioTestCases, false);
+  });
+
+  test("Test validNumber schema", () => {
+    testValidNumber(validNumber(), goodValidNumberTestCases, true);
+    testValidNumber(validNumber(), badValidNumberTestCases, false);
   });
 });

--- a/services/app-api/utils/validation/completionSchemas.ts
+++ b/services/app-api/utils/validation/completionSchemas.ts
@@ -16,6 +16,7 @@ export const error = {
   INVALID_URL: "Response must be a valid hyperlink/URL",
   INVALID_DATE: "Response must be a valid date",
   INVALID_END_DATE: "End date can't be before start date",
+  INVALID_NUMBER: "Response must be a valid number",
   INVALID_NUMBER_OR_NA: 'Response must be a valid number or "N/A"',
   INVALID_RATIO: "Response must be a valid ratio",
 };

--- a/services/app-api/utils/validation/completionSchemas.ts
+++ b/services/app-api/utils/validation/completionSchemas.ts
@@ -69,6 +69,27 @@ const valueCleaningNumberSchema = (value: string, charsToReplace: RegExp) => {
 export const number = () => numberSchema().required();
 export const numberOptional = () => numberSchema().notRequired().nullable();
 
+const validNumberSchema = () =>
+  string().test({
+    message: error.INVALID_NUMBER,
+    test: (value) => {
+      return typeof value !== "undefined"
+        ? validNumberRegex.test(value)
+        : false;
+    },
+  });
+
+export const validNumber = () =>
+  validNumberSchema()
+    .required(error.REQUIRED_GENERIC)
+    .test({
+      test: (value) => !isWhitespaceString(value),
+      message: error.REQUIRED_GENERIC,
+    });
+
+export const validNumberOptional = () =>
+  validNumberSchema().notRequired().nullable();
+
 // Number - Ratio
 export const ratio = () =>
   mixed()

--- a/services/app-api/utils/validation/schemaMap.test.ts
+++ b/services/app-api/utils/validation/schemaMap.test.ts
@@ -6,6 +6,7 @@ import {
   date,
   isEndDateAfterStartDate,
   nested,
+  validNumber,
 } from "./schemaMap";
 import {} from "./validation";
 
@@ -48,6 +49,9 @@ describe("Schemas", () => {
   const goodDateTestCases = ["01/01/1990", "12/31/2020", "01012000"];
   const badDateTestCases = ["01-01-1990", "13/13/1990", "12/32/1990"];
 
+  const goodValidNumberTestCases = [1, "1", "100000", "1,000,000"];
+  const badValidNumberTestCases = ["N/A", "number", "foo"];
+
   // nested
   const fieldValidationObject = {
     type: "text",
@@ -66,6 +70,17 @@ describe("Schemas", () => {
     for (let testCase of testCases) {
       let test = schemaToUse.isValidSync(testCase);
 
+      expect(test).toEqual(expectedReturn);
+    }
+  };
+
+  const testValidNumber = (
+    schemaToUse: MixedSchema,
+    testCases: Array<string | number>,
+    expectedReturn: boolean
+  ) => {
+    for (let testCase of testCases) {
+      let test = schemaToUse.isValidSync(testCase);
       expect(test).toEqual(expectedReturn);
     }
   };
@@ -96,5 +111,10 @@ describe("Schemas", () => {
       ["string"],
       true
     );
+  });
+
+  test("Test validNumber schema", () => {
+    testValidNumber(validNumber(), goodValidNumberTestCases, true);
+    testValidNumber(validNumber(), badValidNumberTestCases, false);
   });
 });

--- a/services/app-api/utils/validation/schemaMap.ts
+++ b/services/app-api/utils/validation/schemaMap.ts
@@ -13,6 +13,7 @@ const error = {
   INVALID_URL: "Response must be a valid hyperlink/URL",
   INVALID_DATE: "Response must be a valid date",
   INVALID_END_DATE: "End date can't be before start date",
+  INVALID_NUMBER: "Response must be a valid number",
   INVALID_NUMBER_OR_NA: 'Response must be a valid number or "N/A"',
   INVALID_RATIO: "Response must be a valid ratio",
 };

--- a/services/app-api/utils/validation/schemaMap.ts
+++ b/services/app-api/utils/validation/schemaMap.ts
@@ -9,6 +9,7 @@ import {
 } from "yup";
 
 const error = {
+  REQUIRED_GENERIC: "A response is required",
   INVALID_EMAIL: "Response must be a valid email address",
   INVALID_URL: "Response must be a valid hyperlink/URL",
   INVALID_DATE: "Response must be a valid date",
@@ -17,6 +18,8 @@ const error = {
   INVALID_NUMBER_OR_NA: 'Response must be a valid number or "N/A"',
   INVALID_RATIO: "Response must be a valid ratio",
 };
+
+const isWhitespaceString = (value?: string) => value?.trim().length === 0;
 
 // TEXT
 export const text = (): StringSchema => string();
@@ -46,7 +49,29 @@ export const number = () =>
       } else return true;
     },
   });
+
 export const numberOptional = () => number();
+
+const validNumberSchema = () =>
+  string().test({
+    message: error.INVALID_NUMBER,
+    test: (value) => {
+      return typeof value !== "undefined"
+        ? validNumberRegex.test(value)
+        : false;
+    },
+  });
+
+export const validNumber = () =>
+  validNumberSchema()
+    .required(error.REQUIRED_GENERIC)
+    .test({
+      test: (value) => !isWhitespaceString(value),
+      message: error.REQUIRED_GENERIC,
+    });
+
+export const validNumberOptional = () =>
+  validNumberSchema().notRequired().nullable();
 
 // Number - Ratio
 export const ratio = () =>

--- a/services/ui-src/src/forms/mlr/mlr.json
+++ b/services/ui-src/src/forms/mlr/mlr.json
@@ -501,7 +501,7 @@
           {
             "id": "report_mlrNumerator",
             "type": "number",
-            "validation": "number",
+            "validation": "validNumber",
             "props": {
               "label": "1.3 MLR numerator",
               "hint": [
@@ -618,7 +618,7 @@
           {
             "id": "report_mlrDenominator",
             "type": "number",
-            "validation": "number",
+            "validation": "validNumber",
             "props": {
               "label": "2.3 MLR denominator",
               "hint": [
@@ -660,7 +660,7 @@
           {
             "id": "report_requiredMemberMonths",
             "type": "number",
-            "validation": "number",
+            "validation": "validNumber",
             "props": {
               "label": "3.1 Member months",
               "hint": [
@@ -910,7 +910,7 @@
                       "id": "report_remittanceDollarAmountOwed",
                       "type": "number",
                       "validation": {
-                        "type": "number",
+                        "type": "validNumber",
                         "nested": true,
                         "parentFieldName": "report_contractIncludesMlrRemittanceRequirement",
                         "parentOptionId": "7FP4jcg4jK7Ssqp3cCW5vQ"

--- a/services/ui-src/src/forms/mlr/mlr.json
+++ b/services/ui-src/src/forms/mlr/mlr.json
@@ -762,7 +762,7 @@
           {
             "id": "report_adjustedMlrPercentage",
             "type": "number",
-            "validation": "number",
+            "validation": "validNumber",
             "props": {
               "label": "3.4 Adjusted MLR",
               "hint": [

--- a/services/ui-src/src/utils/validation/schemaMap.ts
+++ b/services/ui-src/src/utils/validation/schemaMap.ts
@@ -20,4 +20,6 @@ export const schemaMap: any = {
   radioOptional: schema.radioOptional(),
   dynamic: schema.dynamic(),
   dynamicOptional: schema.dynamicOptional(),
+  validNumber: schema.validNumber(),
+  validNumberOptional: schema.validNumberOptional(),
 };

--- a/services/ui-src/src/utils/validation/schemas.test.ts
+++ b/services/ui-src/src/utils/validation/schemas.test.ts
@@ -1,5 +1,5 @@
 import { MixedSchema } from "yup/lib/mixed";
-import { dateOptional, number, ratio } from "./schemas";
+import { dateOptional, number, ratio, validNumber } from "./schemas";
 
 describe("Schemas", () => {
   const goodNumberTestCases = [
@@ -51,6 +51,10 @@ describe("Schemas", () => {
     "0/01/2023",
   ];
 
+  const goodValidNumberTestCases = [1, "1", "100000", "1,000,000"];
+
+  const badValidNumberTestCases = ["N/A", "number", "foo"];
+
   const testNumberSchema = (
     schemaToUse: MixedSchema,
     testCases: Array<string>,
@@ -73,6 +77,17 @@ describe("Schemas", () => {
     }
   };
 
+  const testValidNumber = (
+    schemaToUse: MixedSchema,
+    testCases: Array<string | number>,
+    expectedReturn: boolean
+  ) => {
+    for (let testCase of testCases) {
+      let test = schemaToUse.isValidSync(testCase);
+      expect(test).toEqual(expectedReturn);
+    }
+  };
+
   test("Evaluate Number Schema using number scheme", () => {
     testNumberSchema(number(), goodNumberTestCases, true);
     testNumberSchema(number(), badNumberTestCases, false);
@@ -86,5 +101,10 @@ describe("Schemas", () => {
   test("Test dateOptional schema", () => {
     testDateOptional(dateOptional(), goodDateOptionalTestCases, true);
     testDateOptional(dateOptional(), badDateOptionalTestCases, false);
+  });
+
+  test("Test validNumber schema", () => {
+    testValidNumber(validNumber(), goodValidNumberTestCases, true);
+    testValidNumber(validNumber(), badValidNumberTestCases, false);
   });
 });

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -63,6 +63,27 @@ export const number = () =>
     });
 export const numberOptional = () => numberSchema().notRequired().nullable();
 
+const validNumberSchema = () =>
+  string().test({
+    message: error.INVALID_NUMBER,
+    test: (value) => {
+      return typeof value !== "undefined"
+        ? validNumberRegex.test(value)
+        : false;
+    },
+  });
+
+export const validNumber = () =>
+  validNumberSchema()
+    .required(error.REQUIRED_GENERIC)
+    .test({
+      test: (value) => !isWhitespaceString(value),
+      message: error.REQUIRED_GENERIC,
+    });
+
+export const validNumberOptional = () =>
+  validNumberSchema().notRequired().nullable();
+
 // Number - Ratio
 export const ratio = () =>
   mixed()

--- a/services/ui-src/src/verbiage/errors.ts
+++ b/services/ui-src/src/verbiage/errors.ts
@@ -14,6 +14,7 @@ export const validationErrors = {
   INVALID_URL: "Response must be a valid hyperlink/URL",
   INVALID_DATE: "Response must be a valid date",
   INVALID_END_DATE: "End date can't be before start date",
+  INVALID_NUMBER: "Response must be a valid number",
   INVALID_NUMBER_OR_NA: 'Response must be a valid number or "N/A"',
   INVALID_RATIO: "Response must be a valid ratio",
 };


### PR DESCRIPTION
### Description
Some form fields need to accept a **valid number**, not N/A. This PR adds a new schema to all validation sources (`validNumber` and `validNumberOptional`) and updates the form fields that need this new validation.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2469

---
### How to test
1. Create a new MLR report.
2. Verify that questions 1.3, 2.3, 3.1, and 4.6.1 all have the correct validation.

### Important updates
NB: I only tested this in one place, because the schema are the same. CodeClimate might be upset about that—if so I'll add more tests.


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
