### PR TITLE
Update github workflows to avoid deprecations

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Dependabotbot Gather Metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.3.0
+        uses: dependabot/fetch-metadata@v1
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
       - "dependabot/**"
       - "!skipci*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   id-token: write
   contents: read
@@ -25,7 +28,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             **/node_modules
@@ -38,7 +41,7 @@ jobs:
         run: ./scripts/test-unit.sh
       - name: publish test coverage to code climate
         if: env.CODE_CLIMATE_ID != ''
-        uses: paambaati/codeclimate-action@v2.7.5
+        uses: paambaati/codeclimate-action@v5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}
         with:
@@ -46,7 +49,7 @@ jobs:
             ${{github.workspace}}/services/app-api/coverage/lcov.info:lcov
             ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
       - name: Store unit test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: unit_test_results
           path: ${{github.workspace}}/services/ui-src/coverage/lcov.info
@@ -78,18 +81,14 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
       - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
-      - name: lock this branch to prevent concurrent builds
-        run: ./.github/github-lock.sh $branch_name
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             **/node_modules
@@ -146,7 +145,7 @@ jobs:
           CYPRESS_ADMIN_USER_PASSWORD: ${{ secrets.CYPRESS_ADMIN_USER_PASSWORD }}
 
       - name: Upload screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots
@@ -180,7 +179,7 @@ jobs:
           RUN_PA11Y: true
 
       - name: Upload screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -7,7 +7,6 @@ permissions:
   contents: read
   actions: read
 
-
 jobs:
   destroy:
     # Protected branches should be designated as such in the GitHub UI.
@@ -35,7 +34,7 @@ jobs:
           AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
       - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}

--- a/.github/workflows/git-secrets.yaml
+++ b/.github/workflows/git-secrets.yaml
@@ -4,8 +4,8 @@ jobs:
   gitleaks-scan:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Run gitlakes docker	    
-      uses: docker://zricethezav/gitleaks
-      with:
-        args: detect --source /github/workspace/ --no-git --verbose
+      - uses: actions/checkout@v3
+      - name: Run gitleaks docker
+        uses: docker://zricethezav/gitleaks
+        with:
+          args: detect --source /github/workspace/ --no-git --verbose

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.2
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0
       - uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/scan_security-hub-jira-integration.yml
+++ b/.github/workflows/scan_security-hub-jira-integration.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.PRODUCTION_SYNC_OIDC_ROLE }}

--- a/.github/workflows/scan_snyk-jira-integration.yml
+++ b/.github/workflows/scan_snyk-jira-integration.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Snyk and Run Snyk test
         run: |
@@ -32,7 +32,7 @@ jobs:
     if: github.event_name == 'schedule'
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Snyk and Run Snyk test
         run: |


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Updating versions to avoid warnings and deprecations

Also modified deploy workflow to block using concurrency rather than lock script. That way only the `deploy` from the same branch can stop it, and it uses native github actions logic rather than custom scripts. we are already using this in CARTS and QMR. More info from [QMR PR](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/1968) and [docs for concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#examples-using-concurrency-and-the-default-behavior)

Note: these have already been tested in [another PR](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/1982) and I'm migrating them here

DOCS:
[aws-configure-credentials readme](https://github.com/aws-actions/configure-aws-credentials) – no breaking changes between 1 and 4. ("By default, your account ID will not be masked in workflow logs. This was changed from being masked by default in the previous version. AWS does not consider account IDs as sensitive information, so this change reflects that stance." Let me know if you want to mask this still and I'll add that option)
[cache readme](https://github.com/actions/cache) – no breaking changes with v3
[codeclimate action changelog](https://github.com/paambaati/codeclimate-action/releases) – breaking changes not relevant to us
[node version action](https://github.com/actions/setup-node) – update allows us to read from .nvmrc natively
[pre-commit/action changelog](https://github.com/pre-commit/action/releases) – doesn't specifically call out a fix but the warnings were resolved by upgrading
[actions/checkout changelog](https://github.com/actions/checkout/releases/tag/v3.0.0) – v3 uses node 16 which will be deprecated soon but doesn't have a warning for now, and keeps it up to date with our other checkouts@v3
[dependabot/fetch-metadata action changelog](https://github.com/dependabot/fetch-metadata/releases) – specifically v1.5.0 removes deprecated set-output so by changing to @v1 it will automatically use latest version

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-none

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
All steps here pass