### PR TITLE
Add maxWidth to dashboard program name

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -405,6 +405,7 @@ const sxChildStyles = {
     fontSize: "md",
     fontWeight: "bold",
     width: "13rem",
+    maxWidth: "13rem",
     ".tablet &, .mobile &": {
       width: "100%",
     },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Add `maxWidth` property to the program name column such that it doesn't cause the page to scroll left and right at smaller sizes

https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/57802560/bde8ff2e-8e19-4879-8285-3c802a333c8d


Open to suggestions!
If you remove `width` and only use `maxWidth` the width changes as you resize and the text shifts, which I think is not desirable

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2824

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Login as state user
- Go to MCPAR
- Make a report with a really long name
- Resize the window to near the tablet/desktop breakpoint and verify the window does not push any information off the screen

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
---
