### PR TITLE
MDCT-2580: Clear data user no longer needs from Drawers/Modals

### DIFF
--- a/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.tsx
@@ -83,7 +83,7 @@ export const EntityCardBottomSection = ({
               !formattedEntityData?.noncomplianceInstances ||
               !formattedEntityData?.dollarAmount ||
               !formattedEntityData?.assessmentDate ||
-              !formattedEntityData?.remediationDate ||
+              !formattedEntityData?.remediationCompleted ||
               !formattedEntityData?.correctiveActionPlan
                 ? "error"
                 : ""
@@ -129,11 +129,10 @@ export const EntityCardBottomSection = ({
                   }Remediation date non-compliance was corrected`}
                 </Text>
                 <Text sx={sx.subtext}>
-                  {formattedEntityData?.remediationCompleted ===
-                    "Yes, remediated" && formattedEntityData?.remediationDate
+                  {formattedEntityData?.remediationDate ||
+                  formattedEntityData?.remediationCompleted
                     ? `${formattedEntityData?.remediationCompleted} ${formattedEntityData?.remediationDate}`
-                    : formattedEntityData?.remediationCompleted ||
-                      (printVersion && notAnswered)}
+                    : printVersion && notAnswered}
                 </Text>
               </Box>
             </Flex>

--- a/services/ui-src/src/components/modals/AddEditEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.tsx
@@ -12,7 +12,13 @@ import {
   isFieldElement,
   ReportStatus,
 } from "types";
-import { entityWasUpdated, filterFormData, useUser } from "utils";
+import {
+  entityWasUpdated,
+  filterFormData,
+  getEntriesToClear,
+  setClearedEntriesToDefaultValue,
+  useUser,
+} from "utils";
 
 export const AddEditEntityModal = ({
   entityType,
@@ -49,6 +55,10 @@ export const AddEditEntityModal = ({
     );
     if (selectedEntity?.id) {
       // if existing entity selected, edit
+      const entriesToClear = getEntriesToClear(
+        enteredData,
+        form.fields.filter(isFieldElement)
+      );
       const selectedEntityIndex = currentEntities.findIndex(
         (entity: EntityShape) => entity.id === selectedEntity.id
       );
@@ -59,6 +69,12 @@ export const AddEditEntityModal = ({
         ...currentEntities[selectedEntityIndex],
         ...filteredFormData,
       };
+
+      updatedEntities[selectedEntityIndex] = setClearedEntriesToDefaultValue(
+        updatedEntities[selectedEntityIndex],
+        entriesToClear
+      );
+
       dataToWrite.fieldData = { [entityType]: updatedEntities };
       const shouldSave = entityWasUpdated(
         report?.fieldData?.[entityType][selectedEntityIndex],

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -18,7 +18,9 @@ import {
 import {
   entityWasUpdated,
   filterFormData,
+  getEntriesToClear,
   parseCustomHtml,
+  setClearedEntriesToDefaultValue,
   useUser,
 } from "utils";
 import {
@@ -65,12 +67,20 @@ export const DrawerReportPage = ({ route }: Props) => {
         enteredData,
         drawerForm.fields.filter(isFieldElement)
       );
+      const entriesToClear = getEntriesToClear(
+        enteredData,
+        drawerForm.fields.filter(isFieldElement)
+      );
       const newEntity = {
         ...selectedEntity,
         ...filteredFormData,
       };
       let newEntities = currentEntities;
       newEntities[selectedEntityIndex] = newEntity;
+      newEntities[selectedEntityIndex] = setClearedEntriesToDefaultValue(
+        newEntities[selectedEntityIndex],
+        entriesToClear
+      );
       const shouldSave = entityWasUpdated(
         entities[selectedEntityIndex],
         newEntity

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -17,6 +17,8 @@ import {
   createRepeatedFields,
   useUser,
   entityWasUpdated,
+  getEntriesToClear,
+  setClearedEntriesToDefaultValue,
 } from "utils";
 // types
 import {
@@ -120,12 +122,20 @@ export const ModalDrawerReportPage = ({ route }: Props) => {
         enteredData,
         drawerForm.fields.filter(isFieldElement)
       );
+      const entriesToClear = getEntriesToClear(
+        enteredData,
+        drawerForm.fields.filter(isFieldElement)
+      );
       const newEntity = {
         ...selectedEntity,
         ...filteredFormData,
       };
       let newEntities = currentEntities;
       newEntities[selectedEntityIndex] = newEntity;
+      newEntities[selectedEntityIndex] = setClearedEntriesToDefaultValue(
+        newEntities[selectedEntityIndex],
+        entriesToClear
+      );
       const shouldSave = entityWasUpdated(
         reportFieldDataEntities[selectedEntityIndex],
         newEntity

--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -5,6 +5,7 @@ import {
   formFieldFactory,
   hydrateFormFields,
   initializeChoiceListFields,
+  setClearedEntriesToDefaultValue,
   sortFormErrors,
 } from "./forms";
 // types
@@ -15,6 +16,7 @@ import {
   mockFormField,
   mockNestedFormField,
   mockNumberField,
+  mockSanctionsEntity,
 } from "utils/testing/setupJest";
 
 const mockedFormFields = [
@@ -345,6 +347,39 @@ describe("Test form related type guards", () => {
     });
     it("should accept good entity types", () => {
       expect(isEntityType("program")).toBeTruthy();
+    });
+  });
+});
+
+describe("Test setClearedEntriesToDefaultValue", () => {
+  it("should return an empty array value for arrays", () => {
+    expect(
+      setClearedEntriesToDefaultValue(mockSanctionsEntity, [
+        "sanction_interventionType",
+      ])
+    ).toEqual({
+      ...mockSanctionsEntity,
+      sanction_interventionType: [],
+    });
+  });
+  it("should return an empty object value for objects", () => {
+    expect(
+      setClearedEntriesToDefaultValue(mockSanctionsEntity, [
+        "sanction_planName",
+      ])
+    ).toEqual({
+      ...mockSanctionsEntity,
+      sanction_planName: {},
+    });
+  });
+  it("should return an empty string value for strings", () => {
+    expect(
+      setClearedEntriesToDefaultValue(mockSanctionsEntity, [
+        "sanction_remediationDate",
+      ])
+    ).toEqual({
+      ...mockSanctionsEntity,
+      sanction_remediationDate: "",
     });
   });
 });

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -159,12 +159,52 @@ export const filterFormData = (
     (field: FormField) => field.id
   );
   // filter user-entered data to only fields in the current form
-  const filteredDataEntries = enteredDataEntries.filter((fieldData) => {
+  const userEnteredEntries = enteredDataEntries.filter((fieldData) => {
     const [fieldDataKey] = fieldData;
     return formFieldArray.includes(fieldDataKey);
   });
   // translate data array back to a form data object
-  return Object.fromEntries(filteredDataEntries);
+  return Object.fromEntries(userEnteredEntries);
+};
+
+export const getEntriesToClear = (
+  enteredData: AnyObject,
+  currentFormFields: FormField[]
+) => {
+  // Get the users entered data
+  const enteredDataEntries = Object.entries(enteredData);
+  // Map over the users entered data and get each of the fields ids
+  const enteredDataFieldIds = enteredDataEntries.map((enteredField) => {
+    return enteredField?.[0];
+  });
+  // Grab all of the possible form fields that a user could have filled out
+  const flattenedFormFields = flattenFormFields(currentFormFields);
+  // Find what fields weren't directly entered by the user to send back to be cleared
+  const entriesToClear = flattenedFormFields.filter((formField) => {
+    return !enteredDataFieldIds.includes(formField.id);
+  });
+  // Return array of field ID's
+  return entriesToClear.map((enteredField) => {
+    return enteredField.id;
+  });
+};
+
+export const setClearedEntriesToDefaultValue = (
+  entity: AnyObject,
+  entriesToClear: string[]
+) => {
+  entriesToClear.forEach((entry) => {
+    if (Array.isArray(entity[entry])) {
+      entity[entry] = [];
+    } else if (typeof entity[entry] == "object") {
+      entity[entry] = {};
+    } else if (typeof entity[entry] == "string") {
+      entity[entry] = "";
+    } else {
+      entity[entry] = undefined;
+    }
+  });
+  return entity;
 };
 
 // returns all fields in a given form, flattened to a single level array

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -198,10 +198,8 @@ export const setClearedEntriesToDefaultValue = (
       entity[entry] = [];
     } else if (typeof entity[entry] == "object") {
       entity[entry] = {};
-    } else if (typeof entity[entry] == "string") {
-      entity[entry] = "";
     } else {
-      entity[entry] = undefined;
+      entity[entry] = "";
     }
   });
   return entity;

--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -70,9 +70,7 @@ export const getFormattedEntityData = (
         noncomplianceInstances: entity?.sanction_noncomplianceInstances,
         dollarAmount: entity?.sanction_dollarAmount,
         assessmentDate: entity?.sanction_assessmentDate,
-        remediationDate: entity?.sanction_remediationDate
-          ? entity?.sanction_remediationDate
-          : getRadioValue(entity, "sanction_remediationCompleted"),
+        remediationDate: entity?.sanction_remediationDate,
         remediationCompleted: getRadioValue(
           entity,
           "sanction_remediationCompleted"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Fix Drawers so that if a user clicks off the parent choice then that child is cleared and its cleared state is sent to the db

Double checked that Modals are also having their child questions be properly cleared if a parent choice is unselected

Removed the band-aid fix for Sanctions in EntityCardBottomSection

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2580

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

- Create a program
- Add a plan
- Go to Sanctions
- Create a sanction and add other text
- Check the network tab and see other text data was sent
- Edit the sanction modal and choose an option without other text
- See the network tab has sent an empty string for the other text option
- Repeat with the Sanction Details drawer and the remediation choicelist (Yes, In Progress, No) question
- Create a BSS Entity
- Go to a Drawer page (Section D)
- Find a choicelist or anything with a child choice
- Repeat adding othertext or entering the child, saving, coming back and choosing a different parent, and saving to see the past child data has been removed.
- 

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
