### PR TITLE
update completion status requirements

### DIFF
--- a/services/ui-src/src/components/cards/EntityCard/EntityCard.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCard.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import userEvent from "@testing-library/user-event";
 // components
-import { EntityCard, EntityCardBottomSection } from "components";
+import { EntityCard, EntityCardBottomSection, ReportContext } from "components";
 import {
   mockModalDrawerReportPageJson,
   mockAccessMeasuresEntity,
@@ -13,11 +13,16 @@ import {
   mockCompletedSanctionsFormattedEntityData,
   mockQualityMeasuresEntity,
   mockUnfinishedQualityMeasuresFormattedEntityData,
-  mockHalfCompletedQualityMeasuresEntity,
-  mockHalfCompletedQualityMeasuresFormattedEntityData,
   mockCompletedQualityMeasuresEntity,
   mockCompletedQualityMeasuresFormattedEntityData,
+  mockQualityMeasuresEntityMissingReportingPeriodAndDetails,
+  mockQualityMeasuresFormattedEntityDataMissingReportingPeriodAndDetails,
+  mockQualityMeasuresEntityMissingReportingPeriod,
+  mockQualityMeasuresFormattedEntityDataMissingReportingPeriod,
+  mockQualityMeasuresEntityMissingDetails,
+  mockQualityMeasuresFormattedEntityDataMissingDetails,
 } from "utils/testing/setupJest";
+import { ReportContextShape } from "types";
 
 const openAddEditEntityModal = jest.fn();
 const openDeleteEntityModal = jest.fn();
@@ -195,45 +200,140 @@ describe("Test Uncompleted Print Version EntityCard", () => {
   });
 });
 
+describe("Test EntityCard status indicators for AccessMeasures", () => {
+  test("Correct indicators for unfinished access measure", () => {
+    render(UnfinishedAccessMeasuresEntityCardComponent);
+    // status icon alt text should indicate incompleteness
+    expect(screen.queryByAltText("entity is incomplete")).toBeTruthy();
+
+    // Access measures do not have reporting periods, so their metadata is always complete
+    expect(
+      screen.queryByText("Mock entity missing reporting period message")
+    ).toBeFalsy();
+
+    // This message shows for entities with partial details; this entity isn't even started
+    expect(
+      screen.queryByText("Mock entity missing response message")
+    ).toBeFalsy();
+    expect(screen.queryByText("Mock entity unfinished messsage")).toBeTruthy();
+
+    // There are no details yet, so they cannot be EDITed
+    expect(
+      screen.queryByText("Mock edit entity details button text")
+    ).toBeFalsy();
+    expect(
+      screen.queryByText("Mock enter entity details button text")
+    ).toBeTruthy();
+  });
+
+  test("Correct indicators for completed access measure", () => {
+    render(AccessMeasuresEntityCardComponent);
+
+    // status icon alt text should indicate incompleteness
+    expect(screen.queryByAltText("entity is incomplete")).toBeFalsy();
+
+    expect(
+      screen.queryByText("Mock entity missing reporting period message")
+    ).toBeFalsy();
+
+    expect(
+      screen.queryByText("Mock entity missing response message")
+    ).toBeFalsy();
+    expect(screen.queryByText("Mock entity unfinished messsage")).toBeFalsy();
+
+    // The details are complete but they can still be EDITed
+    expect(
+      screen.queryByText("Mock edit entity details button text")
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("Mock enter entity details button text")
+    ).toBeFalsy();
+  });
+});
+
 // QUALITY MEASURES
 
+const mockReportWithTwoPlans = {
+  report: { fieldData: { plans: { length: 2 } } },
+} as unknown as ReportContextShape;
+
 const UnstartedQualityMeasuresEntityCardComponent = (
-  <EntityCard
-    entity={mockQualityMeasuresEntity}
-    entityIndex={0}
-    entityType="qualityMeasures"
-    formattedEntityData={mockUnfinishedQualityMeasuresFormattedEntityData}
-    verbiage={mockModalDrawerReportPageJson.verbiage}
-    openAddEditEntityModal={openAddEditEntityModal}
-    openDeleteEntityModal={openDeleteEntityModal}
-    openDrawer={mockOpenDrawer}
-  />
+  <ReportContext.Provider value={mockReportWithTwoPlans}>
+    <EntityCard
+      entity={mockQualityMeasuresEntity}
+      entityIndex={0}
+      entityType="qualityMeasures"
+      formattedEntityData={mockUnfinishedQualityMeasuresFormattedEntityData}
+      verbiage={mockModalDrawerReportPageJson.verbiage}
+      openAddEditEntityModal={openAddEditEntityModal}
+      openDeleteEntityModal={openDeleteEntityModal}
+      openDrawer={mockOpenDrawer}
+    />
+  </ReportContext.Provider>
 );
 
