### PR TITLE
MDCT-2784: PDF Issue w/ "Other, specify" Text

### DIFF
--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -88,7 +88,7 @@ export const renderDrawerDataCell = (
   pageType: string,
   parentFieldCheckedChoiceIds?: string[]
 ) =>
-  entityResponseData?.map((entity: EntityShape) => {
+  entityResponseData?.map((entity: EntityShape, index: number) => {
     const notApplicable =
       parentFieldCheckedChoiceIds &&
       !parentFieldCheckedChoiceIds?.includes(entity.id);
@@ -105,7 +105,8 @@ export const renderDrawerDataCell = (
               fieldResponseData,
               entityResponseData,
               pageType,
-              notApplicable
+              notApplicable,
+              index
             )}
           </li>
         </ul>
@@ -125,7 +126,8 @@ export const renderResponseData = (
   fieldResponseData: any,
   widerResponseData: AnyObject,
   pageType: string,
-  notApplicable?: boolean
+  notApplicable?: boolean,
+  entityIndex?: number
 ) => {
   const isChoiceListField = ["checkbox", "radio"].includes(formField.type);
   // check for and handle no response
@@ -144,7 +146,8 @@ export const renderResponseData = (
       formField,
       fieldResponseData,
       widerResponseData,
-      pageType
+      pageType,
+      entityIndex!
     );
   }
   // check for and handle link fields (email, url)
@@ -159,7 +162,7 @@ export const renderChoiceListFieldResponse = (
   fieldResponseData: AnyObject,
   widerResponseData: AnyObject,
   pageType: string,
-  entityIndex?: number
+  entityIndex: number
 ) => {
   // filter potential choices to just those that are selected
   const potentialFieldChoices = formField.props?.choices;
@@ -177,7 +180,7 @@ export const renderChoiceListFieldResponse = (
       choice.children?.[0]?.id.endsWith("-otherText");
     const relatedOtherTextEntry =
       pageType === "drawer"
-        ? widerResponseData[entityIndex!]?.[firstChildId]
+        ? widerResponseData[entityIndex]?.[firstChildId]
         : widerResponseData?.[firstChildId];
     return (
       <Text key={choice.id} sx={sx.fieldChoice}>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Currently this bug occurs a user has multiple entities (plans or BSS) then selects "Other, specify" and adds text: the generated PDF does not retain user-input text, it just shows `undefined`

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2784

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Generate a new MCPAR report
- Add two (2) plans
- Navigate to Question D1.II.1b under `Financial performance` 
- Select `Other, specify` and input text (do this for both plans)
- Generate a PDF, find that question

You should see the input text correctly.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_