### PR TITLE
Add new DynamoDB table for form templates

### DIFF
--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -26,6 +26,7 @@ custom:
   dotenv:
     path: ../../.env
   bannerTableName: ${self:custom.stage}-banners
+  formTemplateTableName: ${self:custom.stage}-form-templates
   mcparReportTableName: ${self:custom.stage}-mcpar-reports
   mcparFormBucket: ${env:MCPAR_FORM_BUCKET, "${self:service}-${self:custom.stage}-mcpar"}
   mlrReportTableName: ${self:custom.stage}-mlr-reports
@@ -182,6 +183,37 @@ resources:
           ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:
                 SSEAlgorithm: AES256
+    FormTemplateTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:custom.formTemplateTableName}
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
+        StreamSpecification:
+          StreamViewType: NEW_AND_OLD_IMAGES
+        BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
+        LocalSecondaryIndexes:
+          - IndexName: LastAlteredIndex
+            KeySchema:
+              - AttributeName: reportType
+                KeyType: HASH
+              - AttributeName: lastAltered
+                KeyType: RANGE
+            Projection:
+              ProjectionType: ALL
+        KeySchema:
+          - AttributeName: reportType
+            KeyType: HASH
+          - AttributeName: versionNumber
+            KeyType: RANGE
+        AttributeDefinitions:
+          - AttributeName: reportType
+            AttributeType: S
+          - AttributeName: versionNumber
+            AttributeType: N
+          - AttributeName: lastAltered
+            AttributeType: S
+
   Outputs:
     BannerTableName:
       Value: !Ref BannerTable


### PR DESCRIPTION
### Description
Add a new DynamoDB Table for form templates.

This new table has the primary key `reportType` and the sort key `versionNumber`. Additionally, there is a secondary index using `lastAltered` as the sort key, allowing easy querying of "all reports for a type, sorted by lastAltered date.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2599

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Ensure `./dev local` runs correctly.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