-const HalfCompletedQualityMeasuresEntityCardComponent = (
-  <EntityCard
-    entity={mockHalfCompletedQualityMeasuresEntity}
-    entityIndex={0}
-    entityType="qualityMeasures"
-    formattedEntityData={mockHalfCompletedQualityMeasuresFormattedEntityData}
-    verbiage={mockModalDrawerReportPageJson.verbiage}
-    openAddEditEntityModal={openAddEditEntityModal}
-    openDeleteEntityModal={openDeleteEntityModal}
-    openDrawer={mockOpenDrawer}
-  />
+const QualityMeasuresEntityCardComponentMissingReportingPeriodAndDetails = (
+  <ReportContext.Provider value={mockReportWithTwoPlans}>
+    <EntityCard
+      entity={mockQualityMeasuresEntityMissingReportingPeriodAndDetails}
+      entityIndex={0}
+      entityType="qualityMeasures"
+      formattedEntityData={
+        mockQualityMeasuresFormattedEntityDataMissingReportingPeriodAndDetails
+      }
+      verbiage={mockModalDrawerReportPageJson.verbiage}
+      openAddEditEntityModal={openAddEditEntityModal}
+      openDeleteEntityModal={openDeleteEntityModal}
+      openDrawer={mockOpenDrawer}
+    />
+  </ReportContext.Provider>
+);
+
+const QualityMeasuresEntityCardComponentMissingReportingPeriod = (
+  <ReportContext.Provider value={mockReportWithTwoPlans}>
+    <EntityCard
+      entity={mockQualityMeasuresEntityMissingReportingPeriod}
+      entityIndex={0}
+      entityType="qualityMeasures"
+      formattedEntityData={
+        mockQualityMeasuresFormattedEntityDataMissingReportingPeriod
+      }
+      verbiage={mockModalDrawerReportPageJson.verbiage}
+      openAddEditEntityModal={openAddEditEntityModal}
+      openDeleteEntityModal={openDeleteEntityModal}
+      openDrawer={mockOpenDrawer}
+    />
+  </ReportContext.Provider>
+);
+
+const QualityMeasuresEntityCardComponentMissingDetails = (
+  <ReportContext.Provider value={mockReportWithTwoPlans}>
+    <EntityCard
+      entity={mockQualityMeasuresEntityMissingDetails}
+      entityIndex={0}
+      entityType="qualityMeasures"
+      formattedEntityData={mockQualityMeasuresFormattedEntityDataMissingDetails}
+      verbiage={mockModalDrawerReportPageJson.verbiage}
+      openAddEditEntityModal={openAddEditEntityModal}
+      openDeleteEntityModal={openDeleteEntityModal}
+      openDrawer={mockOpenDrawer}
+    />
+  </ReportContext.Provider>
 );
 
 const CompletedQualityMeasuresEntityCardComponent = (
-  <EntityCard
-    entity={mockCompletedQualityMeasuresEntity}
-    entityIndex={0}
-    entityType="qualityMeasures"
-    formattedEntityData={mockCompletedQualityMeasuresFormattedEntityData}
-    verbiage={mockModalDrawerReportPageJson.verbiage}
-    openAddEditEntityModal={openAddEditEntityModal}
-    openDeleteEntityModal={openDeleteEntityModal}
-    openDrawer={mockOpenDrawer}
-  />
+  <ReportContext.Provider value={mockReportWithTwoPlans}>
+    <EntityCard
+      entity={mockCompletedQualityMeasuresEntity}
+      entityIndex={0}
+      entityType="qualityMeasures"
+      formattedEntityData={mockCompletedQualityMeasuresFormattedEntityData}
+      verbiage={mockModalDrawerReportPageJson.verbiage}
+      openAddEditEntityModal={openAddEditEntityModal}
+      openDeleteEntityModal={openDeleteEntityModal}
+      openDrawer={mockOpenDrawer}
+    />
+  </ReportContext.Provider>
 );
 
 describe("Test Unstarted QualityMeasures EntityCard", () => {
@@ -262,9 +362,9 @@ describe("Test Unstarted QualityMeasures EntityCard", () => {
   });
 });
 
-describe("Test half-completed QualityMeasures EntityCard", () => {
+describe("Test QualityMeasures EntityCard with missing details", () => {
   beforeEach(() => {
-    render(HalfCompletedQualityMeasuresEntityCardComponent);
+    render(QualityMeasuresEntityCardComponentMissingDetails);
   });
 
   afterEach(() => {
@@ -314,6 +414,120 @@ describe("Test completed QualityMeasures EntityCard", () => {
   });
 });
 
+describe("Test EntityCard status indicators for QualityMeasures", () => {
+  test("Correct indicators for quality measure which has not been started", () => {
+    render(UnstartedQualityMeasuresEntityCardComponent);
+    // status icon alt text should indicate incompleteness
+    expect(screen.queryByAltText("entity is incomplete")).toBeTruthy();
+
+    // This quality measure was just created from scratch, so it has a reporting period
+    expect(
+      screen.queryByText("Mock entity missing reporting period message")
+    ).toBeFalsy();
+
+    // This message shows for entities with partial details; this entity isn't even started
+    expect(
+      screen.queryByText("Mock entity missing response message")
+    ).toBeFalsy();
+    expect(screen.queryByText("Mock entity unfinished messsage")).toBeTruthy();
+
+    // There are no details yet, so they cannot be EDITed
+    expect(
+      screen.queryByText("Mock edit entity details button text")
+    ).toBeFalsy();
+    expect(
+      screen.queryByText("Mock enter entity details button text")
+    ).toBeTruthy();
+  });
+
+  test("Correct indicators for quality measure without reporting period", () => {
+    render(QualityMeasuresEntityCardComponentMissingReportingPeriod);
+
+    // status icon alt text should indicate incompleteness
+    expect(screen.queryByAltText("entity is incomplete")).toBeTruthy();
+
+    expect(
+      screen.queryByText("Mock entity missing reporting period message")
+    ).toBeTruthy();
+
+    expect(
+      screen.queryByText("Mock entity missing response message")
+    ).toBeFalsy();
+    expect(screen.queryByText("Mock entity unfinished messsage")).toBeFalsy();
+
+    // The details are complete but they can still be EDITed
+    expect(
+      screen.queryByText("Mock edit entity details button text")
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("Mock enter entity details button text")
+    ).toBeFalsy();
+  });
+
+  test("Correct indicators for quality measure with neither reporting period nor details", () => {
+    render(QualityMeasuresEntityCardComponentMissingReportingPeriodAndDetails);
+    expect(screen.queryByAltText("entity is incomplete")).toBeTruthy();
+
+    expect(
+      screen.queryByText("Mock entity missing reporting period message")
+    ).toBeTruthy();
+
+    expect(
+      screen.queryByText("Mock entity missing response message")
+    ).toBeTruthy();
+    expect(screen.queryByText("Mock entity unfinished messsage")).toBeFalsy();
+
+    expect(
+      screen.queryByText("Mock edit entity details button text")
+    ).toBeFalsy();
+    expect(
+      screen.queryByText("Mock enter entity details button text")
+    ).toBeTruthy();
+  });
+
+  test("Correct indicators for quality measures without details", () => {
+    render(QualityMeasuresEntityCardComponentMissingDetails);
+    expect(screen.queryByAltText("entity is incomplete")).toBeTruthy();
+
+    expect(
+      screen.queryByText("Mock entity missing reporting period message")
+    ).toBeFalsy();
+
+    expect(
+      screen.queryByText("Mock entity missing response message")
+    ).toBeTruthy();
+    expect(screen.queryByText("Mock entity unfinished messsage")).toBeFalsy();
+
+    expect(
+      screen.queryByText("Mock edit entity details button text")
+    ).toBeFalsy();
+    expect(
+      screen.queryByText("Mock enter entity details button text")
+    ).toBeTruthy();
+  });
+
+  test("Correct indicators for quality measure which is complete", () => {
+    render(CompletedQualityMeasuresEntityCardComponent);
+    expect(screen.queryByAltText("entity is incomplete")).toBeFalsy();
+
+    expect(
+      screen.queryByText("Mock entity missing reporting period message")
+    ).toBeFalsy();
+
+    expect(
+      screen.queryByText("Mock entity missing response message")
+    ).toBeFalsy();
+    expect(screen.queryByText("Mock entity unfinished messsage")).toBeFalsy();
+
+    expect(
+      screen.queryByText("Mock edit entity details button text")
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("Mock enter entity details button text")
+    ).toBeFalsy();
+  });
+});
+
 describe("Test QualityMeasures EntityCard accessibility", () => {
   it("Unstarted QualityMeasures EntityCard should not have basic accessibility issues", async () => {
     const { container } = render(UnstartedQualityMeasuresEntityCardComponent);
@@ -323,7 +537,7 @@ describe("Test QualityMeasures EntityCard accessibility", () => {
 
   it("Half-completed QualityMeasures EntityCard should not have basic accessibility issues", async () => {
     const { container } = render(
-      HalfCompletedQualityMeasuresEntityCardComponent
+      QualityMeasuresEntityCardComponentMissingDetails
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -419,6 +633,57 @@ describe("Test Unfinished Sanctions EntityCard", () => {
     const enterDetailsButton = screen.getByText(enterEntityDetailsButtonText);
     await userEvent.click(enterDetailsButton);
     expect(mockOpenDrawer).toBeCalledTimes(1);
+  });
+});
+
+describe("Test EntityCard status indicators for Sanctions", () => {
+  test("Correct indicators for unfinished sanction card", () => {
+    render(UnfinishedSanctionsEntityCardComponent);
+    // status icon alt text should indicate incompleteness
+    expect(screen.queryByAltText("entity is incomplete")).toBeTruthy();
+
+    // Sanctions do not have reporting periods, so their metadata is always complete
+    expect(
+      screen.queryByText("Mock entity missing reporting period message")
+    ).toBeFalsy();
+
+    // This message shows for entities with partial details; this entity isn't even started
+    expect(
+      screen.queryByText("Mock entity missing response message")
+    ).toBeFalsy();
+    expect(screen.queryByText("Mock entity unfinished messsage")).toBeTruthy();
+
+    // There are no details yet, so they cannot be EDITed
+    expect(
+      screen.queryByText("Mock edit entity details button text")
+    ).toBeFalsy();
+    expect(
+      screen.queryByText("Mock enter entity details button text")
+    ).toBeTruthy();
+  });
+
+  test("Correct indicators for completed sanction", () => {
+    render(SanctionsEntityCardComponent);
+
+    // status icon alt text should indicate incompleteness
+    expect(screen.queryByAltText("entity is incomplete")).toBeFalsy();
+
+    expect(
+      screen.queryByText("Mock entity missing reporting period message")
+    ).toBeFalsy();
+
+    expect(
+      screen.queryByText("Mock entity missing response message")
+    ).toBeFalsy();
+    expect(screen.queryByText("Mock entity unfinished messsage")).toBeFalsy();
+
+    // The details are complete but they can still be EDITed
+    expect(
+      screen.queryByText("Mock edit entity details button text")
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("Mock enter entity details button text")
+    ).toBeFalsy();
   });
 });
 

--- a/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
@@ -64,6 +64,8 @@ export const EntityCard = ({
     default:
       break;
   }
+  const entityDetailsAndReportingPeriodComplete =
+    entityCompleted && reportingPeriodCompletedOrOptional;
   return (
     <Card {...props} marginTop="2rem" data-testid="entityCard">
       <Box sx={sx.contentBox} className={printVersion ? "print-version" : ""}>
@@ -75,7 +77,7 @@ export const EntityCard = ({
         {!printVersion ? (
           <Image
             src={
-              entityCompleted && reportingPeriodCompletedOrOptional
+              entityDetailsAndReportingPeriodComplete
                 ? completedIcon
                 : unfinishedIcon
             }
@@ -93,14 +95,14 @@ export const EntityCard = ({
           >
             <Image
               src={
-                entityCompleted && reportingPeriodCompletedOrOptional
+                entityDetailsAndReportingPeriodComplete
                   ? completedIcon
                   : unfinishedIcon
               }
               alt={`entity is ${entityCompleted ? "complete" : "incomplete"}`}
               sx={sx.printVersionIcon}
             />
-            {entityCompleted && reportingPeriodCompletedOrOptional ? (
+            {entityDetailsAndReportingPeriodComplete ? (
               <Text className="completed-text">Complete</Text>
             ) : (
               <Text className="error-text">Error</Text>

--- a/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
@@ -81,13 +81,17 @@ export const EntityCard = ({
                 ? completedIcon
                 : unfinishedIcon
             }
-            alt={`entity is ${entityCompleted ? "complete" : "incomplete"}`}
+            alt={`entity is ${
+              entityDetailsAndReportingPeriodComplete
+                ? "complete"
+                : "incomplete"
+            }`}
             sx={sx.statusIcon}
           />
         ) : (
           <Box
             className={
-              entityCompleted
+              entityDetailsAndReportingPeriodComplete
                 ? "print-version-icon-div-complete"
                 : "print-version-icon-div-incomplete"
             }
@@ -99,7 +103,11 @@ export const EntityCard = ({
                   ? completedIcon
                   : unfinishedIcon
               }
-              alt={`entity is ${entityCompleted ? "complete" : "incomplete"}`}
+              alt={`entity is ${
+                entityDetailsAndReportingPeriodComplete
+                  ? "complete"
+                  : "incomplete"
+              }`}
               sx={sx.printVersionIcon}
             />
             {entityDetailsAndReportingPeriodComplete ? (

--- a/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
@@ -31,7 +31,7 @@ export const EntityCard = ({
   const { report } = useContext(ReportContext);
   let entityStarted = false;
   let entityCompleted = false;
-  const qualityMeasureReportingPeriod =
+  const reportingPeriodCompletedOrOptional =
     entityType == ModalDrawerEntityTypes.QUALITY_MEASURES
       ? formattedEntityData.reportingPeriod
       : true;
@@ -75,7 +75,7 @@ export const EntityCard = ({
         {!printVersion ? (
           <Image
             src={
-              entityCompleted && qualityMeasureReportingPeriod
+              entityCompleted && reportingPeriodCompletedOrOptional
                 ? completedIcon
                 : unfinishedIcon
             }
@@ -93,14 +93,14 @@ export const EntityCard = ({
           >
             <Image
               src={
-                entityCompleted && qualityMeasureReportingPeriod
+                entityCompleted && reportingPeriodCompletedOrOptional
                   ? completedIcon
                   : unfinishedIcon
               }
               alt={`entity is ${entityCompleted ? "complete" : "incomplete"}`}
               sx={sx.printVersionIcon}
             />
-            {entityCompleted && qualityMeasureReportingPeriod ? (
+            {entityCompleted && reportingPeriodCompletedOrOptional ? (
               <Text className="completed-text">Complete</Text>
             ) : (
               <Text className="error-text">Error</Text>

--- a/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
@@ -31,6 +31,11 @@ export const EntityCard = ({
   const { report } = useContext(ReportContext);
   let entityStarted = false;
   let entityCompleted = false;
+  const qualityMeasureReportingPeriod =
+    entityType == ModalDrawerEntityTypes.QUALITY_MEASURES
+      ? formattedEntityData.reportingPeriod
+      : true;
+
   // get index and length of entities
   const reportFieldDataEntities = report?.fieldData[entityType] || [];
   const entitiesCount = `${entityIndex + 1} / ${
@@ -69,7 +74,11 @@ export const EntityCard = ({
         )}
         {!printVersion ? (
           <Image
-            src={entityCompleted ? completedIcon : unfinishedIcon}
+            src={
+              entityCompleted && qualityMeasureReportingPeriod
+                ? completedIcon
+                : unfinishedIcon
+            }
             alt={`entity is ${entityCompleted ? "complete" : "incomplete"}`}
             sx={sx.statusIcon}
           />
@@ -83,11 +92,15 @@ export const EntityCard = ({
             data-testid="print-status-indicator"
           >
             <Image
-              src={entityCompleted ? completedIcon : unfinishedIcon}
+              src={
+                entityCompleted && qualityMeasureReportingPeriod
+                  ? completedIcon
+                  : unfinishedIcon
+              }
               alt={`entity is ${entityCompleted ? "complete" : "incomplete"}`}
               sx={sx.printVersionIcon}
             />
-            {entityCompleted ? (
+            {entityCompleted && qualityMeasureReportingPeriod ? (
               <Text className="completed-text">Complete</Text>
             ) : (
               <Text className="error-text">Error</Text>

--- a/services/ui-src/src/utils/reports/entities.test.ts
+++ b/services/ui-src/src/utils/reports/entities.test.ts
@@ -7,11 +7,11 @@ import {
   mockCompletedSanctionsFormattedEntityData,
   mockQualityMeasuresEntity,
   mockUnfinishedQualityMeasuresFormattedEntityData,
-  mockHalfCompletedQualityMeasuresEntity,
-  mockHalfCompletedQualityMeasuresFormattedEntityData,
   mockCompletedQualityMeasuresEntity,
   mockCompletedQualityMeasuresFormattedEntityData,
   mockReportFieldData,
+  mockQualityMeasuresEntityMissingDetails,
+  mockQualityMeasuresFormattedEntityDataMissingDetails,
 } from "utils/testing/setupJest";
 
 describe("Test getFormattedEntityData", () => {
@@ -37,11 +37,11 @@ describe("Test getFormattedEntityData", () => {
   it("Returns correct data for quality measures with some completed measures", () => {
     const entityData = getFormattedEntityData(
       ModalDrawerEntityTypes.QUALITY_MEASURES,
-      mockHalfCompletedQualityMeasuresEntity,
+      mockQualityMeasuresEntityMissingDetails,
       mockReportFieldData
     );
     expect(entityData).toEqual(
-      mockHalfCompletedQualityMeasuresFormattedEntityData
+      mockQualityMeasuresFormattedEntityDataMissingDetails
     );
   });
 

--- a/services/ui-src/src/utils/testing/mockEntities.tsx
+++ b/services/ui-src/src/utils/testing/mockEntities.tsx
@@ -77,12 +77,44 @@ export const mockUnfinishedQualityMeasuresFormattedEntityData = {
   ],
 };
 
-export const mockHalfCompletedQualityMeasuresEntity = {
+export const mockQualityMeasuresEntityMissingReportingPeriodAndDetails = {
+  ...mockQualityMeasuresEntity,
+  qualityMeasure_reportingPeriod: undefined,
+  "qualityMeasure_plan_measureResults_mock-plan-id-1": "mock-response-1",
+};
+
+export const mockQualityMeasuresFormattedEntityDataMissingReportingPeriodAndDetails =
+  {
+    ...mockUnfinishedQualityMeasuresFormattedEntityData,
+    reportingPeriod: undefined,
+    perPlanResponses: [
+      { name: "mock-plan-name-1", response: "mock-response-1" },
+      { name: "mock-plan-name-2", response: undefined },
+    ],
+  };
+
+export const mockQualityMeasuresEntityMissingReportingPeriod = {
+  ...mockQualityMeasuresEntity,
+  qualityMeasure_reportingPeriod: undefined,
+  "qualityMeasure_plan_measureResults_mock-plan-id-1": "mock-response-1",
+  "qualityMeasure_plan_measureResults_mock-plan-id-2": "mock-response-2",
+};
+
+export const mockQualityMeasuresFormattedEntityDataMissingReportingPeriod = {
+  ...mockUnfinishedQualityMeasuresFormattedEntityData,
+  reportingPeriod: undefined,
+  perPlanResponses: [
+    { name: "mock-plan-name-1", response: "mock-response-1" },
+    { name: "mock-plan-name-2", response: "mock-response-2" },
+  ],
+};
+
+export const mockQualityMeasuresEntityMissingDetails = {
   ...mockQualityMeasuresEntity,
   "qualityMeasure_plan_measureResults_mock-plan-id-1": "mock-response-1",
 };
 
-export const mockHalfCompletedQualityMeasuresFormattedEntityData = {
+export const mockQualityMeasuresFormattedEntityDataMissingDetails = {
   ...mockUnfinishedQualityMeasuresFormattedEntityData,
   perPlanResponses: [
     { name: "mock-plan-name-1", response: "mock-response-1" },

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -237,7 +237,7 @@ export const mockNestedReportPageJson = {
 export const mockModalDrawerReportPageVerbiage = {
   intro: mockVerbiageIntro,
   dashboardTitle: "Mock dashboard title",
-  missingReportingPeriodMessage: "Mock measure unfinished message",
+  missingReportingPeriodMessage: "Mock entity missing reporting period message",
   addEntityButtonText: "Mock add entity button text",
   editEntityButtonText: "Mock edit entity button text",
   addEditModalAddTitle: "Mock add/edit entity modal add title",
@@ -247,6 +247,7 @@ export const mockModalDrawerReportPageVerbiage = {
   deleteModalTitle: "Mock delete modal title",
   deleteModalConfirmButtonText: "Mock delete modal confirm button text",
   deleteModalWarning: "Mock delete modal warning",
+  entityMissingResponseMessage: "Mock entity missing response message",
   entityUnfinishedMessage: "Mock entity unfinished messsage",
   enterEntityDetailsButtonText: "Mock enter entity details button text",
   editEntityDetailsButtonText: "Mock edit entity details button text",

--- a/tests/cypress/package.json
+++ b/tests/cypress/package.json
@@ -17,7 +17,7 @@
     "@testing-library/cypress": "^9.0.0",
     "axe-core": "^4.6.3",
     "concurrently": "^7.6.0",
-    "cypress": "^12.5.1",
+    "cypress": "^12.15.1",
     "cypress-axe": "^1.3.0",
     "cypress-file-upload": "^5.0.8"
   },

--- a/tests/cypress/yarn.lock
+++ b/tests/cypress/yarn.lock
@@ -1106,10 +1106,10 @@
     through2 "^2.0.0"
     watchify "^4.0.0"
 
-"@cypress/request@^2.88.10":
-  version "2.88.10"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.10.tgz#b66d76b07f860d3a4b8d7a0604d020c662752cce"
-  integrity sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==
+"@cypress/request@2.88.12":
+  version "2.88.12"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.12.tgz#ba4911431738494a85e93fb04498cb38bc55d590"
+  integrity sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -1124,9 +1124,9 @@
     json-stringify-safe "~5.0.1"
     mime-types "~2.1.19"
     performance-now "^2.1.0"
-    qs "~6.5.2"
+    qs "~6.10.3"
     safe-buffer "^5.1.2"
-    tough-cookie "~2.5.0"
+    tough-cookie "^4.1.3"
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
 
@@ -1206,10 +1206,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.32.tgz#51d59d7a90ef2d0ae961791e0900cad2393a0149"
   integrity sha512-eAIcfAvhf/BkHcf4pkLJ7ECpBAhh9kcxRBpip9cTiO+hf+aJrsxYxBeS6OXvOd9WqNAJmavXVpZvY1rBjNsXmw==
 
-"@types/node@^14.14.31":
-  version "14.18.17"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.17.tgz#37d3c01043fd09f3f17ffa8c17062bbb580f9558"
-  integrity sha512-oajWz4kOajqpKJMPgnCvBajPq8QAvl2xIWoFjlAJPKGu6n7pjov5SxGE45a+0RxHDoo4ycOMoZw1SCOWtDERbw==
+"@types/node@^16.18.39":
+  version "16.18.54"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.54.tgz#4a63bdcea5b714f546aa27406a1c60621236a132"
+  integrity sha512-oTmGy68gxZZ21FhTJVVvZBYpQHEBZxHKTsGshobMqm9qWpbqdZsA5jvsuPZcHu0KwpmLrOHWPdEfg7XDpNT9UA==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -1978,10 +1978,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
-  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+commander@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
 commander@~8.0.0:
   version "8.0.0"
@@ -2155,14 +2155,14 @@ cypress-tags@^1.1.2:
     boolean-parser "0.0.2"
     through "^2.3.8"
 
-cypress@^12.5.1:
-  version "12.6.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.6.0.tgz#d71a82639756173c0682b3d467eb9f0523460e91"
-  integrity sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==
+cypress@^12.15.1:
+  version "12.17.4"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.17.4.tgz#b4dadf41673058493fa0d2362faa3da1f6ae2e6c"
+  integrity sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==
   dependencies:
-    "@cypress/request" "^2.88.10"
+    "@cypress/request" "2.88.12"
     "@cypress/xvfb" "^1.2.4"
-    "@types/node" "^14.14.31"
+    "@types/node" "^16.18.39"
     "@types/sinonjs__fake-timers" "8.1.1"
     "@types/sizzle" "^2.3.2"
     arch "^2.2.0"
@@ -2174,7 +2174,7 @@ cypress@^12.5.1:
     check-more-types "^2.24.0"
     cli-cursor "^3.1.0"
     cli-table3 "~0.6.1"
-    commander "^5.1.0"
+    commander "^6.2.1"
     common-tags "^1.8.0"
     dayjs "^1.10.4"
     debug "^4.3.4"
@@ -2192,12 +2192,13 @@ cypress@^12.5.1:
     listr2 "^3.8.3"
     lodash "^4.17.21"
     log-symbols "^4.0.0"
-    minimist "^1.2.6"
+    minimist "^1.2.8"
     ospath "^1.2.2"
     pretty-bytes "^5.6.0"
+    process "^0.11.10"
     proxy-from-env "1.0.0"
     request-progress "^3.0.0"
-    semver "^7.3.2"
+    semver "^7.5.3"
     supports-color "^8.1.1"
     tmp "~0.2.1"
     untildify "^4.0.0"
@@ -3449,10 +3450,15 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.6:
+minimist@^1.1.0, minimist@^1.1.1:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
+minimist@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 mkdirp-classic@^0.5.2:
   version "0.5.3"
@@ -3783,7 +3789,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process@~0.11.0:
+process@^0.11.10, process@~0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
@@ -3803,10 +3809,10 @@ proxy-from-env@^1.1.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
-psl@^1.1.28:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
-  integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
+psl@^1.1.33:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
+  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
 
 public-encrypt@^4.0.0:
   version "4.0.3"
@@ -3861,10 +3867,12 @@ puppeteer@~9.1.1:
     unbzip2-stream "^1.3.3"
     ws "^7.2.3"
 
-qs@~6.5.2:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
-  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
+qs@~6.10.3:
+  version "6.10.5"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.5.tgz#974715920a80ff6a262264acd2c7e6c2a53282b4"
+  integrity sha512-O5RlPh0VFtR78y79rgcgKK4wbAI0C5zGVLztOIdpWX6ep368q5Hv6XRxDvXuZ9q3C6v+e3n8UfZZJw7IIG27eQ==
+  dependencies:
+    side-channel "^1.0.4"
 
 querystring-es3@~0.2.0:
   version "0.2.1"
@@ -3875,6 +3883,11 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
@@ -4018,6 +4031,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -4111,7 +4129,7 @@ semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.2:
+semver@^7.5.3:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -4449,13 +4467,15 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tough-cookie@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+tough-cookie@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
+  integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
   dependencies:
-    psl "^1.1.28"
+    psl "^1.1.33"
     punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -4561,6 +4581,11 @@ unicode-property-aliases-ecmascript@^2.0.0:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz#0a36cb9a585c4f6abd51ad1deddb285c165297c8"
   integrity sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
@@ -4570,6 +4595,14 @@ untildify@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
   integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 url@~0.11.0:
   version "0.11.0"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
David found a little bug with the YoY completion status.
On the VII: Quality Measures page, if a report was copied over, the Reporting Period and the Details are not copied over and show incomplete alerts. I made an update to create the Reporting Period error message, but it wasn't being taken into account for the cards completed status (the icon in the top left corner)

<img width="606" alt="Screenshot 2023-09-22 at 2 56 53 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/10237149/88ac3f5e-a799-4bf9-b3e7-6c3fcb3c1ee6">

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2988

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Create a report copy
navigate to VII: Quality Measures
update the details of the measure (but not the reporting period)
see that the completion status is still incomplete
update the Reporting Period
that should fulfill all the requirements and the completion status should be Complete

this should be the case for the PDF as well

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
