### PR TITLE
MDCT-2449: Add Cancel Button to Entity Modals

### DIFF
--- a/services/ui-src/src/components/modals/AddEditEntityModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.test.tsx
@@ -88,6 +88,11 @@ describe("Test AddEditEntityModal", () => {
     expect(screen.getByText("mock modal text field")).toBeTruthy();
   });
 
+  test("AddEditEntityModal cancel button closes modal", () => {
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(mockCloseHandler).toHaveBeenCalledTimes(1);
+  });
+
   test("AddEditEntityModal close button closes modal", () => {
     fireEvent.click(screen.getByText("Close"));
     expect(mockCloseHandler).toHaveBeenCalledTimes(1);

--- a/services/ui-src/src/components/modals/AddEditEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.tsx
@@ -95,6 +95,7 @@ export const AddEditEntityModal = ({
         ) : (
           "Save"
         ),
+        closeButtonText: "Cancel",
       }}
     >
       <Form


### PR DESCRIPTION
### Description

Adding a `Cancel` button the Add / Edit entity modals.

### Related ticket(s)

MDCT-2449

---
### How to test

- Go to `MLR`
- Create a new report
- Navigate to `mlr/mlr-reporting`
- Click on `Add a new program reporting information`
- Verify that there is a Cancel button there

### Important updates

N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
