### PR TITLE
MDCT-2464: Zustand State Management + Admin Banner Form

### DIFF
--- a/services/database/package.json
+++ b/services/database/package.json
@@ -25,15 +25,13 @@
     "typescript": "^4.9.3"
   },
   "dependencies": {},
-  "resolutions": {
-    "xml2js": "^0.5.0"
-  },
   "overrides": {
     "serverless-dynamodb-local": {
       "dynamodb-localhost": "https://github.com/99x/dynamodb-localhost#db30898f8c40932c7177be7b2f1a81360d12876d"
     }
   },
   "resolutions": {
-    "luxon": "3.3.0"
+    "luxon": "3.3.0",
+    "xml2js": "^0.5.0"
   }
 }

--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -42,7 +42,8 @@
     "react-scripts": "^5.0.0",
     "react-uuid": "^1.0.3",
     "sass": "^1.37.5",
-    "yup": "^0.32.11"
+    "yup": "^0.32.11",
+    "zustand": "^4.3.9"
   },
   "devDependencies": {
     "@aws-sdk/types": "^3.38.0",

--- a/services/ui-src/src/components/banners/AdminBannerProvider.tsx
+++ b/services/ui-src/src/components/banners/AdminBannerProvider.tsx
@@ -19,8 +19,11 @@ export const AdminBannerContext = createContext<AdminBannerShape>({
 });
 
 export const AdminBannerProvider = ({ children }: Props) => {
+  // Zustand state management
   const bannerData = useStore((state) => state.bannerData);
-  const setBannerData = useStore((state) => state.setBannerData);
+  const setBannerData = useStore().setBannerData;
+  const clearBannerData = useStore().clearBannerData;
+
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>();
 
@@ -42,7 +45,7 @@ export const AdminBannerProvider = ({ children }: Props) => {
 
   const deleteAdminBanner = async () => {
     await deleteBanner(ADMIN_BANNER_ID);
-    setBannerData(undefined);
+    clearBannerData();
   };
 
   const writeAdminBanner = async (newBannerData: AdminBannerData) => {

--- a/services/ui-src/src/components/banners/AdminBannerProvider.tsx
+++ b/services/ui-src/src/components/banners/AdminBannerProvider.tsx
@@ -5,6 +5,7 @@ import { bannerId } from "../../constants";
 import { bannerErrors } from "verbiage/errors";
 // api
 import { deleteBanner, getBanner, writeBanner } from "utils";
+import { useStore } from "utils/state/useStore";
 
 const ADMIN_BANNER_ID = bannerId;
 
@@ -18,9 +19,8 @@ export const AdminBannerContext = createContext<AdminBannerShape>({
 });
 
 export const AdminBannerProvider = ({ children }: Props) => {
-  const [bannerData, setBannerData] = useState<AdminBannerData | undefined>(
-    undefined
-  );
+  const bannerData = useStore((state) => state.bannerData);
+  const setBannerData = useStore((state) => state.setBannerData);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>();
 

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -1,13 +1,26 @@
-import { AdminBannerData, AnyObject } from "types";
+import { AdminBannerData } from "types";
 import { create } from "zustand";
+import { devtools } from "zustand/middleware";
 
 interface McrState {
   bannerData: AdminBannerData | undefined;
-  setBannerData: Function;
+  setBannerData: (newBannerData: AdminBannerData) => void;
+  clearBannerData: () => void;
 }
 
-export const useStore = create<McrState>((set) => ({
-  bannerData: undefined,
-  setBannerData: () =>
-    set((state: AnyObject) => ({ bannerData: state.newBannerData })),
-}));
+export const useStore = create(
+  devtools<McrState>(
+    (set) => ({
+      // initial admin banner state
+      bannerData: undefined,
+      // set new banner data
+      setBannerData: (newBannerData: AdminBannerData) =>
+        set(() => ({ bannerData: newBannerData })),
+      // clear existing banner data
+      clearBannerData: () => set(() => ({ bannerData: undefined })),
+    }),
+    {
+      enabled: true,
+    }
+  )
+);

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -1,0 +1,13 @@
+import { AdminBannerData, AnyObject } from "types";
+import { create } from "zustand";
+
+interface McrState {
+  bannerData: AdminBannerData | undefined;
+  setBannerData: Function;
+}
+
+export const useStore = create<McrState>((set) => ({
+  bannerData: undefined,
+  setBannerData: () =>
+    set((state: AnyObject) => ({ bannerData: state.newBannerData })),
+}));

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -13530,6 +13530,11 @@ use-sidecar@^1.0.1, use-sidecar@^1.0.5:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
 
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -14181,3 +14186,10 @@ zen-push@0.2.1:
   integrity sha512-Qv4qvc8ZIue51B/0zmeIMxpIGDVhz4GhJALBvnKs/FRa2T7jy4Ori9wFwaHVt0zWV7MIFglKAHbgnVxVTw7U1w==
   dependencies:
     zen-observable "^0.7.0"
+
+zustand@^4.3.9:
+  version "4.3.9"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.9.tgz#a7d4332bbd75dfd25c6848180b3df1407217f2ad"
+  integrity sha512-Tat5r8jOMG1Vcsj8uldMyqYKC5IZvQif8zetmLHs9WoZlntTHmIoNM8TpLRY31ExncuUvUOXehd0kvahkuHjDw==
+  dependencies:
+    use-sync-external-store "1.2.0"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This is an initial proof of concept for using [Zustand](https://docs.pmnd.rs/zustand/getting-started/introduction) as a state management library going forward. 

For this POC, a store has been created with an initial banner state (`undefined` by default) and there are two (2) functions: one for setting a new admin banner and one for clearing it. Another option is using the `setAdminBanner` to take an `undefined` value to clear banners, and both work exactly the same.

In my opinion, it was quite simple to set up (even with TypeScript) and I was able to plug in the new store functions/actions in place of the `useState` actions without changing much. The biggest lift I'd see is organizing our actions within a single store, but I've seen documentation and examples of folks having multiple stores for different contexts (in our case, we could have one store for banners, another store for form fields, etc.) and maintaining them. 

ALSO, there is no extra setup for unit testing! 💯 
_And_ I used `Redux DevTools` as part of this POC, which is a plug-and-play feature.

See [SPIKE document here](https://docs.google.com/document/d/1Raj0Z_XEwWI_ZT5qoX5Odb4bAp1nZ4IDNlrVieYQ-0w/edit#heading=h.m6o98tnzl5s9)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2464

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Login as admin
- Create a new banner! ✨ 
- Clear that banner! 🚫 

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
`zustand` has been installed at `ui-src`

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
