### PR TITLE
YoY copy: show alert msg if reporting period is not available

### DIFF
--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -2625,6 +2625,7 @@
             "dashboardTitle": "Quality & performance measure total count:",
             "countEntitiesInTitle": true,
             "addEntityButtonText": "Add quality & performance measure",
+            "unfinishedMeasureMessage": "Add the Measure Reporting Period for this quality and performance measure by editing the measure.",
             "editEntityButtonText": "Edit measure",
             "addEditModalAddTitle": "Add a quality & performance measure",
             "addEditModalEditTitle": "Edit quality & performance measure",

--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -2625,7 +2625,7 @@
             "dashboardTitle": "Quality & performance measure total count:",
             "countEntitiesInTitle": true,
             "addEntityButtonText": "Add quality & performance measure",
-            "unfinishedMeasureMessage": "Add the Measure Reporting Period for this quality and performance measure by editing the measure.",
+            "missingReportingPeriodMessage": "Add the Measure Reporting Period for this quality and performance measure by editing the measure.",
             "editEntityButtonText": "Edit measure",
             "addEditModalAddTitle": "Add a quality & performance measure",
             "addEditModalEditTitle": "Edit quality & performance measure",

--- a/services/app-api/utils/testing/mocks/mockForm.ts
+++ b/services/app-api/utils/testing/mocks/mockForm.ts
@@ -216,7 +216,7 @@ export const mockModalDrawerReportPageVerbiage = {
   intro: mockVerbiageIntro,
   dashboardTitle: "Mock dashboard title",
   addEntityButtonText: "Mock add entity button text",
-  unfinishedMeasureMessage: "Mock measure unfinished message",
+  missingReportingPeriodMessage: "Mock measure unfinished message",
   editEntityButtonText: "Mock edit entity button text",
   addEditModalAddTitle: "Mock add/edit entity modal add title",
   addEditModalEditTitle: "Mock add/edit entity modal edit title",

--- a/services/app-api/utils/testing/mocks/mockForm.ts
+++ b/services/app-api/utils/testing/mocks/mockForm.ts
@@ -216,6 +216,7 @@ export const mockModalDrawerReportPageVerbiage = {
   intro: mockVerbiageIntro,
   dashboardTitle: "Mock dashboard title",
   addEntityButtonText: "Mock add entity button text",
+  unfinishedMeasureMessage: "Mock measure unfinished message",
   editEntityButtonText: "Mock edit entity button text",
   addEditModalAddTitle: "Mock add/edit entity modal add title",
   addEditModalEditTitle: "Mock add/edit entity modal edit title",

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -94,7 +94,7 @@ export interface DrawerReportPageVerbiage extends ReportPageVerbiage {
 export interface ModalDrawerReportPageVerbiage
   extends DrawerReportPageVerbiage {
   addEntityButtonText: string;
-  unfinishedMeasureMessage: string;
+  missingReportingPeriodMessage: string;
   editEntityButtonText: string;
   addEditModalAddTitle: string;
   addEditModalEditTitle: string;

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -94,6 +94,7 @@ export interface DrawerReportPageVerbiage extends ReportPageVerbiage {
 export interface ModalDrawerReportPageVerbiage
   extends DrawerReportPageVerbiage {
   addEntityButtonText: string;
+  unfinishedMeasureMessage: string;
   editEntityButtonText: string;
   addEditModalAddTitle: string;
   addEditModalEditTitle: string;

--- a/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
@@ -115,11 +115,11 @@ export const EntityCard = ({
         />
         {openAddEditEntityModal && (
           <>
-            {!formattedEntityData.reportingPeriod ? (
+            {!formattedEntityData.reportingPeriod && (
               <Text sx={sx.missingReportingPeriodMessage}>
                 {verbiage.missingReportingPeriodMessage}
               </Text>
-            ) : null}
+            )}
             <Button
               variant="outline"
               size="sm"

--- a/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
@@ -114,15 +114,22 @@ export const EntityCard = ({
           printVersion={!!printVersion}
         />
         {openAddEditEntityModal && (
-          <Button
-            variant="outline"
-            size="sm"
-            sx={sx.editButton}
-            leftIcon={<Image src={editIcon} alt="edit icon" height="1rem" />}
-            onClick={() => openAddEditEntityModal(entity)}
-          >
-            {verbiage.editEntityButtonText}
-          </Button>
+          <>
+            {!formattedEntityData.reportingPeriod ? (
+              <Text sx={sx.unfinishedMeasureMessage}>
+                {verbiage.unfinishedMeasureMessage}
+              </Text>
+            ) : null}
+            <Button
+              variant="outline"
+              size="sm"
+              sx={sx.editButton}
+              leftIcon={<Image src={editIcon} alt="edit icon" height="1rem" />}
+              onClick={() => openAddEditEntityModal(entity)}
+            >
+              {verbiage.editEntityButtonText}
+            </Button>
+          </>
         )}
         {entityStarted || entityCompleted || printVersion ? (
           <EntityCardBottomSection
@@ -238,6 +245,11 @@ const sx = {
     _hover: {
       filter: svgFilters.primary_darker,
     },
+  },
+  unfinishedMeasureMessage: {
+    marginTop: "1rem",
+    fontSize: "xs",
+    color: "palette.error_dark",
   },
   unfinishedMessage: {
     fontSize: "xs",

--- a/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
@@ -115,11 +115,12 @@ export const EntityCard = ({
         />
         {openAddEditEntityModal && (
           <>
-            {!formattedEntityData.reportingPeriod && (
-              <Text sx={sx.missingReportingPeriodMessage}>
-                {verbiage.missingReportingPeriodMessage}
-              </Text>
-            )}
+            {entityType == "qualityMeasures" &&
+              !formattedEntityData.reportingPeriod && (
+                <Text sx={sx.missingReportingPeriodMessage}>
+                  {verbiage.missingReportingPeriodMessage}
+                </Text>
+              )}
             <Button
               variant="outline"
               size="sm"

--- a/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
@@ -115,7 +115,7 @@ export const EntityCard = ({
         />
         {openAddEditEntityModal && (
           <>
-            {entityType == "qualityMeasures" &&
+            {entityType == ModalDrawerEntityTypes.QUALITY_MEASURES &&
               !formattedEntityData.reportingPeriod && (
                 <Text sx={sx.missingReportingPeriodMessage}>
                   {verbiage.missingReportingPeriodMessage}

--- a/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
@@ -116,8 +116,8 @@ export const EntityCard = ({
         {openAddEditEntityModal && (
           <>
             {!formattedEntityData.reportingPeriod ? (
-              <Text sx={sx.unfinishedMeasureMessage}>
-                {verbiage.unfinishedMeasureMessage}
+              <Text sx={sx.missingReportingPeriodMessage}>
+                {verbiage.missingReportingPeriodMessage}
               </Text>
             ) : null}
             <Button
@@ -246,7 +246,7 @@ const sx = {
       filter: svgFilters.primary_darker,
     },
   },
-  unfinishedMeasureMessage: {
+  missingReportingPeriodMessage: {
     marginTop: "1rem",
     fontSize: "xs",
     color: "palette.error_dark",

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
@@ -109,7 +109,7 @@ export const EntityCardTopSection = ({
                   {formattedEntityData.reportingPeriod}
                 </Text>
               ) : (
-                <Text sx={sx.unfinishedMessage}>Not Answered</Text>
+                <Text sx={sx.unfinishedMessage}>Not answered</Text>
               )}
             </GridItem>
           </Grid>

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
@@ -109,7 +109,12 @@ export const EntityCardTopSection = ({
                   {formattedEntityData.reportingPeriod}
                 </Text>
               ) : (
-                <Text sx={sx.unfinishedMessage}>Not answered</Text>
+                <Text
+                  sx={sx.unfinishedMessage}
+                  className={printVersion ? "pdf-color" : ""}
+                >
+                  Not answered
+                </Text>
               )}
             </GridItem>
           </Grid>
@@ -154,5 +159,8 @@ const sx = {
   unfinishedMessage: {
     fontSize: "xs",
     color: "palette.error_dark",
+    "&.pdf-color": {
+      color: "palette.error_darker",
+    },
   },
 };

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
@@ -109,7 +109,7 @@ export const EntityCardTopSection = ({
                   {formattedEntityData.reportingPeriod}
                 </Text>
               ) : (
-                <Text sx={sx.unfinishedMessage}>No Answer</Text>
+                <Text sx={sx.unfinishedMessage}>Not Answered</Text>
               )}
             </GridItem>
           </Grid>

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
@@ -104,7 +104,13 @@ export const EntityCardTopSection = ({
                   ? "D2.VII.7a Reporting Period and D2.VII.7b Reporting period: Date range"
                   : "Measure Reporting Period"}
               </Text>
-              <Text sx={sx.subtext}>{formattedEntityData.reportingPeriod}</Text>
+              {formattedEntityData.reportingPeriod ? (
+                <Text sx={sx.subtext}>
+                  {formattedEntityData.reportingPeriod}
+                </Text>
+              ) : (
+                <Text sx={sx.unfinishedMessage}>No Answer</Text>
+              )}
             </GridItem>
           </Grid>
           <Text sx={sx.subtitle}>
@@ -144,5 +150,9 @@ const sx = {
   subtext: {
     marginTop: "0.25rem",
     fontSize: "sm",
+  },
+  unfinishedMessage: {
+    fontSize: "xs",
+    color: "palette.error_dark",
   },
 };

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -126,7 +126,7 @@ export interface DrawerReportPageVerbiage extends ReportPageVerbiage {
 export interface ModalDrawerReportPageVerbiage
   extends DrawerReportPageVerbiage {
   addEntityButtonText: string;
-  unfinishedMeasureMessage: string;
+  missingReportingPeriodMessage: string;
   editEntityButtonText: string;
   addEditModalAddTitle: string;
   addEditModalEditTitle: string;

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -126,6 +126,7 @@ export interface DrawerReportPageVerbiage extends ReportPageVerbiage {
 export interface ModalDrawerReportPageVerbiage
   extends DrawerReportPageVerbiage {
   addEntityButtonText: string;
+  unfinishedMeasureMessage: string;
   editEntityButtonText: string;
   addEditModalAddTitle: string;
   addEditModalEditTitle: string;

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -237,6 +237,7 @@ export const mockNestedReportPageJson = {
 export const mockModalDrawerReportPageVerbiage = {
   intro: mockVerbiageIntro,
   dashboardTitle: "Mock dashboard title",
+  unfinishedMeasureMessage: "Mock measure unfinished message",
   addEntityButtonText: "Mock add entity button text",
   editEntityButtonText: "Mock edit entity button text",
   addEditModalAddTitle: "Mock add/edit entity modal add title",

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -237,7 +237,7 @@ export const mockNestedReportPageJson = {
 export const mockModalDrawerReportPageVerbiage = {
   intro: mockVerbiageIntro,
   dashboardTitle: "Mock dashboard title",
-  unfinishedMeasureMessage: "Mock measure unfinished message",
+  missingReportingPeriodMessage: "Mock measure unfinished message",
   addEntityButtonText: "Mock add entity button text",
   editEntityButtonText: "Mock edit entity button text",
   addEditModalAddTitle: "Mock add/edit entity modal add title",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
add additional alert messaging for Quality & Performance Measures (per design)

"Not Answered" - when reporting period hasn't been reported
"Add the Measure Reporting Period for this quality and performance measure by editing the measure." -  if the measure still needs to be updated

<img width="671" alt="Screenshot 2023-09-18 at 1 59 55 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/10237149/f6ccea21-c227-4a9d-a5f2-1552e81c0d7f">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2945

---
### How to test- 
<!-- Step-by-step instructions on how to test, if necessary -->
- create a copy of a submitted report
- go to the Quality & Performance Measures section
- see that all details about the measure have been copied over except the reporting period
- verify that the alerts regarding the reporting period are showing



### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
