### PR TITLE
Do not select a report when archiving it

### DIFF
--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -132,8 +132,7 @@ export const ReportProvider = ({ children }: Props) => {
 
   const archiveReport = async (reportKeys: ReportKeys) => {
     try {
-      const result = await archiveReportRequest(reportKeys);
-      hydrateAndSetReport(result);
+      await archiveReportRequest(reportKeys);
       setLastSavedTime(getLocalHourMinuteTime());
     } catch (e: any) {
       setError(reportErrors.SET_REPORT_FAILED);


### PR DESCRIPTION
### Description
This PR fixes a UI issue when archiving reports. Despite the archival being successful, users were shown an error message that an error occurred.

This error was entirely inconsequential; we were calling `hydrateAndSetReport()` in the ReportProvider, after the API call succeeded. That function expects the report to have a form template, which is not returned from the archive API call.

Rather than accounting for this edge case, we can just skip this call. Archiving a report does not imply that the report needs to be selected; the user will still be on the report dashboard, which refreshes to show the updated status of the archived report regardless.

### Related ticket(s)
MDCT-2821

---
### How to test
1. Create a report (MCPAR or MLR, it doesn't matter)
2. Log in as an admin user
3. Archive the report - note that it is archived, and you did not see an error on the page
4. Unarchive the report - note that it is no longer archived, and you did not see an error on the page

### Important updates
n/a

---
### Author checklist

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
