### PR TITLE
Redirect fix for IDM login

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -166,7 +166,7 @@ resources:
         DefaultRedirectURI: ${self:custom.application_endpoint_url}
         LogoutURLs:
           - ${self:custom.application_endpoint_url}
-          - ${self:custom.application_endpoint_url}/postLogout
+          - ${self:custom.application_endpoint_url}postLogout
           - http://localhost:3000/
           - http://localhost:3000/postLogout
         SupportedIdentityProviders:

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -166,7 +166,9 @@ resources:
         DefaultRedirectURI: ${self:custom.application_endpoint_url}
         LogoutURLs:
           - ${self:custom.application_endpoint_url}
+          - "${self:custom.application_endpoint_url}/postLogout"
           - http://localhost:3000/
+          - http://localhost:3000/postLogout
         SupportedIdentityProviders:
           - Fn::If:
               - BackWithOktaOIDC

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -166,7 +166,7 @@ resources:
         DefaultRedirectURI: ${self:custom.application_endpoint_url}
         LogoutURLs:
           - ${self:custom.application_endpoint_url}
-          - "${self:custom.application_endpoint_url}/postLogout"
+          - ${self:custom.application_endpoint_url}/postLogout
           - http://localhost:3000/
           - http://localhost:3000/postLogout
         SupportedIdentityProviders:

--- a/services/ui-src/scripts/configure-local.sh
+++ b/services/ui-src/scripts/configure-local.sh
@@ -41,7 +41,7 @@ export COGNITO_USER_POOL_ID=$cognito_user_pool_id
 export COGNITO_USER_POOL_CLIENT_ID=$cognito_user_pool_client_id
 export COGNITO_USER_POOL_CLIENT_DOMAIN=$cognito_user_pool_client_domain
 export COGNITO_REDIRECT_SIGNIN=http://localhost:3000/
-export COGNITO_REDIRECT_SIGNOUT=http://localhost:3000/
+export COGNITO_REDIRECT_SIGNOUT=http://localhost:3000/postLogout
 export S3_ATTACHMENTS_BUCKET_REGION=$s3_attachments_bucket_region
 export S3_ATTACHMENTS_BUCKET_NAME=$s3_attachements_bucket_name
 # This is set to false, as using this script points your local react server to Amazon

--- a/services/ui-src/serverless.yml
+++ b/services/ui-src/serverless.yml
@@ -44,7 +44,7 @@ custom:
   ui_cloudfront_distribution_id: ${cf:ui-${self:custom.stage}.CloudFrontDistributionId}
   application_endpoint_url: ${cf:ui-${self:custom.stage}.ApplicationEndpointUrl}
   signout_redirect_url: ${env:POST_SIGNOUT_REDIRECT, ssm:/configuration/${self:custom.stage}/cognito/redirectSignout, ssm:/configuration/default/cognito/redirectSignout}
-  application_signout_url: "${application_endpoint_url}/postLogout"
+  application_signout_url: ${self:custom.application_endpoint_url}/postLogout
   s3Sync:
     - bucketName: ${self:custom.ui_s3_bucket_name}
       localDir: ./build

--- a/services/ui-src/serverless.yml
+++ b/services/ui-src/serverless.yml
@@ -44,6 +44,7 @@ custom:
   ui_cloudfront_distribution_id: ${cf:ui-${self:custom.stage}.CloudFrontDistributionId}
   application_endpoint_url: ${cf:ui-${self:custom.stage}.ApplicationEndpointUrl}
   signout_redirect_url: ${env:POST_SIGNOUT_REDIRECT, ssm:/configuration/${self:custom.stage}/cognito/redirectSignout, ssm:/configuration/default/cognito/redirectSignout}
+  application_signout_url: "${application_endpoint_url}/postLogout"
   s3Sync:
     - bucketName: ${self:custom.ui_s3_bucket_name}
       localDir: ./build
@@ -69,7 +70,7 @@ custom:
         export COGNITO_IDP_NAME=${self:custom.cognito_idp_name}
         export COGNITO_IDP=${self:custom.cognito_idp}
         export COGNITO_REDIRECT_SIGNIN=${self:custom.application_endpoint_url}
