### PR TITLE
Explicitly convert array length to boolean

### DIFF
--- a/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
@@ -55,7 +55,7 @@ export const EntityCard = ({
       const validPerPlanResponses = perPlanResponses?.filter(
         (el: any) => el.response
       );
-      entityStarted = validPerPlanResponses?.length;
+      entityStarted = !!validPerPlanResponses?.length;
       entityCompleted =
         entityStarted &&
         validPerPlanResponses?.length === report?.fieldData?.plans?.length;


### PR DESCRIPTION
### Description
This PR fixes a minor but long-standing bug, which caused a zero to display on the quality measure cards with no results.

The common React pattern of
```tsx
  {shouldDisplay && <Foo>displayed content</Foo>}
```
works perfectly when `shouldDisplay` is a boolean. It even works when `shouldDisplay` is a truthy number. But when it is `0`, that zero is rendered directly to the screen.

That's exactly what happened here, with `formattedEntityData?.isPartiallyComplete` on line 152 of EntityCardBottomSection.tsx. The numeric type of that flag traces back to the line changed by this PR.

Note that `entityStarted` is hinted to be a boolean at its declaration site, but Typescript couldn't help us ensure it was one, because the `formattedEntityData` we inspect to derive it is typed as `AnyObject`. I would love to change that, but I suspect the payoff in safety would not be worth the effort in typing.

> Bang bang, you're a boolean!

### Related ticket(s)
MDCT-2970

---
### How to test
1. Create a MCPAR report
2. Add a plan
3. Create a quality measure _without_ adding any results
4. View the PDF export page
5. Confirm that there is no zero displayed between the "Measure results" heading and the "not answered" message

### Important updates
n/a

---
### Author checklist

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
