### PR TITLE
get continuation tokens from scanning the templates

### DIFF
--- a/services/app-api/utils/s3/s3-lib.ts
+++ b/services/app-api/utils/s3/s3-lib.ts
@@ -63,20 +63,33 @@ export default {
       });
     });
   },
-  list: async (params: S3.ListObjectsRequest) => {
-    return new Promise<S3.ObjectList>((resolve, reject) => {
-      s3Client.listObjects(
-        params,
-        function (err: any, result: S3.ListObjectsOutput) {
-          if (err) {
-            reject(err);
-          }
-          if (result) {
-            resolve(result.Contents ?? []);
-          }
+  list: async (params: S3.ListObjectsV2Request) => {
+    let continuationToken: S3.Token | undefined;
+    const s3Objects: S3.ObjectList = [];
+
+    do {
+      const response = await new Promise<S3.ListObjectsV2Output>(
+        (resolve, reject) => {
+          s3Client.listObjectsV2(
+            { ...params, ContinuationToken: continuationToken },
+            function (err: any, result: S3.ListObjectsV2Output) {
+              if (err) {
+                reject(err);
+              }
+              if (result) {
+                resolve(result);
+              }
+            }
+          );
         }
       );
-    });
+      if (response.Contents) {
+        s3Objects.push(...response.Contents);
+      }
+      continuationToken = response.NextContinuationToken;
+    } while (continuationToken);
+
+    return s3Objects;
   },
 };
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
S3 lib scans are paginated. Iterate when provided with a continuation token. The function is not used anywhere else atm, so only the population script is impacted.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
