### PR TITLE
Update validation for text fields

### DIFF
--- a/services/ui-src/src/utils/validation/schemas.test.ts
+++ b/services/ui-src/src/utils/validation/schemas.test.ts
@@ -6,6 +6,8 @@ import {
   validNumber,
   numberNotLessThanOne,
   numberNotLessThanZero,
+  text,
+  textOptional,
 } from "./schemas";
 
 describe("Schemas", () => {
@@ -86,6 +88,10 @@ describe("Schemas", () => {
 
   const badValidNumberTestCases = ["N/A", "number", "foo"];
 
+  const goodRequiredTextTestCases = ["a", " a ", ".", "string"];
+  const goodOptionalTextTestCases = ["", ...goodRequiredTextTestCases];
+  const badRequiredTextTestCases = ["", "   ", undefined];
+
   const testNumberSchema = (
     schemaToUse: MixedSchema,
     testCases: Array<string>,
@@ -111,6 +117,17 @@ describe("Schemas", () => {
   const testValidNumber = (
     schemaToUse: MixedSchema,
     testCases: Array<string | number>,
+    expectedReturn: boolean
+  ) => {
+    for (let testCase of testCases) {
+      let test = schemaToUse.isValidSync(testCase);
+      expect(test).toEqual(expectedReturn);
+    }
+  };
+
+  const testText = (
+    schemaToUse: MixedSchema,
+    testCases: Array<string | undefined>,
     expectedReturn: boolean
   ) => {
     for (let testCase of testCases) {
@@ -169,5 +186,15 @@ describe("Schemas", () => {
   test("Test validNumber schema", () => {
     testValidNumber(validNumber(), goodValidNumberTestCases, true);
     testValidNumber(validNumber(), badValidNumberTestCases, false);
+  });
+
+  test("Test text schema", () => {
+    testText(text(), goodRequiredTextTestCases, true);
+    testText(text(), badRequiredTextTestCases, false);
+  });
+
+  test("Test textOptional schema", () => {
+    testText(textOptional(), goodOptionalTextTestCases, true);
+    testText(textOptional(), ["   "], false);
   });
 });

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -7,7 +7,11 @@ import {
 } from "utils/other/checkInputValidity";
 
 // TEXT - Helpers
+const stringHasLength = (value?: string) => value?.length != 0;
 const isWhitespaceString = (value?: string) => value?.trim().length === 0;
+// valid if string is empty or not whitespace only
+const isValidString = (value?: string) =>
+  !(stringHasLength(value) && isWhitespaceString(value));
 
 // TEXT
 export const text = () =>
@@ -15,10 +19,16 @@ export const text = () =>
     .typeError(error.INVALID_GENERIC)
     .required(error.REQUIRED_GENERIC)
     .test({
-      test: (value) => !isWhitespaceString(value),
+      test: (value) => isValidString(value),
       message: error.REQUIRED_GENERIC,
     });
-export const textOptional = () => string().typeError(error.INVALID_GENERIC);
+export const textOptional = () =>
+  string()
+    .typeError(error.INVALID_GENERIC)
+    .test({
+      test: (value) => isValidString(value),
+      message: error.INVALID_GENERIC,
+    });
 
 // NUMBER - Helpers
 const validNAValues = ["N/A", "Data not available"];


### PR DESCRIPTION
### Description
Previously you could submit an optional text field with whitespaces only and it would save to the db and silently fail validation.

Now validation for optional strings checks for whitespace.


https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/57802560/8295a6a9-f69d-4eaa-a7c1-341c2ff9951c



Open to suggestions on making the code logic cleaner! It works as such
| String has length | String is only whitespace | Desired outcome |
| ----------------- | ------------------------- | ----------------- |
| empty                   | N/A                                     | valid |
| empty                   | N/A                                     | valid |
| has length            | is only whitespace            | not valid |
| has length            | is not only whitespace     | valid |

empty strings here are considered valid because we apply this logic to both optional and required fields, where the latter already has a `.required()` on its schema 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2799

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Login as state user
- Navigate to MLR, create new submission, edit
- Go to MLR Reporting
- Add program reporting information
- Verify that the text boxes that are required validate as expected (must be filled, cannot be spaces only)
- Verify the optional text box (last one) validates as expected (can be empty, cannot be spaces only)
- Verify the report cannot be created if you have spaces only in a box

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
---
