### PR TITLE
Make numberfields send their masked conversions

### DIFF
--- a/services/ui-src/src/components/fields/NumberField.test.tsx
+++ b/services/ui-src/src/components/fields/NumberField.test.tsx
@@ -141,6 +141,14 @@ describe("Test Masked NumberField", () => {
     await userEvent.type(numberFieldInput, "12055.99");
     await userEvent.tab();
     expect(numberFieldInput.value).toEqual("12,055.99");
+    await userEvent.clear(numberFieldInput);
+    await userEvent.type(numberFieldInput, "-1234");
+    await userEvent.tab();
+    expect(numberFieldInput.value).toEqual("1,234");
+    await userEvent.clear(numberFieldInput);
+    await userEvent.type(numberFieldInput, "$$1234567890.10");
+    await userEvent.tab();
+    expect(numberFieldInput.value).toEqual("1,234,567,890.1");
   });
 
   test("onChangeHandler updates Currency masked field value", async () => {
@@ -160,14 +168,6 @@ describe("Test Masked NumberField", () => {
     await userEvent.type(numberFieldInput, "1234.00");
     await userEvent.tab();
     expect(numberFieldInput.value).toEqual("1,234");
-    await userEvent.clear(numberFieldInput);
-    await userEvent.type(numberFieldInput, "-1234");
-    await userEvent.tab();
-    expect(numberFieldInput.value).toEqual("1,234");
-    await userEvent.clear(numberFieldInput);
-    await userEvent.type(numberFieldInput, "$$1234567890.10");
-    await userEvent.tab();
-    expect(numberFieldInput.value).toEqual("1,234,567,890.1");
   });
 
   test("onChangeHandler updates Percentage masked field value", async () => {

--- a/services/ui-src/src/components/fields/NumberField.test.tsx
+++ b/services/ui-src/src/components/fields/NumberField.test.tsx
@@ -164,6 +164,10 @@ describe("Test Masked NumberField", () => {
     await userEvent.type(numberFieldInput, "-1234");
     await userEvent.tab();
     expect(numberFieldInput.value).toEqual("1,234");
+    await userEvent.clear(numberFieldInput);
+    await userEvent.type(numberFieldInput, "$$1234567890.10");
+    await userEvent.tab();
+    expect(numberFieldInput.value).toEqual("1,234,567,890.1");
   });
 
   test("onChangeHandler updates Percentage masked field value", async () => {

--- a/services/ui-src/src/components/fields/NumberField.test.tsx
+++ b/services/ui-src/src/components/fields/NumberField.test.tsx
@@ -160,6 +160,10 @@ describe("Test Masked NumberField", () => {
     await userEvent.type(numberFieldInput, "1234.00");
     await userEvent.tab();
     expect(numberFieldInput.value).toEqual("1,234");
+    await userEvent.clear(numberFieldInput);
+    await userEvent.type(numberFieldInput, "-1234");
+    await userEvent.tab();
+    expect(numberFieldInput.value).toEqual("1,234");
   });
 
   test("onChangeHandler updates Percentage masked field value", async () => {

--- a/services/ui-src/src/components/fields/NumberField.tsx
+++ b/services/ui-src/src/components/fields/NumberField.tsx
@@ -91,7 +91,7 @@ export const NumberField = ({
       const fields = getAutosaveFields({
         name,
         type: "number",
-        value,
+        value: maskedFieldValue,
         defaultValue,
         hydrationValue,
       });

--- a/services/ui-src/src/utils/other/mask.test.ts
+++ b/services/ui-src/src/utils/other/mask.test.ts
@@ -21,6 +21,8 @@ const commaSeparatedMaskAcceptableTestCases = [
   { test: "1,234", expected: "1,234" },
   { test: "1234", expected: "1,234" },
   { test: "1,234", expected: "1,234" },
+  { test: "-1234", expected: "1,234" },
+  { test: "$$1234567890.10", expected: "1,234,567,890.1" },
   { test: "100,000,000", expected: "100,000,000" },
   { test: "100000000", expected: "100,000,000" },
   {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->

Numberfields weren't sending their masked outputs. Now they are! This will fix any negative numbers that were sneaking through, as well as the long number inputs and multiple dollar signs.

https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/19439679/9f40cdc4-cdb8-48b2-8c5d-2e71b065b01e



### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2571 MDCT-2461

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Create a program in MCPAR
Go to B:1
Play with the number fields by adding negatives, non number characters, and more!

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary