### PR TITLE
Switch order of - and $ in currency fields in PDF

### DIFF
--- a/services/ui-src/src/utils/other/mask.test.ts
+++ b/services/ui-src/src/utils/other/mask.test.ts
@@ -171,9 +171,14 @@ describe("Test maskResponseData", () => {
     expect(result).toEqual("12%");
   });
 
-  test("Currency mask works correctly", () => {
+  test("Currency mask works correctly on positive number", () => {
     const result = maskResponseData("12", "currency");
     expect(result).toEqual("$12");
+  });
+
+  test("Currency mask works correctly on negative number", () => {
+    const result = maskResponseData("-12", "currency");
+    expect(result).toEqual("-$12");
   });
 
   test("Standard field is not masked", () => {

--- a/services/ui-src/src/utils/other/mask.tsx
+++ b/services/ui-src/src/utils/other/mask.tsx
@@ -41,6 +41,9 @@ export function maskResponseData(
     case "percentage":
       return maskValue + "%";
     case "currency":
+      if (numericValue < 0) {
+        return "-$" + maskValue.substring(1);
+      }
       return "$" + maskValue;
     case "ratio": {
       let sidesOfRatio = fieldResponseData.split(":");


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Negative currency values were being displayed as $-123.45, with this change they will be displayed as -$123.45

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2825

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Login 
- Fill out a currency field 
- Review PDF version of form 
- Confirm correct order of symbols
<img width="417" alt="Screenshot 2023-08-22 at 9 13 54 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/6752256/84e24386-a34c-442d-83d7-6ba77f84cada">


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
