### PR TITLE
[MDCT-2582] - Handle cases where there is no formfield props during export render

### DIFF
--- a/services/ui-src/src/components/export/ExportedReportFieldRow.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldRow.tsx
@@ -17,7 +17,7 @@ export const ExportedReportFieldRow = ({
   const { report } = useContext(ReportContext);
   const reportData = report?.fieldData;
   const isDynamicField = formField.type === "dynamic";
-  const formFieldInfo = parseFormFieldInfo(formField?.props!);
+  const formFieldInfo = parseFormFieldInfo(formField?.props);
 
   // guard against double-rendering "otherText" response
   const isOtherTextEntry = formField.id.endsWith("-otherText");
@@ -29,24 +29,26 @@ export const ExportedReportFieldRow = ({
       {!isDynamicField && (
         <Td sx={sx.numberColumn}>
           <Text sx={sx.fieldNumber}>
-            {formFieldInfo.number.replace(".", "") || "N/A"}
+            {formFieldInfo?.number?.replace(".", "") || "N/A"}
           </Text>
         </Td>
       )}
 
       {/* label column/cell */}
       <Td sx={sx.labelColumn}>
-        {formFieldInfo.label || formFieldInfo.hint ? (
+        {formFieldInfo?.label || formFieldInfo?.hint ? (
           <Box>
             {formFieldInfo.label && (
               <Text sx={sx.fieldLabel}>
                 {!isDynamicField
-                  ? formFieldInfo.label
+                  ? formFieldInfo?.label
                   : formField?.props?.label}
               </Text>
             )}
-            {showHintText && formFieldInfo.hint && (
-              <Box sx={sx.fieldHint}>{parseCustomHtml(formFieldInfo.hint)}</Box>
+            {showHintText && formFieldInfo?.hint && (
+              <Box sx={sx.fieldHint}>
+                {parseCustomHtml(formFieldInfo?.hint)}
+              </Box>
             )}
           </Box>
         ) : (

--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -238,11 +238,13 @@ export const maskResponseData = (fieldMask: string, fieldResponseData: any) => {
 };
 
 // parse field info from field props
-export const parseFormFieldInfo = (formFieldProps: AnyObject) => {
-  const labelArray = formFieldProps?.label?.split(" ");
-  if (Object.values(formFieldProps).every((x) => typeof x === "undefined"))
+export const parseFormFieldInfo = (formFieldProps?: AnyObject) => {
+  if (
+    formFieldProps === undefined ||
+    Object.values(formFieldProps).every((x) => typeof x === "undefined")
+  )
     return {};
-
+  const labelArray = formFieldProps?.label?.split(" ");
   return {
     number: labelArray?.[0].match(/[-.0-9]+/) ? labelArray?.[0] : "N/A",
     label: labelArray?.[0].match(/[-.0-9]+/)


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Old reports (Reports created longer than 4 months ago) have a question that has no label. Since then we've updated the way that the exported report is generated and when it came across something that had no label it broke. This makes sure the any cases where theres an undefined label/hint text that we account for it

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2582

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

- Create a new program and make sure that the exported fields come back correctly.
- Remove Message Nick for how to reproduce the error that Georgia is seeing OR For in the mcpar.json file replace lines 596-601, 

```
    "id": "program_contractDate",
    "type": "date",
    "validation": "date"
```

with
``` 
    "id": "program_contractDate",
    "type": "date",
    "validation": "date",
    "props": {
        "hint": "Enter the date of the contract between the state and plans participating in the managed care program."
    }
```
Create a new program, and the checkout the export. Look for C1.I.1 question

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary

