### PR TITLE
[MDCT-2450]: Make it so locked reports are unable to edit their name

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -19,6 +19,7 @@ import {
   mockDashboardReportContext,
   mockReportContextNoReports,
   mockReportContextWithError,
+  mockDashboardLockedReportContext,
 } from "utils/testing/setupJest";
 import { useBreakpoint, makeMediaQueryClasses, useUser } from "utils";
 // verbiage
@@ -74,6 +75,14 @@ const dashboardViewWithError = (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockReportContextWithError}>
       <DashboardPage reportType="MCPAR" />
+    </ReportContext.Provider>
+  </RouterWrappedComponent>
+);
+
+const dashboardViewWithLockedReport = (
+  <RouterWrappedComponent>
+    <ReportContext.Provider value={mockDashboardLockedReportContext}>
+      <DashboardPage reportType="MLR" />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
@@ -143,6 +152,14 @@ describe("Test Report Dashboard view (with reports, desktop view)", () => {
     expect(addReportButton).toBeVisible();
     await userEvent.click(addReportButton);
     await expect(screen.getByTestId("add-edit-report-form")).toBeVisible();
+  });
+
+  test("Unable to edit a report if it is locked", async () => {
+    await act(async () => {
+      await render(dashboardViewWithLockedReport);
+    });
+    const addReportButtons = screen.queryAllByAltText("Edit Report");
+    expect(addReportButtons).toHaveLength(0);
   });
 });
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -28,84 +28,89 @@ export const DashboardTable = ({
   sxOverride,
   isStateLevelUser,
   isAdmin,
-}: DashboardTableProps) => (
-  <Table content={tableBody(body.table, isAdmin)} sx={sx.table}>
-    {reportsByState.map((report: ReportMetadataShape) => (
-      <Tr key={report.id}>
-        {/* Edit Button */}
-        {isStateLevelUser ? (
-          <EditReportButton
-            report={report}
-            openAddEditReportModal={openAddEditReportModal}
-            sxOverride={sxOverride}
-          />
-        ) : (
-          <Td></Td>
-        )}
-        {/* Report Name */}
-        <Td sx={sxOverride.programNameText}>
-          {report.programName ?? report.submissionName}
-        </Td>
-        {/* Date Fields */}
-        <DateFields report={report} reportType={reportType} />
-        {/* Last Altered By */}
-        <Td>{report?.lastAlteredBy || "-"}</Td>
-        {/* Report Status */}
-        <Td>
-          {getStatus(
-            reportType as ReportType,
-            report.status,
-            report.archived,
-            report.submissionCount
+}: DashboardTableProps) => {
+  return (
+    <Table content={tableBody(body.table, isAdmin)} sx={sx.table}>
+      {reportsByState.map((report: ReportMetadataShape) => (
+        <Tr key={report.id}>
+          {/* Edit Button */}
+          {isStateLevelUser && !report?.locked ? (
+            <EditReportButton
+              report={report}
+              openAddEditReportModal={openAddEditReportModal}
+              sxOverride={sxOverride}
+            />
+          ) : (
+            <Td></Td>
           )}
-        </Td>
-        {/* MLR-ONLY: Submission count */}
-        {reportType === "MLR" && isAdmin && (
-          <Td> {report.submissionCount === 0 ? 1 : report.submissionCount} </Td>
-        )}
-        {/* Action Buttons */}
-        <Td sx={sxOverride.editReportButtonCell}>
-          <Button
-            variant="outline"
-            data-testid="enter-report"
-            onClick={() => enterSelectedReport(report)}
-            isDisabled={report?.archived}
-          >
-            {entering && reportId == report.id ? (
-              <Spinner size="small" />
-            ) : (
-              "Enter"
+          {/* Report Name */}
+          <Td sx={sxOverride.programNameText}>
+            {report.programName ?? report.submissionName}
+          </Td>
+          {/* Date Fields */}
+          <DateFields report={report} reportType={reportType} />
+          {/* Last Altered By */}
+          <Td>{report?.lastAlteredBy || "-"}</Td>
+          {/* Report Status */}
+          <Td>
+            {getStatus(
+              reportType as ReportType,
+              report.status,
+              report.archived,
+              report.submissionCount
             )}
-          </Button>
-        </Td>
-        {isAdmin && (
-          <>
-            {reportType === "MLR" && (
-              <AdminReleaseButton
+          </Td>
+          {/* MLR-ONLY: Submission count */}
+          {reportType === "MLR" && isAdmin && (
+            <Td>
+              {" "}
+              {report.submissionCount === 0 ? 1 : report.submissionCount}{" "}
+            </Td>
+          )}
+          {/* Action Buttons */}
+          <Td sx={sxOverride.editReportButtonCell}>
+            <Button
+              variant="outline"
+              data-testid="enter-report"
+              onClick={() => enterSelectedReport(report)}
+              isDisabled={report?.archived}
+            >
+              {entering && reportId == report.id ? (
+                <Spinner size="small" />
+              ) : (
+                "Enter"
+              )}
+            </Button>
+          </Td>
+          {isAdmin && (
+            <>
+              {reportType === "MLR" && (
+                <AdminReleaseButton
+                  report={report}
+                  reportType={reportType}
+                  reportId={reportId}
+                  releaseReport={releaseReport}
+                  releasing={releasing}
+                  sxOverride={sxOverride}
+                />
+              )}
+              <AdminArchiveButton
                 report={report}
                 reportType={reportType}
                 reportId={reportId}
+                archiveReport={archiveReport}
+                archiving={archiving}
                 releaseReport={releaseReport}
                 releasing={releasing}
                 sxOverride={sxOverride}
               />
-            )}
-            <AdminArchiveButton
-              report={report}
-              reportType={reportType}
-              reportId={reportId}
-              archiveReport={archiveReport}
-              archiving={archiving}
-              releaseReport={releaseReport}
-              releasing={releasing}
-              sxOverride={sxOverride}
-            />
-          </>
-        )}
-      </Tr>
-    ))}
-  </Table>
-);
+            </>
+          )}
+        </Tr>
+      ))}
+    </Table>
+  );
+};
 
 interface DashboardTableProps {
   reportsByState: ReportMetadataShape[];
@@ -273,6 +278,10 @@ const sx = {
       textAlign: "left",
       "&:last-of-type": {
         paddingRight: 0,
+      },
+      "&:first-of-type": {
+        width: "2rem",
+        minWidth: "2rem",
       },
     },
   },

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
@@ -31,7 +31,7 @@ export const MobileDashboardTable = ({
             {reportType === "MCPAR" ? "Program name" : "Submission name"}
           </Text>
           <Flex alignContent="flex-start">
-            {isStateLevelUser && (
+            {isStateLevelUser && !report?.locked && (
               <Box sx={sxOverride.editReport}>
                 <button onClick={() => openAddEditReportModal(report)}>
                   <Image

--- a/services/ui-src/src/utils/testing/mockReport.tsx
+++ b/services/ui-src/src/utils/testing/mockReport.tsx
@@ -357,6 +357,24 @@ export const mockMlrReport = {
   fieldData: mockMlrReportFieldData,
 };
 
+export const mockMLRLockedReport = {
+  ...mockReportKeys,
+  reportType: "MLR",
+  formTemplate: mockReportJson,
+  programName: "testProgram",
+  status: ReportStatus.SUBMITTED,
+  dueDate: 168515200000,
+  reportingPeriodStartDate: 162515200000,
+  reportingPeriodEndDate: 168515200000,
+  createdAt: 162515200000,
+  lastAltered: 162515200000,
+  lastAlteredBy: "Thelonious States",
+  combinedData: false,
+  submittedOnDate: Date.now(),
+  fieldData: mockMlrReportFieldData,
+  locked: true,
+};
+
 export const mockReportsByState = [
   { ...mockMcparReport, id: "mock-report-id-1" },
   { ...mockMcparReport, id: "mock-report-id-2" },
@@ -384,6 +402,14 @@ export const mockReportMethods = {
 export const mockMcparReportContext = {
   ...mockReportMethods,
   report: mockMcparReport,
+  reportsByState: mockReportsByState,
+  errorMessage: "",
+  lastSavedTime: "1:58 PM",
+};
+
+export const mockMLRLockedReportContext = {
+  ...mockReportMethods,
+  report: mockMLRLockedReport,
   reportsByState: mockReportsByState,
   errorMessage: "",
   lastSavedTime: "1:58 PM",
@@ -420,6 +446,17 @@ export const mockDashboardReportContext = {
   reportsByState: [
     {
       ...mockMcparReport,
+      formTemplate: undefined,
+      fieldData: undefined,
+    },
+  ],
+};
+
+export const mockDashboardLockedReportContext = {
+  ...mockMLRLockedReportContext,
+  reportsByState: [
+    {
+      ...mockMLRLockedReport,
       formTemplate: undefined,
       fieldData: undefined,
     },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
When MLRs are locked after submission, changed the edit glyph next to submission title to the inactive style

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2450

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Create an MLR Submission
Fill it out 100%
Submit it
See theres no icon anymore to edit the submission name on the dashboard!

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary