### PR TITLE
Tag epic fix

### DIFF
--- a/.github/workflows/snyk-test.yml
+++ b/.github/workflows/snyk-test.yml
@@ -3,6 +3,8 @@ name: Snyk Scan and Report
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ tag-epic-fix ]
   schedule:
     - cron:  '0 4 * * *'  # run every day at midnight
 
@@ -30,7 +32,7 @@ jobs:
   snyk_nightly_run:  
       name: Snyk Nightly Run (for nightly cron with JIRA)
       runs-on: ubuntu-latest
-      if: github.event_name == 'schedule'
+      if: github.event_name == 'schedule' || 'push'
       steps:
         - name: Check out repository
           uses: actions/checkout@v2
@@ -43,7 +45,7 @@ jobs:
             SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           
         - name: use the custom github  action to parse Snyk output
-          uses: Enterprise-CMCS/macfc-security-scan-report@v1.0.2
+          uses: Enterprise-CMCS/macfc-security-scan-report@v1.0.3
           with:
               jira-username: ${{ secrets.JIRA_SERVICE_USERNAME }}
               jira-token: ${{ secrets.JIRA_SERVICE_USER_TOKEN }}

--- a/.github/workflows/snyk-test.yml
+++ b/.github/workflows/snyk-test.yml
@@ -3,8 +3,6 @@ name: Snyk Scan and Report
 on:
   pull_request:
     branches: [ main ]
-  push:
-    branches: [ tag-epic-fix ]
   schedule:
     - cron:  '0 4 * * *'  # run every day at midnight
 
@@ -32,7 +30,7 @@ jobs:
   snyk_nightly_run:  
       name: Snyk Nightly Run (for nightly cron with JIRA)
       runs-on: ubuntu-latest
-      if: github.event_name == 'schedule' || 'push'
+      if: github.event_name == 'schedule'
       steps:
         - name: Check out repository
           uses: actions/checkout@v2


### PR DESCRIPTION
Two workflow Jobs

Runs during PR creation on main and outputs the findings in GitHub Workflow console
Runs on Cron and creates JIRA ticket based on findings

JIRA ticket behavior

Existing ticket check is set to default 60days, this can be adjusted as needed.
The same Vulnerability can re-exist after the resolution when a the same package is added for this reason there is a check for Closed or Cancelled ticket and based on that a ticket get created.
SNYK Ignore

There is a .snyk file in the root directory that can hold a list of snyk ignore ids, a vulnerability can be manually added there following the same synaxt in the file, so when Snyk scan runs all the vulnerabilities in .snyk file will be ignored.

Important updates

Author checklist

I have performed a self-review of my code
I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
I have updated relevant documentation, if necessary
