### PR TITLE
Prevent the superfluous error message on MLR unlock

### DIFF
--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -146,8 +146,7 @@ export const ReportProvider = ({ children }: Props) => {
 
   const releaseReport = async (reportKeys: ReportKeys) => {
     try {
-      const result = await releaseReportRequest(reportKeys);
-      hydrateAndSetReport(result);
+      await releaseReportRequest(reportKeys);
     } catch (e: any) {
       setError(reportErrors.SET_REPORT_FAILED);
     }


### PR DESCRIPTION
### Description
Locking (or unlocking) a report does not select that report; the user remains on the dashboard. Therefore we do not need to set that report in the store.

Skipping that set prevents an error that would occur when attempting to hydrate a report which does not have a form template - because the API response from the lock endpoint does not include a form template.

This problem, and this fix, are exactly analogous to #11432. This will the last such problem; all other calls to `hydrateAndSetReport` pass either `undefined` (which does not hit the bad path), or a complete `ReportShape` with formTemplate included.

### Related ticket(s)
N/A

---
### How to test
1. Log in as an admin
2. View the MLR dashboard (for a state which has at least one MLR report)
3. Lock a report. Note that it is locked, and no error message was displayed.
4. Unlock that report. Note that it is unlocked, and no error message was displayed.

### Important updates
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
