### PR TITLE
MDCT-2784: PDF Issue w/ "Other, specify" Text

### DIFF
--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -143,8 +143,7 @@ export const renderResponseData = (
     return renderChoiceListFieldResponse(
       formField,
       fieldResponseData,
-      widerResponseData,
-      pageType
+      widerResponseData
     );
   }
   // check for and handle link fields (email, url)
@@ -157,9 +156,7 @@ export const renderResponseData = (
 export const renderChoiceListFieldResponse = (
   formField: FormField,
   fieldResponseData: AnyObject,
-  widerResponseData: AnyObject,
-  pageType: string,
-  entityIndex?: number
+  widerResponseData: AnyObject
 ) => {
   // filter potential choices to just those that are selected
   const potentialFieldChoices = formField.props?.choices;
@@ -170,22 +167,30 @@ export const renderChoiceListFieldResponse = (
       );
     }
   );
-  const choicesToDisplay = selectedChoices?.map((choice: FieldChoice) => {
-    // get related "otherText" value, if present (always only a single child element here)
-    const firstChildId = choice?.children?.[0]?.id!;
-    const shouldDisplayRelatedOtherTextEntry =
-      choice.children?.[0]?.id.endsWith("-otherText");
-    const relatedOtherTextEntry =
-      pageType === "drawer"
-        ? widerResponseData[entityIndex!]?.[firstChildId]
-        : widerResponseData?.[firstChildId];
-    return (
-      <Text key={choice.id} sx={sx.fieldChoice}>
-        {choice.label}
-        {shouldDisplayRelatedOtherTextEntry && " – " + relatedOtherTextEntry}
-      </Text>
-    );
-  });
+
+  let choicesToDisplay;
+  // handle "other text" case
+  if (fieldResponseData[0].value === "Other, specify") {
+    choicesToDisplay = widerResponseData?.map((choice: FieldChoice) => {
+      // get related "otherText" value, if present (always only a single child element here)
+      const childId: string = fieldResponseData[0].key;
+      const choiceId =
+        childId.substring(0, childId.indexOf("-")) + "-otherText";
+      return (
+        <Text key={choice.id} sx={sx.fieldChoice}>
+          Other, specify - {choice[choiceId as keyof FieldChoice]}
+        </Text>
+      );
+    });
+  } else {
+    choicesToDisplay = selectedChoices?.map((choice: FieldChoice) => {
+      return (
+        <Text key={choice.id} sx={sx.fieldChoice}>
+          {choice.label}
+        </Text>
+      );
+    });
+  }
   return choicesToDisplay;
 };
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Currently this bug occurs a user has multiple entities (plans or BSS) then selects "Other, specify" and adds text: the generated PDF does not retain user-input text, it just shows `undefined`

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2784

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Generate a new MCPAR report
- Add two (2) plans
- Navigate to Question D1.II.1b under `Financial performance` 
- Select `Other, specify` and input text (do this for both plans)
- Generate a PDF, find that question

You should see the input text correctly.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
