### PR TITLE
changes to enter button

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -121,12 +121,12 @@ describe("Test Report Dashboard view (with reports, desktop view)", () => {
     expect(screen.queryByText("Leave form")).not.toBeInTheDocument();
   });
 
-  test("Clicking 'Enter' button on a report row fetches the field data, then navigates to report", async () => {
+  test("Clicking 'Edit' button on a report row fetches the field data, then navigates to report", async () => {
     await act(async () => {
       await render(dashboardViewWithReports);
     });
     mockMcparReportContext.fetchReport.mockReturnValueOnce(mockMcparReport);
-    const enterReportButton = screen.getAllByText("Enter")[0];
+    const enterReportButton = screen.getAllByText("Edit")[0];
     expect(enterReportButton).toBeVisible();
     await userEvent.click(enterReportButton);
     expect(mockMcparReportContext.setReportSelection).toHaveBeenCalledTimes(1);
@@ -187,9 +187,9 @@ describe("Test Dashboard view (with reports, mobile view)", () => {
     ).not.toBeInTheDocument();
   });
 
-  test("Clicking 'Enter' button on a report navigates to first page of report", async () => {
+  test("Clicking 'Edit' button on a report navigates to first page of report", async () => {
     mockMcparReportContext.fetchReport.mockReturnValueOnce(mockMcparReport);
-    const enterReportButton = screen.getAllByText("Enter")[0];
+    const enterReportButton = screen.getAllByText("Edit")[0];
     expect(enterReportButton).toBeVisible();
     await userEvent.click(enterReportButton);
     expect(mockUseNavigate).toBeCalledTimes(1);

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -72,8 +72,10 @@ export const DashboardTable = ({
           >
             {entering && reportId == report.id ? (
               <Spinner size="md" />
+            ) : isStateLevelUser && !report?.locked ? (
+              "Edit"
             ) : (
-              "Enter"
+              "View"
             )}
           </Button>
         </Td>

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
@@ -80,8 +80,10 @@ export const MobileDashboardTable = ({
             >
               {entering && reportId == report.id ? (
                 <Spinner size="md" />
+              ) : isStateLevelUser && !report?.locked ? (
+                "Edit"
               ) : (
-                "Enter"
+                "View"
               )}
             </Button>
           </Box>

--- a/services/ui-src/src/forms/mlr/mlr.json
+++ b/services/ui-src/src/forms/mlr/mlr.json
@@ -644,6 +644,10 @@
               "hint": "This element indicates if a remittance to the state or a payment to a plan is required in an MCO/PIHP/PAHP contract if a minimum MLR is not met.",
               "choices": [
                 {
+                  "id": "UL4dAeyyvCFAXttxZioacR",
+                  "label": "No"
+                },
+                {
                   "id": "7FP4jcg4jK7Ssqp3cCW5vQ",
                   "label": "Yes",
                   "children": [
@@ -857,10 +861,6 @@
                       }
                     }
                   ]
-                },
-                {
-                  "id": "UL4dAeyyvCFAXttxZioacR",
-                  "label": "No"
                 }
               ]
             }

--- a/services/ui-src/src/verbiage/pages/home.ts
+++ b/services/ui-src/src/verbiage/pages/home.ts
@@ -1,6 +1,6 @@
 export default {
   intro: {
-    header: "Online Managed Care Reporting Portal",
+    header: "Managed Care Reporting Portal",
     body: {
       preLinkText:
         "Get started by adding all the Medicaid managed care programs for your state. Learn more about this ",

--- a/tests/cypress/tests/e2e/mcpar/form.stepdef.js
+++ b/tests/cypress/tests/e2e/mcpar/form.stepdef.js
@@ -219,7 +219,7 @@ const traverseRoute = (route) => {
 const completeDrawerForm = (drawerForm) => {
   if (drawerForm) {
     //enter the drawer, then fill out the form and save it
-    cy.get('button:contains("Edit")').focus().click();
+    cy.get('button:contains("Enter")').focus().click();
     completeFrom(drawerForm);
     cy.get('button:contains("Save")').focus().click();
   }

--- a/tests/cypress/tests/e2e/mcpar/form.stepdef.js
+++ b/tests/cypress/tests/e2e/mcpar/form.stepdef.js
@@ -115,7 +115,7 @@ When("I completely fill out a {string} form", (form) => {
   //Find our new program and open it
   cy.findByText(programName)
     .parent()
-    .find('button:contains("Enter")')
+    .find('button:contains("Edit")')
     .focus()
     .click();
 
@@ -161,7 +161,7 @@ When("I try to submit an incomplete {string} program", (form) => {
   //Find our new program and open it
   cy.findByText(programName)
     .parent()
-    .find('button:contains("Enter")')
+    .find('button:contains("Edit")')
     .focus()
     .click();
 
@@ -219,7 +219,7 @@ const traverseRoute = (route) => {
 const completeDrawerForm = (drawerForm) => {
   if (drawerForm) {
     //enter the drawer, then fill out the form and save it
-    cy.get('button:contains("Enter")').focus().click();
+    cy.get('button:contains("Edit")').focus().click();
     completeFrom(drawerForm);
     cy.get('button:contains("Save")').focus().click();
   }

--- a/tests/cypress/tests/e2e/mlr/form.stepdef.js
+++ b/tests/cypress/tests/e2e/mlr/form.stepdef.js
@@ -23,6 +23,7 @@ When("I submit a new MLR program", () => {
   traverseRoutes(template.routes);
 
   //Submit the program
+  cy.wait(5000);
   cy.get('button:contains("Submit MLR")').focus().click();
   cy.get('[data-testid="modal-submit-button"]').focus().click();
 });

--- a/tests/cypress/tests/e2e/mlr/form.stepdef.js
+++ b/tests/cypress/tests/e2e/mlr/form.stepdef.js
@@ -15,7 +15,7 @@ When("I submit a new MLR program", () => {
   //Find our new program and open it
   cy.findByText(programName)
     .parent()
-    .find('button:contains("Enter")')
+    .find('button:contains("Edit")')
     .focus()
     .click();
 
@@ -80,7 +80,7 @@ const completeModalForm = (modalForm, buttonText) => {
 const completeOverlayForm = (overlayForm) => {
   //open the modal, then fill out the form and save it
   if (overlayForm) {
-    cy.get(`button:contains("Enter")`).focus().click();
+    cy.get(`button:contains("Edit")`).focus().click();
     completeFrom(overlayForm);
     cy.get('button:contains("Save")').focus().click();
   }

--- a/tests/cypress/tests/e2e/mlr/form.stepdef.js
+++ b/tests/cypress/tests/e2e/mlr/form.stepdef.js
@@ -80,7 +80,7 @@ const completeModalForm = (modalForm, buttonText) => {
 const completeOverlayForm = (overlayForm) => {
   //open the modal, then fill out the form and save it
   if (overlayForm) {
-    cy.get(`button:contains("Edit")`).focus().click();
+    cy.get(`button:contains("Enter")`).focus().click();
     completeFrom(overlayForm);
     cy.get('button:contains("Save")').focus().click();
   }

--- a/tests/cypress/tests/e2e/mlr/release.stepdef.js
+++ b/tests/cypress/tests/e2e/mlr/release.stepdef.js
@@ -17,7 +17,7 @@ When("I create, fill, and submit a report", () => {
   //Find our new program and open it
   cy.findByText(programName)
     .parent()
-    .find('button:contains("Enter")')
+    .find('button:contains("Edit")')
     .focus()
     .click();
 
@@ -99,7 +99,7 @@ Then("the report will have the correct content pre-filled", () => {
   cy.findByText(programName)
     .last()
     .parent()
-    .find('button:contains("Enter")')
+    .find('button:contains("View")')
     .focus()
     .click();
   cy.get('input[type="radio"]').first().should("be.checked");
@@ -132,7 +132,7 @@ When("I create, fill but don't submit a report", () => {
   //Find our new program and open it
   cy.findByText(programName)
     .parent()
-    .find('button:contains("Enter")')
+    .find('button:contains("Edit")')
     .focus()
     .click();
 
@@ -145,7 +145,7 @@ When("I fill and re-submit that report", () => {
   cy.findByText(programName)
     .last()
     .parent()
-    .find('button:contains("Enter")')
+    .find('button:contains("Edit")')
     .focus()
     .click();
 

--- a/tests/cypress/tests/e2e/mlr/release.stepdef.js
+++ b/tests/cypress/tests/e2e/mlr/release.stepdef.js
@@ -99,7 +99,7 @@ Then("the report will have the correct content pre-filled", () => {
   cy.findByText(programName)
     .last()
     .parent()
-    .find('button:contains("View")')
+    .find('button:contains("Edit")')
     .focus()
     .click();
   cy.get('input[type="radio"]').first().should("be.checked");


### PR DESCRIPTION
### Description

When a state user is on their dashboard all unlocked reports should have the CTA “Edit”

When a state user is on their dashboard all locked reports should have the CTA “View”

Admin (and all other read-only users) should always have the CTA “View”

Note:

MCPAR State User will always say “Edit” because it cannot be locked.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2642

---
### How to test
Log in as a state user and go into MCPAR, create a program, see that the 'enter' button says 'Edit'. Login as admin and see that the button says 'View'. Login as state user and enter MLR, create a program, see that the 'enter' button says, 'Edit'. After submitting, see that it says 'View'. Login as Admin and see that the MLR program always says 'View'


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
