### PR TITLE
MDCT-2629: Clear Reports in Admin Selector Dashboard 

### DIFF
--- a/services/ui-src/src/components/forms/AdminDashSelector.tsx
+++ b/services/ui-src/src/components/forms/AdminDashSelector.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useFlags } from "launchdarkly-react-client-sdk";
 // components
 import { Box, Button, Flex, Heading } from "@chakra-ui/react";
-import { Form } from "components";
+import { Form, ReportContext } from "components";
 // types
 import { AnyObject, FormJson, InputChangeEvent } from "types";
 // form
@@ -12,6 +12,7 @@ import formJson from "forms/adminDashSelector/adminDashSelector";
 import { useUser } from "utils";
 
 export const AdminDashSelector = ({ verbiage }: Props) => {
+  const { reportsByState, clearReportsByState } = useContext(ReportContext);
   const navigate = useNavigate();
   const [reportSelected, setReportSelected] = useState<boolean>(false);
 
@@ -39,6 +40,12 @@ export const AdminDashSelector = ({ verbiage }: Props) => {
 
   // add validation to formJson
   const form: FormJson = formJson;
+
+  useEffect(() => {
+    if (reportsByState) {
+      clearReportsByState();
+    }
+  }, []);
 
   const onChange = (event: InputChangeEvent) => {
     if (event.target.name === "report") {

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -38,6 +38,7 @@ export const ReportContext = createContext<ReportContextShape>({
   fetchReportsByState: Function,
   // selected report
   clearReportSelection: Function,
+  clearReportsByState: Function,
   setReportSelection: Function,
   errorMessage: undefined as string | undefined,
   lastSavedTime: undefined as string | undefined,
@@ -72,7 +73,7 @@ export const ReportProvider = ({ children }: Props) => {
   ) => {
     try {
       // clear stored reports by state prior to fetching from current state
-      setReportsByState([]);
+      clearReportsByState();
       const result = await getReportsByState(reportType, selectedState);
       setReportsByState(sortReportsOldestToNewest(result));
     } catch (e: any) {
@@ -141,6 +142,10 @@ export const ReportProvider = ({ children }: Props) => {
     localStorage.setItem("selectedReport", "");
   };
 
+  const clearReportsByState = () => {
+    setReportsByState(undefined);
+  };
+
   const setReportSelection = async (report: ReportShape) => {
     setReport(report);
     localStorage.setItem("selectedReportType", report.reportType);
@@ -178,6 +183,7 @@ export const ReportProvider = ({ children }: Props) => {
       fetchReportsByState,
       // selected report
       clearReportSelection,
+      clearReportsByState,
       setReportSelection,
       errorMessage: error,
       lastSavedTime,

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -71,6 +71,8 @@ export const ReportProvider = ({ children }: Props) => {
     selectedState: string
   ) => {
     try {
+      // clear stored reports by state prior to fetching from current state
+      setReportsByState([]);
       const result = await getReportsByState(reportType, selectedState);
       setReportsByState(sortReportsOldestToNewest(result));
     } catch (e: any) {

--- a/services/ui-src/src/types/reportContext.ts
+++ b/services/ui-src/src/types/reportContext.ts
@@ -48,6 +48,7 @@ export interface ReportContextMethods {
   createReport: Function;
   updateReport: Function;
   clearReportSelection: Function;
+  clearReportsByState: Function;
   setReportSelection: Function;
 }
 

--- a/services/ui-src/src/utils/testing/mockReport.tsx
+++ b/services/ui-src/src/utils/testing/mockReport.tsx
@@ -396,6 +396,7 @@ export const mockReportMethods = {
   updateReport: jest.fn(),
   submitReport: jest.fn(),
   clearReportSelection: jest.fn(),
+  clearReportsByState: jest.fn(),
   setReportSelection: jest.fn(),
 };
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Currently, reports by state are being "cached" in the report context for Admin users, so whenever an Admin switches from one state to another (e.g. AL to MN), they will see any reports of the previous state for a bit before rendering the second states' reports. 

Here we're clearing the reports by state from context whenever an Admin user returns to the Admin Dashboard Selector page.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2629

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as two distinct state users, for example `stateuser` and `stateuser1`
- Create a new `MLR` report for each state (don't worry about filling it in or anything)
- Log in as a `adminuser`
- Navigate to the first state, view the report
- Return to the state selection dashboard
- Navigate to the second state

You shouldn't see the report from the first state on screen, not even for a **second** 👀 

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
