### PR TITLE
Logout Cypress Header fix

### DIFF
--- a/tests/cypress/support/step_definitions/navigation.js
+++ b/tests/cypress/support/step_definitions/navigation.js
@@ -29,3 +29,7 @@ When("the element described by {string} is clicked", (selector) => {
 Then("the {string} page is loaded", (uri) => {
   cy.url().should("include", uri);
 });
+
+When("I wait {int} ms before continuing", (ms) => {
+  cy.wait(ms);
+});

--- a/tests/cypress/tests/e2e/header.feature
+++ b/tests/cypress/tests/e2e/header.feature
@@ -22,6 +22,8 @@ Feature: Header
 
         When the element described by "[aria-label='my account']" is clicked
         And the element described by "[data-testid='header-menu-option-log-out']" is clicked
+        And I wait 3000 ms before continuing
+        And I visit "/"
         Then the "/" page is loaded
         And the following element states are validated:
             | [data-testid='cognito-login-button'] | be.visible |

--- a/tests/cypress/yarn.lock
+++ b/tests/cypress/yarn.lock
@@ -1130,11 +1130,6 @@
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
 
-"@cypress/xpath@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@cypress/xpath/-/xpath-2.0.3.tgz#9a631d12cb935ba493fd30290163bde54c3c1428"
-  integrity sha512-Seilxmws+yty5lZSbwbjEOOiEbr7O1bCxKy2FC4jwMssC22yjByb5orDfBZPLZXYfmWZafJjvZFwts4Q3CzQAg==
-
 "@cypress/xvfb@^1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@cypress/xvfb/-/xvfb-1.2.4.tgz#2daf42e8275b39f4aa53c14214e557bd14e7748a"
@@ -2159,11 +2154,6 @@ cypress-tags@^1.1.2:
     "@cypress/browserify-preprocessor" "^3.0.1"
     boolean-parser "0.0.2"
     through "^2.3.8"
-
-cypress-wait-until@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz#7f534dd5a11c89b65359e7a0210f20d3dfc22107"
-  integrity sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==
 
 cypress@^12.5.1:
   version "12.6.0"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The header cypress test gets lost after logout navigates it to IDM in deployed environments. Just wait for the logout to flush through and nav back to "/" to resolve any cross origin issues.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2638

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