-        export COGNITO_REDIRECT_SIGNOUT=${self:custom.application_endpoint_url}
+        export COGNITO_REDIRECT_SIGNOUT=${self:custom.application_signout_url}
         export POST_SIGNOUT_REDIRECT=${self:custom.signout_redirect_url}
         export REACT_APP_LD_SDK_CLIENT=${self:custom.ldSdkClient}
         export S3_ATTACHMENTS_BUCKET_REGION=${self:custom.s3_attachments_bucket_region}

--- a/services/ui-src/serverless.yml
+++ b/services/ui-src/serverless.yml
@@ -44,7 +44,7 @@ custom:
   ui_cloudfront_distribution_id: ${cf:ui-${self:custom.stage}.CloudFrontDistributionId}
   application_endpoint_url: ${cf:ui-${self:custom.stage}.ApplicationEndpointUrl}
   signout_redirect_url: ${env:POST_SIGNOUT_REDIRECT, ssm:/configuration/${self:custom.stage}/cognito/redirectSignout, ssm:/configuration/default/cognito/redirectSignout}
-  application_signout_url: ${self:custom.application_endpoint_url}/postLogout
+  application_signout_url: ${self:custom.application_endpoint_url}postLogout
   s3Sync:
     - bucketName: ${self:custom.ui_s3_bucket_name}
       localDir: ./build

--- a/services/ui-src/src/components/PostLogoutRedirect/index.tsx
+++ b/services/ui-src/src/components/PostLogoutRedirect/index.tsx
@@ -1,0 +1,6 @@
+import config from "config";
+
+export const PostLogoutRedirect = () => {
+  window.location.href = config.POST_SIGNOUT_REDIRECT;
+  return <></>;
+};

--- a/services/ui-src/src/components/app/App.tsx
+++ b/services/ui-src/src/components/app/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, Route, Routes } from "react-router-dom";
 import { ErrorBoundary } from "react-error-boundary";
 // components
 import { Container, Divider, Flex, Heading, Stack } from "@chakra-ui/react";
@@ -14,6 +14,7 @@ import {
   ReportProvider,
   SkipNav,
   Timeout,
+  PostLogoutRedirect,
 } from "components";
 // utils
 import {
@@ -35,8 +36,8 @@ export const App = () => {
     fireTealiumPageView(user, window.location.href, pathname, isReportPage);
   }, [key]);
 
-  return (
-    <div id="app-wrapper" className={mqClasses}>
+  const authenticatedRoutes = (
+    <>
       {user && (
         <Flex sx={sx.appLayout}>
           <Timeout />
@@ -74,6 +75,15 @@ export const App = () => {
           </Container>
         </main>
       )}
+    </>
+  );
+
+  return (
+    <div id="app-wrapper" className={mqClasses}>
+      <Routes>
+        <Route path="*" element={authenticatedRoutes} />
+        <Route path="postLogout" element={<PostLogoutRedirect />} />
+      </Routes>
     </div>
   );
 };

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -108,3 +108,5 @@ export { MobileEntityRow } from "./tables/MobileEntityRow";
 export { EntityStatusIcon } from "./tables/EntityStatusIcon";
 // widgets
 export { SpreadsheetWidget } from "./widgets/SpreadsheetWidget";
+// redirects
+export { PostLogoutRedirect } from "./PostLogoutRedirect";

--- a/services/ui-src/src/utils/auth/UserProvider.tsx
+++ b/services/ui-src/src/utils/auth/UserProvider.tsx
@@ -52,6 +52,12 @@ export const UserProvider = ({ children }: Props) => {
   }, []);
 
   const checkAuthState = useCallback(async () => {
+    // Allow Post Logout flow alongside user login flow
+    if (location?.pathname.toLowerCase() === "/postlogout") {
+      window.location.href = config.POST_SIGNOUT_REDIRECT;
+      return;
+    }
+
     try {
       const session = await Auth.currentSession();
       const payload = session.getIdToken().payload;
@@ -100,7 +106,7 @@ export const UserProvider = ({ children }: Props) => {
         setShowLocalLogins(true);
       }
     }
-  }, [isProduction]);
+  }, [isProduction, location]);
 
   // single run configuration
   useEffect(() => {


### PR DESCRIPTION
### Description
Create an endpoint to handle redirect on successful logout, and all the config that is required.
The endpoint exists outside the normal auth gates, so returning to it doesn't trap you in an endless loop in prod.

* This is similar to the fix that was done on QMR. https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/1911

---
### How to test



### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
