### PR TITLE
[MDCT-2712]: Update fields so they no longer trigger validations between same page types

### DIFF
--- a/services/ui-src/src/components/drawers/ReportDrawer.test.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawer.test.tsx
@@ -10,6 +10,7 @@ import {
   mockEmptyDrawerForm,
   mockModalDrawerReportPageVerbiage,
   mockStateUser,
+  RouterWrappedComponent,
 } from "utils/testing/setupJest";
 // utils
 import { useUser } from "utils";
@@ -28,13 +29,15 @@ jest.mock("utils/auth/useUser");
 const mockedUseUser = useUser as jest.MockedFunction<typeof useUser>;
 
 const drawerComponent = (
-  <ReportDrawer
-    verbiage={mockModalDrawerReportPageVerbiage}
-    selectedEntity={mockCompletedQualityMeasuresEntity}
-    form={mockDrawerForm}
-    onSubmit={mockOnSubmit}
-    drawerDisclosure={mockDrawerDisclosure}
-  />
+  <RouterWrappedComponent>
+    <ReportDrawer
+      verbiage={mockModalDrawerReportPageVerbiage}
+      selectedEntity={mockCompletedQualityMeasuresEntity}
+      form={mockDrawerForm}
+      onSubmit={mockOnSubmit}
+      drawerDisclosure={mockDrawerDisclosure}
+    />
+  </RouterWrappedComponent>
 );
 
 describe("Test ReportDrawer rendering", () => {

--- a/services/ui-src/src/components/drawers/ReportDrawer.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawer.tsx
@@ -44,7 +44,8 @@ export const ReportDrawer = ({
           formJson={form}
           onSubmit={onSubmit}
           formData={selectedEntity}
-          validateOnRender={validateOnRender}
+          validateOnRender={validateOnRender || false}
+          dontReset={true}
         />
       ) : (
         <Text sx={sx.noFormMessage}>{verbiage.drawerNoFormMessage}</Text>

--- a/services/ui-src/src/components/fields/ChoiceListField.test.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.test.tsx
@@ -34,15 +34,6 @@ const mockGetValues = (returnValue: any) =>
     getValues: jest.fn().mockReturnValueOnce([]).mockReturnValue(returnValue),
   }));
 
-const mockFieldIsRegistered = (fieldName: string, returnValue: any) =>
-  mockUseFormContext.mockImplementation((): any => ({
-    ...mockRhfMethods,
-    getValues: jest
-      .fn()
-      .mockReturnValueOnce({ [`${fieldName}`]: returnValue })
-      .mockReturnValue(returnValue),
-  }));
-
 const CheckboxComponent = (
   <ReportContext.Provider value={mockMcparReportContext}>
     <ChoiceListField
@@ -100,22 +91,6 @@ describe("Test ChoiceListField component rendering", () => {
     render(CheckboxComponent);
     expect(screen.getByText("Choice 1")).toBeVisible();
     expect(screen.getByText("Choice 2")).toBeVisible();
-  });
-
-  it("ChoiceList should render a normal Radiofield and triggers validation after first render if no value given", () => {
-    mockFieldIsRegistered("radioField", []);
-    render(RadioComponent);
-    expect(screen.getByText("Choice 1")).toBeVisible();
-    expect(screen.getByText("Choice 2")).toBeVisible();
-    expect(mockTrigger).toBeCalled();
-  });
-
-  it("ChoiceList should render a normal Checkbox and triggers validation after first render if no value given", () => {
-    mockFieldIsRegistered("checkboxField", []);
-    render(CheckboxComponent);
-    expect(screen.getByText("Choice 1")).toBeVisible();
-    expect(screen.getByText("Choice 2")).toBeVisible();
-    expect(mockTrigger).toBeCalled();
   });
 
   it("RadioField should render nested child fields for choices with children", () => {

--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -61,7 +61,7 @@ export const ChoiceListField = ({
   useEffect(() => {
     if (!fieldIsRegistered && !validateOnRender) {
       form.register(name);
-    } else {
+    } else if (validateOnRender) {
       form.trigger(name);
     }
   }, []);

--- a/services/ui-src/src/components/fields/DateField.test.tsx
+++ b/services/ui-src/src/components/fields/DateField.test.tsx
@@ -28,15 +28,6 @@ const mockGetValues = (returnValue: any) =>
     getValues: jest.fn().mockReturnValueOnce([]).mockReturnValue(returnValue),
   }));
 
-const mockFieldIsRegistered = (fieldName: string, returnValue: any) =>
-  mockUseFormContext.mockImplementation((): any => ({
-    ...mockRhfMethods,
-    getValues: jest
-      .fn()
-      .mockReturnValueOnce({ [`${fieldName}`]: returnValue })
-      .mockReturnValue(returnValue),
-  }));
-
 jest.mock("utils/auth/useUser");
 const mockedUseUser = useUser as jest.MockedFunction<typeof useUser>;
 
@@ -59,18 +50,6 @@ describe("Test DateField basic functionality", () => {
       "[name='testDateField']"
     )!;
     expect(dateFieldInput).toBeVisible();
-  });
-
-  test("DateField triggers validation after first render if no value given", () => {
-    mockedUseUser.mockReturnValue(mockStateUser);
-    mockFieldIsRegistered("testDateField", "");
-    const result = render(dateFieldComponent);
-    const dateFieldInput: HTMLInputElement = result.container.querySelector(
-      "[name='testDateField']"
-    )!;
-    expect(dateFieldInput).toBeVisible();
-    expect(mockTrigger).toBeCalled();
-    jest.clearAllMocks();
   });
 
   test("onChange event fires handler when typing and stays even after blurred", async () => {

--- a/services/ui-src/src/components/fields/DateField.tsx
+++ b/services/ui-src/src/components/fields/DateField.tsx
@@ -42,7 +42,7 @@ export const DateField = ({
   useEffect(() => {
     if (!fieldIsRegistered && !validateOnRender) {
       form.register(name);
-    } else {
+    } else if (validateOnRender) {
       form.trigger(name);
     }
   }, []);

--- a/services/ui-src/src/components/fields/DropdownField.test.tsx
+++ b/services/ui-src/src/components/fields/DropdownField.test.tsx
@@ -33,15 +33,6 @@ const mockGetValues = (returnValue: any) =>
     getValues: jest.fn().mockReturnValueOnce([]).mockReturnValue(returnValue),
   }));
 
-const mockFieldIsRegistered = (fieldName: string, returnValue: any) =>
-  mockUseFormContext.mockImplementation((): any => ({
-    ...mockRhfMethods,
-    getValues: jest
-      .fn()
-      .mockReturnValueOnce({ [`${fieldName}`]: returnValue })
-      .mockReturnValue(returnValue),
-  }));
-
 jest.mock("utils/auth/useUser");
 const mockedUseUser = useUser as jest.MockedFunction<typeof useUser>;
 
@@ -88,14 +79,6 @@ describe("Test DropdownField basic functionality", () => {
     render(dropdownComponentWithOptions);
     const dropdown = screen.getByLabelText("test-dropdown-label");
     expect(dropdown).toBeVisible();
-  });
-
-  test("DropdownField triggers validation after first render if no value given", () => {
-    mockFieldIsRegistered("testDropdown", "");
-    render(dropdownComponentWithOptions);
-    const dropdown = screen.getByLabelText("test-dropdown-label");
-    expect(dropdown).toBeVisible();
-    expect(mockTrigger).toBeCalled();
   });
 
   test("DropdownField calls onChange function successfully", async () => {

--- a/services/ui-src/src/components/fields/DropdownField.tsx
+++ b/services/ui-src/src/components/fields/DropdownField.tsx
@@ -75,7 +75,7 @@ export const DropdownField = ({
   useEffect(() => {
     if (!fieldIsRegistered && !validateOnRender) {
       form.register(name);
-    } else {
+    } else if (validateOnRender) {
       form.trigger(name);
     }
   }, []);

--- a/services/ui-src/src/components/fields/NumberField.test.tsx
+++ b/services/ui-src/src/components/fields/NumberField.test.tsx
@@ -28,15 +28,6 @@ const mockGetValues = (returnValue: any) =>
     getValues: jest.fn().mockReturnValueOnce([]).mockReturnValue(returnValue),
   }));
 
-const mockFieldIsRegistered = (fieldName: string, returnValue: any) =>
-  mockUseFormContext.mockImplementation((): any => ({
-    ...mockRhfMethods,
-    getValues: jest
-      .fn()
-      .mockReturnValueOnce({ [`${fieldName}`]: returnValue })
-      .mockReturnValue(returnValue),
-  }));
-
 jest.mock("utils/auth/useUser");
 const mockedUseUser = useUser as jest.MockedFunction<typeof useUser>;
 
@@ -107,16 +98,6 @@ describe("Test Maskless NumberField", () => {
     expect(numberFieldInput.value).toEqual("123");
     await userEvent.tab();
     expect(numberFieldInput.value).toEqual("123");
-  });
-
-  test("NumberField triggers validation after first render if no value given", () => {
-    mockFieldIsRegistered("testNumberField", "");
-    const result = render(numberFieldComponent);
-    const numberFieldInput: HTMLInputElement = result.container.querySelector(
-      "[name='testNumberField']"
-    )!;
-    expect(numberFieldInput).toBeVisible();
-    expect(mockTrigger).toBeCalled();
   });
 });
 

--- a/services/ui-src/src/components/fields/NumberField.tsx
+++ b/services/ui-src/src/components/fields/NumberField.tsx
@@ -44,7 +44,7 @@ export const NumberField = ({
   useEffect(() => {
     if (!fieldIsRegistered && !validateOnRender) {
       form.register(name);
-    } else {
+    } else if (validateOnRender) {
       form.trigger(name);
     }
   }, []);

--- a/services/ui-src/src/components/fields/TextField.test.tsx
+++ b/services/ui-src/src/components/fields/TextField.test.tsx
@@ -28,15 +28,6 @@ const mockGetValues = (returnValue: any) =>
     getValues: jest.fn().mockReturnValueOnce([]).mockReturnValue(returnValue),
   }));
 
-const mockFieldIsRegistered = (fieldName: string, returnValue: any) =>
-  mockUseFormContext.mockImplementation((): any => ({
-    ...mockRhfMethods,
-    getValues: jest
-      .fn()
-      .mockReturnValueOnce({ [`${fieldName}`]: returnValue })
-      .mockReturnValue(returnValue),
-  }));
-
 jest.mock("utils/auth/useUser");
 const mockedUseUser = useUser as jest.MockedFunction<typeof useUser>;
 
@@ -68,16 +59,6 @@ describe("Test TextField component", () => {
     render(textFieldComponent);
     const textField = screen.getByText("test-label");
     expect(textField).toBeVisible();
-    jest.clearAllMocks();
-  });
-
-  test("TextField triggers validation after first render if no value given", () => {
-    mockedUseUser.mockReturnValue(mockStateUser);
-    mockFieldIsRegistered("testTextField", "");
-    render(textFieldComponent);
-    const textField = screen.getByText("test-label");
-    expect(textField).toBeVisible();
-    expect(mockTrigger).toBeCalled();
     jest.clearAllMocks();
   });
 });

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -41,7 +41,7 @@ export const TextField = ({
   useEffect(() => {
     if (!fieldIsRegistered && !validateOnRender) {
       form.register(name);
-    } else {
+    } else if (validateOnRender) {
       form.trigger(name);
     }
   }, []);

--- a/services/ui-src/src/components/forms/AdminBannerForm.test.tsx
+++ b/services/ui-src/src/components/forms/AdminBannerForm.test.tsx
@@ -6,6 +6,7 @@ import { AdminBannerForm } from "components";
 import { bannerId } from "../../constants";
 // utils
 import { convertDateTimeEtToUtc } from "utils";
+import { RouterWrappedComponent } from "utils/testing/mockRouter";
 
 const mockWriteAdminBanner = jest.fn();
 const mockWriteAdminBannerWithError = jest.fn(() => {
@@ -13,10 +14,12 @@ const mockWriteAdminBannerWithError = jest.fn(() => {
 });
 
 const adminBannerFormComponent = (writeAdminBanner: Function) => (
-  <AdminBannerForm
-    writeAdminBanner={writeAdminBanner}
-    data-testid="test-form"
-  />
+  <RouterWrappedComponent>
+    <AdminBannerForm
+      writeAdminBanner={writeAdminBanner}
+      data-testid="test-form"
+    />
+  </RouterWrappedComponent>
 );
 
 const fillOutForm = async (form: any) => {

--- a/services/ui-src/src/components/forms/AdminBannerForm.tsx
+++ b/services/ui-src/src/components/forms/AdminBannerForm.tsx
@@ -45,7 +45,14 @@ export const AdminBannerForm = ({ writeAdminBanner, ...props }: Props) => {
   return (
     <>
       <ErrorAlert error={error} sxOverride={sx.errorAlert} />
-      <Form id={form.id} formJson={form} onSubmit={onSubmit} {...props}>
+      <Form
+        id={form.id}
+        formJson={form}
+        onSubmit={onSubmit}
+        validateOnRender={false}
+        dontReset={false}
+        {...props}
+      >
         <PreviewBanner />
       </Form>
       <Flex sx={sx.previewFlex}>

--- a/services/ui-src/src/components/forms/AdminDashSelector.tsx
+++ b/services/ui-src/src/components/forms/AdminDashSelector.tsx
@@ -76,6 +76,8 @@ export const AdminDashSelector = ({ verbiage }: Props) => {
         formJson={form}
         onSubmit={onSubmit}
         onChange={onChange}
+        validateOnRender={false}
+        dontReset={false}
       />
       <Flex sx={sx.navigationButton}>
         <Button type="submit" form={formJson.id} isDisabled={!reportSelected}>

--- a/services/ui-src/src/components/forms/Form.test.tsx
+++ b/services/ui-src/src/components/forms/Form.test.tsx
@@ -7,59 +7,84 @@ import {
   mockMcparReportContext,
   mockMlrReportContext,
   mockNonFieldForm,
+  RouterWrappedComponent,
 } from "utils/testing/setupJest";
 import { ReportStatus } from "types";
 
 const mockOnSubmit = jest.fn();
 
 const formComponent = (
-  <>
-    <Form id={mockForm.id} formJson={mockForm} onSubmit={mockOnSubmit} />
+  <RouterWrappedComponent>
+    <Form
+      id={mockForm.id}
+      formJson={mockForm}
+      onSubmit={mockOnSubmit}
+      validateOnRender={false}
+      dontReset={false}
+    />
     <button form={mockForm.id} type="submit">
       Submit
     </button>
-  </>
+  </RouterWrappedComponent>
 );
 
 const formComponentJustHeader = (
-  <>
+  <RouterWrappedComponent>
     <Form
       id={mockNonFieldForm.id}
       formJson={mockNonFieldForm}
       onSubmit={mockOnSubmit}
+      validateOnRender={false}
+      dontReset={false}
     />
     <button form={mockNonFieldForm.id} type="submit">
       Submit
     </button>
-  </>
+  </RouterWrappedComponent>
 );
 
 const mlrFormSubmitted = (
-  <ReportContext.Provider
-    value={{
-      ...mockMlrReportContext,
-      report: {
-        ...mockMlrReportContext.report,
-        status: ReportStatus.SUBMITTED,
-      },
-    }}
-  >
-    <Form id={mockForm.id} formJson={mockForm} onSubmit={mockOnSubmit} />
-  </ReportContext.Provider>
+  <RouterWrappedComponent>
+    <ReportContext.Provider
+      value={{
+        ...mockMlrReportContext,
+        report: {
+          ...mockMlrReportContext.report,
+          status: ReportStatus.SUBMITTED,
+        },
+      }}
+    >
+      <Form
+        id={mockForm.id}
+        formJson={mockForm}
+        onSubmit={mockOnSubmit}
+        validateOnRender={false}
+        dontReset={false}
+      />
+    </ReportContext.Provider>
+  </RouterWrappedComponent>
 );
 
 const mcparFormSubmitted = (
-  <ReportContext.Provider
-    value={{
-      ...mockMcparReportContext,
-      report: {
-        ...mockMcparReportContext.report,
-        status: ReportStatus.SUBMITTED,
-      },
-    }}
-  >
-    <Form id={mockForm.id} formJson={mockForm} onSubmit={mockOnSubmit} />
-  </ReportContext.Provider>
+  <RouterWrappedComponent>
+    <ReportContext.Provider
+      value={{
+        ...mockMcparReportContext,
+        report: {
+          ...mockMcparReportContext.report,
+          status: ReportStatus.SUBMITTED,
+        },
+      }}
+    >
+      <Form
+        id={mockForm.id}
+        formJson={mockForm}
+        onSubmit={mockOnSubmit}
+        validateOnRender={false}
+        dontReset={false}
+      />
+    </ReportContext.Provider>
+  </RouterWrappedComponent>
 );
 
 describe("Test Form component", () => {

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -1,10 +1,11 @@
-import { ReactNode, useContext } from "react";
+import { ReactNode, useContext, useEffect } from "react";
 import {
   FieldValues,
   FormProvider,
   SubmitErrorHandler,
   useForm,
 } from "react-hook-form";
+import { useLocation } from "react-router-dom";
 import { object as yupSchema } from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
 // components
@@ -45,6 +46,7 @@ export const Form = ({
   // determine if fields should be disabled (based on admin roles )
   const { userIsAdmin, userIsReadOnly } = useUser().user ?? {};
   const { report } = useContext(ReportContext);
+  let location = useLocation();
   const fieldInputDisabled =
     ((userIsAdmin || userIsReadOnly) && formJson.adminDisabled) ||
     (report?.status === ReportStatus.SUBMITTED &&
@@ -88,6 +90,10 @@ export const Form = ({
       validateOnRender,
     });
   };
+
+  useEffect(() => {
+    form?.reset();
+  }, [location?.pathname]);
 
   return (
     <FormProvider {...form}>

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -38,6 +38,7 @@ export const Form = ({
   formData,
   validateOnRender,
   autosave,
+  dontReset,
   children,
   ...props
 }: Props) => {
@@ -92,7 +93,9 @@ export const Form = ({
   };
 
   useEffect(() => {
-    form?.reset();
+    if (!dontReset && !validateOnRender) {
+      form?.reset();
+    }
   }, [location?.pathname]);
 
   return (
@@ -114,10 +117,11 @@ interface Props {
   id: string;
   formJson: FormJson;
   onSubmit: Function;
+  validateOnRender: boolean;
+  dontReset: boolean;
   onError?: SubmitErrorHandler<FieldValues>;
   formData?: AnyObject;
   autosave?: boolean;
-  validateOnRender?: boolean;
   children?: ReactNode;
   [key: string]: any;
 }

--- a/services/ui-src/src/components/modals/AddEditEntityModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.test.tsx
@@ -12,6 +12,7 @@ import {
   mockMcparReportContext,
   mockReportKeys,
   mockStateUser,
+  RouterWrappedComponent,
 } from "utils/testing/setupJest";
 
 jest.mock("react-uuid", () => jest.fn(() => "mock-id-2"));
@@ -47,32 +48,36 @@ const mockUpdateCallPayload = {
 };
 
 const modalComponent = (
-  <ReportContext.Provider value={mockedReportContext}>
-    <AddEditEntityModal
-      entityType="accessMeasures"
-      verbiage={mockModalDrawerReportPageVerbiage}
-      form={mockModalForm}
-      modalDisclosure={{
-        isOpen: true,
-        onClose: mockCloseHandler,
-      }}
-    />
-  </ReportContext.Provider>
+  <RouterWrappedComponent>
+    <ReportContext.Provider value={mockedReportContext}>
+      <AddEditEntityModal
+        entityType="accessMeasures"
+        verbiage={mockModalDrawerReportPageVerbiage}
+        form={mockModalForm}
+        modalDisclosure={{
+          isOpen: true,
+          onClose: mockCloseHandler,
+        }}
+      />
+    </ReportContext.Provider>
+  </RouterWrappedComponent>
 );
 
 const modalComponentWithSelectedEntity = (
-  <ReportContext.Provider value={mockedReportContext}>
-    <AddEditEntityModal
-      entityType="accessMeasures"
-      selectedEntity={mockEntity}
-      verbiage={mockModalDrawerReportPageVerbiage}
-      form={mockModalForm}
-      modalDisclosure={{
-        isOpen: true,
-        onClose: mockCloseHandler,
-      }}
-    />
-  </ReportContext.Provider>
+  <RouterWrappedComponent>
+    <ReportContext.Provider value={mockedReportContext}>
+      <AddEditEntityModal
+        entityType="accessMeasures"
+        selectedEntity={mockEntity}
+        verbiage={mockModalDrawerReportPageVerbiage}
+        form={mockModalForm}
+        modalDisclosure={{
+          isOpen: true,
+          onClose: mockCloseHandler,
+        }}
+      />
+    </ReportContext.Provider>
+  </RouterWrappedComponent>
 );
 
 describe("Test AddEditEntityModal", () => {

--- a/services/ui-src/src/components/modals/AddEditEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.tsx
@@ -123,6 +123,8 @@ export const AddEditEntityModal = ({
             ? modalDisclosure.onClose
             : writeEntity
         }
+        validateOnRender={false}
+        dontReset={true}
       />
       <Text sx={sx.bottomModalMessage}>{verbiage.addEditModalMessage}</Text>
     </Modal>

--- a/services/ui-src/src/components/modals/AddEditReportModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.test.tsx
@@ -8,6 +8,7 @@ import {
   mockMcparReport,
   mockMcparReportContext,
   mockReportJson,
+  RouterWrappedComponent,
 } from "utils/testing/setupJest";
 
 const mockCreateReport = jest.fn();
@@ -23,63 +24,71 @@ const mockedReportContext = {
 };
 
 const modalComponent = (
-  <ReportContext.Provider value={mockedReportContext}>
-    <AddEditReportModal
-      activeState="AB"
-      selectedReport={undefined}
-      reportType={"MCPAR"}
-      formTemplate={mockReportJson}
-      modalDisclosure={{
-        isOpen: true,
-        onClose: mockCloseHandler,
-      }}
-    />
-  </ReportContext.Provider>
+  <RouterWrappedComponent>
+    <ReportContext.Provider value={mockedReportContext}>
+      <AddEditReportModal
+        activeState="AB"
+        selectedReport={undefined}
+        reportType={"MCPAR"}
+        formTemplate={mockReportJson}
+        modalDisclosure={{
+          isOpen: true,
+          onClose: mockCloseHandler,
+        }}
+      />
+    </ReportContext.Provider>
+  </RouterWrappedComponent>
 );
 
 const modalComponentWithSelectedReport = (
-  <ReportContext.Provider value={mockedReportContext}>
-    <AddEditReportModal
-      activeState="AB"
-      selectedReport={mockMcparReport}
-      reportType={"MCPAR"}
-      formTemplate={mockReportJson}
-      modalDisclosure={{
-        isOpen: true,
-        onClose: mockCloseHandler,
-      }}
-    />
-  </ReportContext.Provider>
+  <RouterWrappedComponent>
+    <ReportContext.Provider value={mockedReportContext}>
+      <AddEditReportModal
+        activeState="AB"
+        selectedReport={mockMcparReport}
+        reportType={"MCPAR"}
+        formTemplate={mockReportJson}
+        modalDisclosure={{
+          isOpen: true,
+          onClose: mockCloseHandler,
+        }}
+      />
+    </ReportContext.Provider>
+  </RouterWrappedComponent>
 );
 
 const mlrModalComponent = (
-  <ReportContext.Provider value={mockedReportContext}>
-    <AddEditReportModal
-      activeState="AB"
-      selectedReport={undefined}
-      reportType={"MLR"}
-      formTemplate={mockReportJson}
-      modalDisclosure={{
-        isOpen: true,
-        onClose: mockCloseHandler,
-      }}
-    />
-  </ReportContext.Provider>
+  <RouterWrappedComponent>
+    <ReportContext.Provider value={mockedReportContext}>
+      <AddEditReportModal
+        activeState="AB"
+        selectedReport={undefined}
+        reportType={"MLR"}
+        formTemplate={mockReportJson}
+        modalDisclosure={{
+          isOpen: true,
+          onClose: mockCloseHandler,
+        }}
+      />
+    </ReportContext.Provider>
+  </RouterWrappedComponent>
 );
 
 const mlrModalComponentWithSelectedReport = (
-  <ReportContext.Provider value={mockedReportContext}>
-    <AddEditReportModal
-      activeState="AB"
-      selectedReport={mockMcparReport}
-      reportType={"MLR"}
-      formTemplate={mockReportJson}
-      modalDisclosure={{
-        isOpen: true,
-        onClose: mockCloseHandler,
-      }}
-    />
-  </ReportContext.Provider>
+  <RouterWrappedComponent>
+    <ReportContext.Provider value={mockedReportContext}>
+      <AddEditReportModal
+        activeState="AB"
+        selectedReport={mockMcparReport}
+        reportType={"MLR"}
+        formTemplate={mockReportJson}
+        modalDisclosure={{
+          isOpen: true,
+          onClose: mockCloseHandler,
+        }}
+      />
+    </ReportContext.Provider>
+  </RouterWrappedComponent>
 );
 
 describe("Test AddEditProgramModal", () => {

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -161,6 +161,8 @@ export const AddEditReportModal = ({
         formJson={form}
         formData={selectedReport?.fieldData}
         onSubmit={writeReport}
+        validateOnRender={false}
+        dontReset={true}
       />
     </Modal>
   );

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlay.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlay.tsx
@@ -139,7 +139,8 @@ export const EntityDetailsOverlay = ({
           formData={selectedEntity}
           autosave={true}
           disabled={!userIsEndUser}
-          validateOnRender={validateOnRender}
+          validateOnRender={validateOnRender || false}
+          dontReset={false}
         />
         <Box sx={sx.footerBox}>
           <Flex sx={sx.buttonFlex}>

--- a/services/ui-src/src/components/reports/StandardReportPage.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.tsx
@@ -71,7 +71,8 @@ export const StandardReportPage = ({ route, validateOnRender }: Props) => {
         onError={onError}
         formData={report?.fieldData}
         autosave
-        validateOnRender={validateOnRender}
+        validateOnRender={validateOnRender || false}
+        dontReset={false}
       />
       <ReportPageFooter
         submitting={submitting}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->

Going between 2 pages of the same type would trigger validation during the same user session. This is ideal from a UX perspective but if I user goes between 2 different page types, like a ModalDrawer or ModalOverlay and then a StandardPageType, validation wouldn't trigger. This leads to an experience that isn't standard and inconsistant. We've decided to remove the validation triggering between the same page type and to only have it trigger from Review and Submit for now. Going forward we'll reimplement this in a standard way.

Initial bug:

https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/19439679/24acf0d1-0f07-4abb-9cf3-3934fd54627c


New Fix:

https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/19439679/f330e634-6588-4f64-a106-18c42ae7f6c9


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2712

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Create a MCPAR Report
Go between multiple pages and see that no validation triggers just by visiting it.
Clicking a page in Review and Submit page, however, does trigger validation and calls it out until a user updates those fields.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---
