### PR TITLE
[MDCT-2440]: Create custom currency mask

### DIFF
--- a/services/ui-src/src/components/fields/NumberField.tsx
+++ b/services/ui-src/src/components/fields/NumberField.tsx
@@ -10,7 +10,6 @@ import {
   customMaskMap,
   getAutosaveFields,
   useUser,
-  validCmsdsMask,
 } from "utils";
 import { InputChangeEvent, AnyObject } from "types";
 import { TextFieldMask as ValidCmsdsMask } from "@cmsgov/design-system/dist/types/TextField/TextField";
@@ -124,7 +123,6 @@ export const NumberField = ({
           placeholder={placeholder}
           onChange={onChangeHandler}
           onBlur={onBlurHandler}
-          mask={validCmsdsMask(mask)}
           value={displayValue}
           {...props}
         />

--- a/services/ui-src/src/components/fields/NumberField.tsx
+++ b/services/ui-src/src/components/fields/NumberField.tsx
@@ -12,7 +12,6 @@ import {
   useUser,
 } from "utils";
 import { InputChangeEvent, AnyObject } from "types";
-import { TextFieldMask as ValidCmsdsMask } from "@cmsgov/design-system/dist/types/TextField/TextField";
 import { EntityContext } from "components/reports/EntityProvider";
 
 export const NumberField = ({
@@ -35,6 +34,12 @@ export const NumberField = ({
 
   const fieldIsRegistered = name in form.getValues();
 
+  if (mask === "currency") sx[".ds-c-field"].paddingLeft = "1.5rem";
+  else if (mask === "percentage") sx[".ds-c-field"].paddingRight = "1.75rem";
+  else {
+    sx[".ds-c-field"].paddingLeft = ".5rem";
+    sx[".ds-c-field"].paddingRight = ".5rem";
+  }
   useEffect(() => {
     if (!fieldIsRegistered) {
       form.register(name);
@@ -112,7 +117,6 @@ export const NumberField = ({
       });
     }
   };
-
   return (
     <Box sx={{ ...sx, ...sxOverride }}>
       <Box sx={sx.numberFieldContainer}>
@@ -126,22 +130,11 @@ export const NumberField = ({
           value={displayValue}
           {...props}
         />
-        {mask === "percentage" &&
-          (props.nested ? (
-            <Box
-              className={props.disabled ? "disabled" : undefined}
-              sx={sx.nestedPercentage}
-            >
-              {" % "}
-            </Box>
-          ) : (
-            <Box
-              className={props.disabled ? "disabled" : undefined}
-              sx={sx.percentage}
-            >
-              {" % "}
-            </Box>
-          ))}
+        <FieldOverlay
+          fieldMask={mask}
+          nested={props?.nested}
+          disabled={props?.disabled}
+        />
       </Box>
     </Box>
   );
@@ -151,7 +144,7 @@ interface Props {
   name: string;
   label?: string;
   placeholder?: string;
-  mask?: ValidCmsdsMask | keyof typeof customMaskMap;
+  mask?: keyof typeof customMaskMap;
   nested?: boolean;
   sxOverride?: AnyObject;
   autosave?: boolean;
@@ -159,15 +152,59 @@ interface Props {
   [key: string]: any;
 }
 
+export const FieldOverlay = ({
+  fieldMask,
+  nested,
+  disabled,
+}: FieldOverlayProps) => {
+  switch (fieldMask) {
+    case "percentage":
+      return nested ? (
+        <Box
+          className={disabled ? "disabled" : undefined}
+          sx={sx.nestedOverlayRight}
+        >
+          {" % "}
+        </Box>
+      ) : (
+        <Box className={disabled ? "disabled" : undefined} sx={sx.overlayRight}>
+          {" % "}
+        </Box>
+      );
+    case "currency":
+      return nested ? (
+        <Box
+          className={disabled ? "disabled" : undefined}
+          sx={sx.nestedOverlayLeft}
+        >
+          {" $ "}
+        </Box>
+      ) : (
+        <Box className={disabled ? "disabled" : undefined} sx={sx.overlayLeft}>
+          {" $ "}
+        </Box>
+      );
+    default:
+      return <></>;
+  }
+};
+
+interface FieldOverlayProps {
+  fieldMask?: keyof typeof customMaskMap;
+  nested?: boolean;
+  disabled?: boolean;
+}
+
 const sx = {
   ".ds-c-field": {
     maxWidth: "15rem",
-    paddingRight: "1.75rem",
+    paddingLeft: ".5rem",
+    paddingRight: ".5rem",
   },
   numberFieldContainer: {
     position: "relative",
   },
-  percentage: {
+  overlayRight: {
     position: "absolute",
     bottom: "11px",
     left: "213px",
@@ -175,7 +212,23 @@ const sx = {
     fontSize: "lg",
     fontWeight: "700",
   },
-  nestedPercentage: {
+  nestedOverlayRight: {
+    position: "absolute",
+    bottom: "15px",
+    left: "245px",
+    paddingTop: "1px",
+    fontSize: "lg",
+    fontWeight: "700",
+  },
+  overlayLeft: {
+    position: "absolute",
+    bottom: "11px",
+    left: "10px",
+    paddingTop: "1px",
+    fontSize: "lg",
+    fontWeight: "700",
+  },
+  nestedOverlayLeft: {
     position: "absolute",
     bottom: "15px",
     left: "245px",

--- a/services/ui-src/src/utils/other/mask.tsx
+++ b/services/ui-src/src/utils/other/mask.tsx
@@ -13,12 +13,6 @@ export const isValidCustomMask = (
   );
 };
 
-// if mask specified, but not a custom mask, return mask as assumed CMSDS mask
-export const validCmsdsMask = (maskName: string | undefined) => {
-  const result = isValidCustomMask(maskName) ? undefined : maskName;
-  return result;
-};
-
 /**
  * checks if provided string contains only numbers
  * @param {String} value

--- a/services/ui-src/src/utils/other/mask.tsx
+++ b/services/ui-src/src/utils/other/mask.tsx
@@ -2,6 +2,7 @@ export const customMaskMap = {
   "comma-separated": convertToCommaSeparatedString,
   percentage: convertToCommaSeparatedString,
   ratio: convertToCommaSeparatedRatioString,
+  currency: convertToCommaSeparatedString,
 };
 
 // returns whether a given mask is a valid custom mask


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->

- Change the mask for this question to "currency"
- Add a dollar sign on the left side of the input field, similar to what we do for percentage fields
- Remove the ability to use CMS masks

### Related ticket(s)
MDCT-2440

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

- Enter a MCPAR Report
- Navigate to D. VIII: Sanctions
- Create a sanction and fill out the modal
- Enter the edit sanction details modal
- Enter a valid answer for all fields in the drawer
- Enter “N/A” in D3.VIII.6
- Select “Save & Close”

Expected behavior: save drawer, actual behavior: “Please match the requested format”

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
