### PR TITLE
MDCT-2567: Reorder MLR Question 4.1 Choices

### DIFF
--- a/services/ui-src/src/forms/mlr/mlr.json
+++ b/services/ui-src/src/forms/mlr/mlr.json
@@ -831,6 +831,10 @@
               "hint": "This element indicates if a remittance to the state or a payment to a plan is required in an MCO/PIHP/PAHP contract if a minimum MLR is not met.",
               "choices": [
                 {
+                  "id": "UL4dAeyyvCFAXttxZioacR",
+                  "label": "No"
+                },
+                {
                   "id": "7FP4jcg4jK7Ssqp3cCW5vQ",
                   "label": "Yes",
                   "children": [
@@ -1062,10 +1066,6 @@
                       }
                     }
                   ]
-                },
-                {
-                  "id": "UL4dAeyyvCFAXttxZioacR",
-                  "label": "No"
                 }
               ]
             }

--- a/tests/cypress/tests/e2e/mlr/form.stepdef.js
+++ b/tests/cypress/tests/e2e/mlr/form.stepdef.js
@@ -23,6 +23,7 @@ When("I submit a new MLR program", () => {
   traverseRoutes(template.routes);
 
   //Submit the program
+  cy.wait(5000);
   cy.get('button:contains("Submit MLR")').focus().click();
   cy.get('[data-testid="modal-submit-button"]').focus().click();
 });


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Users found the current order of MLR question 4.1 confusing, so we're switchin' it up 💫 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2567

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Create an MLR report
- Enter MLR program details
- Verify that Question 4.1 choices are: NO, YES (in that order)

![Screenshot 2023-06-02 at 11 16 32 AM](https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/99458559/74f154dd-adff-4480-b4fe-273200971e4a)

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
