### PR TITLE
Sechub fix

### DIFF
--- a/.github/workflows/schedule-jira-sync.yml
+++ b/.github/workflows/schedule-jira-sync.yml
@@ -19,10 +19,10 @@ jobs:
         os: [ubuntu-latest]
         node-version: [18.x]
     steps:
-      # - name: Use Node.js ${{ matrix.node-version }}
-      #   uses: actions/setup-node@v2
-      #   with:
-      #     node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
       - name: Check out repo
         uses: actions/checkout@v3
       - name: Configure AWS credentials
@@ -30,10 +30,6 @@ jobs:
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.PRODUCTION_SYNC_OIDC_ROLE }}
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
       - name: Sync Security Hub and Jira
         uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v1.0.2
         with:

--- a/.github/workflows/schedule-jira-sync.yml
+++ b/.github/workflows/schedule-jira-sync.yml
@@ -15,9 +15,6 @@ jobs:
     name: Run sync
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
       - name: Check out repo
         uses: actions/checkout@v3
       - name: Configure AWS credentials
@@ -26,6 +23,9 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.PRODUCTION_SYNC_OIDC_ROLE }}
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - name: Sync Security Hub and Jira
         uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v1.0.2
         with:

--- a/.github/workflows/schedule-jira-sync.yml
+++ b/.github/workflows/schedule-jira-sync.yml
@@ -23,12 +23,13 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.PRODUCTION_SYNC_OIDC_ROLE }}
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
+      # - uses: actions/setup-node@v3
+      #   with:
+      #     node-version: 18
       - name: Sync Security Hub and Jira
         uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v1.0.2
         with:
+          node-version: 18
           jira-token: ${{ secrets.JIRA_SERVICE_USER_TOKEN }}
           jira-username: ${{ secrets.JIRA_SERVICE_USERNAME }}
           jira-host: qmacbis.atlassian.net

--- a/.github/workflows/schedule-jira-sync.yml
+++ b/.github/workflows/schedule-jira-sync.yml
@@ -13,16 +13,16 @@ permissions:
 jobs:
   sync:
     name: Run sync
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        node-version: [18.x]
+    runs-on: ubuntu:latest
+    # strategy:
+    #   matrix:
+    #     os: [ubuntu-latest]
+    #     node-version: [18.x]
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
+      # - name: Use Node.js ${{ matrix.node-version }}
+      #   uses: actions/setup-node@v2
+      #   with:
+      #     node-version: ${{ matrix.node-version }}
       - name: Check out repo
         uses: actions/checkout@v3
       - name: Configure AWS credentials

--- a/.github/workflows/schedule-jira-sync.yml
+++ b/.github/workflows/schedule-jira-sync.yml
@@ -13,16 +13,12 @@ permissions:
 jobs:
   sync:
     name: Run sync
-    runs-on: ubuntu:latest
-    # strategy:
-    #   matrix:
-    #     os: [ubuntu-latest]
-    #     node-version: [18.x]
+    runs-on: ubuntu-20.04
     steps:
-      # - name: Use Node.js ${{ matrix.node-version }}
-      #   uses: actions/setup-node@v2
-      #   with:
-      #     node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
       - name: Check out repo
         uses: actions/checkout@v3
       - name: Configure AWS credentials
@@ -31,7 +27,7 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.PRODUCTION_SYNC_OIDC_ROLE }}
       - name: Sync Security Hub and Jira
-        uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v1.0.2
+        uses: Enterprise-CMCS/mac-fc-security-hub-visibility-enterprise-jira@v1.1.0
         with:
           jira-token: ${{ secrets.JIRA_SERVICE_USER_TOKEN }}
           jira-username: ${{ secrets.JIRA_SERVICE_USERNAME }}

--- a/.github/workflows/schedule-jira-sync.yml
+++ b/.github/workflows/schedule-jira-sync.yml
@@ -15,10 +15,6 @@ jobs:
     name: Run sync
     runs-on: ubuntu-20.04
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
       - name: Check out repo
         uses: actions/checkout@v3
       - name: Configure AWS credentials
@@ -26,8 +22,9 @@ jobs:
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.PRODUCTION_SYNC_OIDC_ROLE }}
+
       - name: Sync Security Hub and Jira
-        uses: Enterprise-CMCS/mac-fc-security-hub-visibility-enterprise-jira@v1.1.0
+        uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v1.0.3
         with:
           jira-token: ${{ secrets.JIRA_SERVICE_USER_TOKEN }}
           jira-username: ${{ secrets.JIRA_SERVICE_USERNAME }}

--- a/.github/workflows/schedule-jira-sync.yml
+++ b/.github/workflows/schedule-jira-sync.yml
@@ -1,11 +1,9 @@
 name: Sync Security Hub findings and Jira issues
 
 on:
-  push
-# on:
-#   workflow_dispatch: # for testing and manual runs
-#   schedule:
-#     - cron: "25 1 * * *" # daily at 6:25 am EST
+  workflow_dispatch: # for testing and manual runs
+  schedule:
+    - cron: "25 1 * * *" # daily at 6:25 am EST
 
 permissions:
   id-token: write

--- a/.github/workflows/schedule-jira-sync.yml
+++ b/.github/workflows/schedule-jira-sync.yml
@@ -1,9 +1,11 @@
 name: Sync Security Hub findings and Jira issues
 
 on:
-  workflow_dispatch: # for testing and manual runs
-  schedule:
-    - cron: "25 1 * * *" # daily at 6:25 am EST
+  push
+# on:
+#   workflow_dispatch: # for testing and manual runs
+#   schedule:
+#     - cron: "25 1 * * *" # daily at 6:25 am EST
 
 permissions:
   id-token: write
@@ -13,6 +15,9 @@ jobs:
     name: Run sync
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - name: Check out repo
         uses: actions/checkout@v3
       - name: Configure AWS credentials

--- a/.github/workflows/schedule-jira-sync.yml
+++ b/.github/workflows/schedule-jira-sync.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   sync:
     name: Run sync
-    runs-on: ubuntu-20.04
+    #runs-on: ubuntu-20.04
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
@@ -23,13 +23,12 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.PRODUCTION_SYNC_OIDC_ROLE }}
 
-      # - uses: actions/setup-node@v3
-      #   with:
-      #     node-version: 18
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - name: Sync Security Hub and Jira
         uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v1.0.2
         with:
-          node-version: 18
           jira-token: ${{ secrets.JIRA_SERVICE_USER_TOKEN }}
           jira-username: ${{ secrets.JIRA_SERVICE_USERNAME }}
           jira-host: qmacbis.atlassian.net

--- a/.github/workflows/schedule-jira-sync.yml
+++ b/.github/workflows/schedule-jira-sync.yml
@@ -13,8 +13,16 @@ permissions:
 jobs:
   sync:
     name: Run sync
-    #runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [18.x]
     steps:
+      # - name: Use Node.js ${{ matrix.node-version }}
+      #   uses: actions/setup-node@v2
+      #   with:
+      #     node-version: ${{ matrix.node-version }}
       - name: Check out repo
         uses: actions/checkout@v3
       - name: Configure AWS credentials


### PR DESCRIPTION
### Description
Upgrade Security Hub Visibility version to 1.0.3 to fix build issue


### Related ticket(s)


---
### How to test
Run the pipeline by modifying .github/workflows/schedule-jira-sync.yml to run on push. No longer displaying the node version error.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
