### PR TITLE
Number field etl fix

### DIFF
--- a/services/app-api/handlers/etl/numberFieldCleanup.test.ts
+++ b/services/app-api/handlers/etl/numberFieldCleanup.test.ts
@@ -137,6 +137,8 @@ describe("Numeric data cleanup", () => {
 
     expect(s3PutSpy).toBeCalledTimes(1);
 
+    expect(s3PutSpy.mock.calls[0][0].Key).toBe("fieldData/CO/data1.json");
+
     const cleanedReportData = JSON.parse(s3PutSpy.mock.calls[0][0].Body);
     expect(cleanedReportData.q1).toBe("1000");
     expect(cleanedReportData.foos[0].q5).toBe("i ate 5 eggs"); // not fixable

--- a/services/app-api/handlers/etl/numberFieldCleanup.ts
+++ b/services/app-api/handlers/etl/numberFieldCleanup.ts
@@ -119,7 +119,7 @@ const putReport = async (
 ) => {
   await s3Lib.put({
     Bucket: reportBuckets[reportMetadata.reportType as ReportType],
-    Key: getFieldDataKey(reportMetadata.state, reportMetadata.id),
+    Key: getFieldDataKey(reportMetadata.state, reportMetadata.fieldDataId),
     Body: JSON.stringify(reportData),
     ContentType: "application/json",
   });

--- a/services/app-api/handlers/etl/numberFieldValueCategorization.ts
+++ b/services/app-api/handlers/etl/numberFieldValueCategorization.ts
@@ -96,6 +96,15 @@ export const Categories = {
   instantiate() {
     return [
       {
+        name: "empty",
+        level: "good",
+        count: 0,
+        values: [],
+        matcher: (value: string | undefined) => {
+          return !value;
+        },
+      },
+      {
         name: "plain number",
         level: "good",
         count: 0,


### PR DESCRIPTION
### Description
This PR fixes 2 quick bugs with the number ETL
1. The recent change to fix entity indexing caused errors on undefined/missing values. A new category at the top of the list will prevent that.
2. When the cleanup script `PUT` to S3, it was naming the file after the report `id`, not its `fieldDataId`. That's wrong.

### Related ticket(s)
MDCT-2598

---
### How to test
I'm trying to do so myself.

### Important updates
n/a

---
### Author checklist

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
