### PR TITLE
add subhead instructions to modal

### DIFF
--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -183,9 +183,7 @@ export const AddEditReportModal = ({
       modalDisclosure={modalDisclosure}
       content={{
         heading: selectedReport?.id ? form.heading?.edit : form.heading?.add,
-        subheading: selectedReport?.id
-          ? form.heading?.edit
-          : form.heading?.subheading,
+        subheading: selectedReport?.id ? "" : form.heading?.subheading,
         actionButtonText: submitting ? <Spinner size="md" /> : "Save",
         closeButtonText: "Cancel",
       }}

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -183,6 +183,9 @@ export const AddEditReportModal = ({
       modalDisclosure={modalDisclosure}
       content={{
         heading: selectedReport?.id ? form.heading?.edit : form.heading?.add,
+        subheading: selectedReport?.id
+          ? form.heading?.edit
+          : form.heading?.subheading,
         actionButtonText: submitting ? <Spinner size="md" /> : "Save",
         closeButtonText: "Cancel",
       }}

--- a/services/ui-src/src/forms/addEditMcparReport/addEditMcparReport.json
+++ b/services/ui-src/src/forms/addEditMcparReport/addEditMcparReport.json
@@ -5,6 +5,7 @@
   },
   "heading": {
     "add": "Add / Copy a Program",
+    "subheading": "Add a new program to start a blank report or copy an existing report. Copying a program’s MCPAR will retain the structure of your program, including plans, BSS entities, quality & assurance measures, and access measures, but allow you to enter updated responses for the new reporting period, saving you time. You can still edit these details within.",
     "edit": "Edit Program"
   },
   "fields": [


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
I missed this in my last YoY PR - added the subhead instructions to the New Program modal
<img width="532" alt="Screenshot 2023-09-06 at 2 06 45 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/10237149/2fdd36d1-e616-4162-873a-da5b9121b6a3">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2903

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
log in to MCPAR as a state user, click on add / copy managed care program, see the instructions in now at the top of the modal.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
