### PR TITLE
Show sidebar when user clicks backbutton on an overlay page

### DIFF
--- a/services/ui-src/src/components/reports/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/reports/ReportPageWrapper.tsx
@@ -46,9 +46,14 @@ export const ReportPageWrapper = () => {
     }
   }, [report, reportId, reportState]);
 
+  const showSidebar = () => {
+    if (sidebarHidden) setSidebarHidden(false);
+  };
+
   const renderPageSection = (route: ReportRoute) => {
     switch (route.pageType) {
       case PageTypes.DRAWER:
+        showSidebar();
         return (
           <DrawerReportPage
             route={route as DrawerReportPageShape}
@@ -56,6 +61,7 @@ export const ReportPageWrapper = () => {
           />
         );
       case PageTypes.MODAL_DRAWER:
+        showSidebar();
         return (
           <ModalDrawerReportPage
             route={route as ModalDrawerReportPageShape}
@@ -71,8 +77,10 @@ export const ReportPageWrapper = () => {
           />
         );
       case PageTypes.REVIEW_SUBMIT:
+        showSidebar();
         return <ReviewSubmitPage />;
       default:
+        showSidebar();
         return (
           <StandardReportPage
             route={route as StandardReportPageShape}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->

https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/19439679/14e7c4c3-3aef-4708-8c2a-fe1ac04953b0

The sidebar doesn't show if a user click the browser's back button when they are inside the overlay. This fixes it so that a user who navigates away gets the sidebar back!

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Create an mlr report
Add something on the overlay page
Enter that overlay
click the back button, not the inpage back link
See that the sidebar is now there!

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary