### PR TITLE
[MDCT-2684] Number Validation Fixes

### DIFF
--- a/services/ui-src/src/components/fields/NumberField.tsx
+++ b/services/ui-src/src/components/fields/NumberField.tsx
@@ -84,6 +84,7 @@ export const NumberField = ({
     if (!value.trim()) form.trigger(name);
     // mask value and set as display value
     const maskedFieldValue = applyCustomMask(value, mask);
+    form.setValue(name, maskedFieldValue, { shouldValidate: true });
     setDisplayValue(maskedFieldValue);
 
     // submit field data to database

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -64,40 +64,6 @@ export const number = () =>
 
 export const numberOptional = () => numberSchema().notRequired().nullable();
 
-// NUMBER NOT LESS THAN ONE
-export const numberNotLessThanOne = () =>
-  string()
-    .required(error.REQUIRED_GENERIC)
-    .test({
-      test: (value) => !isWhitespaceString(value),
-      message: error.REQUIRED_GENERIC,
-    })
-    .test({
-      test: (value) => validNumberRegex.test(value!),
-      message: error.INVALID_NUMBER,
-    })
-    .test({
-      test: (value) => parseInt(value!) >= 1,
-      message: error.NUMBER_LESS_THAN_ONE,
-    });
-
-// NUMBER NOT LESS THAN ZERO
-export const numberNotLessThanZero = () =>
-  string()
-    .required(error.REQUIRED_GENERIC)
-    .test({
-      test: (value) => !isWhitespaceString(value),
-      message: error.REQUIRED_GENERIC,
-    })
-    .test({
-      test: (value) => validNumberRegex.test(value!),
-      message: error.INVALID_NUMBER,
-    })
-    .test({
-      test: (value) => parseFloat(value!) >= 0,
-      message: error.NUMBER_LESS_THAN_ZERO,
-    });
-
 const validNumberSchema = () =>
   string().test({
     message: error.INVALID_NUMBER,
@@ -118,6 +84,22 @@ export const validNumber = () =>
 
 export const validNumberOptional = () =>
   validNumberSchema().notRequired().nullable();
+
+// NUMBER NOT LESS THAN ONE
+export const numberNotLessThanOne = () =>
+  validNumber().test({
+    test: (value) => {
+      return parseFloat(value!) >= 1;
+    },
+    message: error.NUMBER_LESS_THAN_ONE,
+  });
+
+// NUMBER NOT LESS THAN ZERO
+export const numberNotLessThanZero = () =>
+  validNumber().test({
+    test: (value) => parseFloat(value!) >= 0,
+    message: error.NUMBER_LESS_THAN_ZERO,
+  });
 
 // Number - Ratio
 export const ratio = () =>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Validation was a little too harsh on numberfields and would stay on if a user entered 0,5 despite the mask then changing the value to 5. This PR changes it so the validation gets updated with the new masked value after its tabbed off.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2684
---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Go to any numberfield
Play around with them!
MLR has unique cases containing optional field validation, numberNotGreaterThanOne validation, numberNotGreaterThanZero validation, and more. Would recommend trying out MLR and seeing the various responses.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---
