### PR TITLE
Add a fallback route for MLR

### DIFF
--- a/services/ui-src/src/components/app/AppRoutes.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.tsx
@@ -161,6 +161,20 @@ export const AppRoutes = () => {
                   />
                 </>
               )}
+              <Route
+                path="/mlr/*"
+                element={
+                  !contextIsLoaded ? (
+                    <Flex sx={sx.spinnerContainer}>
+                      <Spinner size="lg" />
+                    </Flex>
+                  ) : userReportAccess["MLR"] ? (
+                    <Navigate to="/mlr" />
+                  ) : (
+                    <Navigate to="/" />
+                  )
+                }
+              />
             </Fragment>
           )}
         </Routes>


### PR DESCRIPTION
### Description
When a user navigates to `/mlr/anything`, a report may need to be fetched from the API before we can determine whether they are on a valid route. This can result in a flash of an error message, even for routes that are ultimately correct & valid.

This issue was addressed for MCPAR by adjusting the fallback route, to display a spinner until the report has been fetched.

This PR applies the same fix to MLR.

### Related ticket(s)
This _should_ fix MDCT-2800.

---
### How to test
1. Enter an MLR report
2. Attempt to export it - did an error message flash on the screen before showing the exported data?
3. Attempt to refresh the page - did an error message flash here either?

### Important updates
n/a

---
### Author checklist

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
