### PR TITLE
fix aria-label parsing from json

### DIFF
--- a/services/ui-src/src/forms/adminDashSelector/adminDashSelector.ts
+++ b/services/ui-src/src/forms/adminDashSelector/adminDashSelector.ts
@@ -30,7 +30,7 @@ export default {
       props: {
         hint: "Select state to view reports:",
         options: dropdownOptions,
-        "aria-description":
+        ariaLabel:
           "List of states, including District of Columbia and Puerto Rico",
       },
     },
@@ -41,7 +41,7 @@ export default {
       props: {
         hint: "Select a report:",
         choices: reportChoices,
-        "aria-description": "Choices of report type",
+        ariaLabel: "Choices of report type",
       },
     },
   ],

--- a/services/ui-src/src/forms/adminDashSelector/adminDashSelector.ts
+++ b/services/ui-src/src/forms/adminDashSelector/adminDashSelector.ts
@@ -30,7 +30,7 @@ export default {
       props: {
         hint: "Select state to view reports:",
         options: dropdownOptions,
-        "aria-label":
+        "aria-description":
           "List of states, including District of Columbia and Puerto Rico",
       },
     },
@@ -41,7 +41,7 @@ export default {
       props: {
         hint: "Select a report:",
         choices: reportChoices,
-        "aria-label": "Choices of report type",
+        "aria-description": "Choices of report type",
       },
     },
   ],

--- a/services/ui-src/src/forms/adminDashSelector/adminDashSelector.ts
+++ b/services/ui-src/src/forms/adminDashSelector/adminDashSelector.ts
@@ -30,7 +30,7 @@ export default {
       props: {
         hint: "Select state to view reports:",
         options: dropdownOptions,
-        ariaLabel:
+        "aria-label":
           "List of states, including District of Columbia and Puerto Rico",
       },
     },
@@ -41,7 +41,7 @@ export default {
       props: {
         hint: "Select a report:",
         choices: reportChoices,
-        ariaLabel: "Choices of report type",
+        "aria-label": "Choices of report type",
       },
     },
   ],

--- a/services/ui-src/src/verbiage/pages/accordion.ts
+++ b/services/ui-src/src/verbiage/pages/accordion.ts
@@ -14,7 +14,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-B/section-438.74",
             target: "_blank",
-            ariaLabel: "Link opens in new tab",
+            "aria-label": "Link opens in new tab",
           },
         },
         {
@@ -29,7 +29,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
             target: "_blank",
-            ariaLabel: "Link opens in new tab",
+            "aria-label": "Link opens in new tab",
           },
         },
         {
@@ -44,7 +44,7 @@ export default {
           props: {
             href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#MLR",
             target: "_blank",
-            ariaLabel: "Link opens in new tab",
+            "aria-label": "Learn more about the Medical Loss Ratio report.",
           },
         },
         {
@@ -74,7 +74,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-B/section-438.74",
             target: "_blank",
-            ariaLabel: "Link opens in new tab",
+            "aria-label": "Link opens in new tab",
           },
         },
         {
@@ -89,7 +89,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
             target: "_blank",
-            ariaLabel: "Link opens in new tab",
+            "aria-label": "Link opens in new tab",
           },
         },
         {
@@ -104,7 +104,7 @@ export default {
           props: {
             href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#MLR",
             target: "_blank",
-            ariaLabel: "Link opens in new tab",
+            "aria-label": "Learn more about the Medical Loss Ratio report.",
           },
         },
         {
@@ -131,7 +131,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
             target: "_blank",
-            ariaLabel: "Link opens in new tab",
+            "aria-label": "Link opens in new tab",
           },
         },
         {
@@ -146,7 +146,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(l)",
             target: "_blank",
-            ariaLabel: "Link opens in new tab",
+            "aria-label": "Link opens in new tab",
           },
         },
         {
@@ -174,7 +174,7 @@ export default {
           props: {
             href: "https://www.medicaid.gov/federal-policy-guidance/downloads/cib073117.pdf",
             target: "_blank",
-            ariaLabel: "Link opens in new tab",
+            "aria-label": "Link opens in new tab",
           },
         },
         {

--- a/services/ui-src/src/verbiage/pages/accordion.ts
+++ b/services/ui-src/src/verbiage/pages/accordion.ts
@@ -14,7 +14,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-B/section-438.74",
             target: "_blank",
-            "aria-label": "Link opens in new tab",
+            "aria-description": "Link opens in new tab",
           },
         },
         {
@@ -29,7 +29,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
             target: "_blank",
-            "aria-label": "Link opens in new tab",
+            "aria-description": "Link opens in new tab",
           },
         },
         {
@@ -40,11 +40,11 @@ export default {
         },
         {
           type: "externalLink",
-          content: "Learn more",
+          content: "Learn more about the Medical Loss Ratio report",
           props: {
             href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#MLR",
             target: "_blank",
-            "aria-label": "Learn more about the Medical Loss Ratio report.",
+            "aria-description": "Link opens in new tab",
           },
         },
         {
@@ -74,7 +74,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-B/section-438.74",
             target: "_blank",
-            "aria-label": "Link opens in new tab",
+            "aria-description": "Link opens in new tab",
           },
         },
         {
@@ -89,7 +89,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
             target: "_blank",
-            "aria-label": "Link opens in new tab",
+            "aria-description": "Link opens in new tab",
           },
         },
         {
@@ -100,11 +100,11 @@ export default {
         },
         {
           type: "externalLink",
-          content: "Learn more",
+          content: "Learn more about the Medical Loss Ratio report",
           props: {
             href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#MLR",
             target: "_blank",
-            "aria-label": "Learn more about the Medical Loss Ratio report.",
+            "aria-description": "Link opens in new tab",
           },
         },
         {
@@ -131,7 +131,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
             target: "_blank",
-            "aria-label": "Link opens in new tab",
+            "aria-description": "Link opens in new tab",
           },
         },
         {
@@ -146,7 +146,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(l)",
             target: "_blank",
-            "aria-label": "Link opens in new tab",
+            "aria-description": "Link opens in new tab",
           },
         },
         {
@@ -174,7 +174,7 @@ export default {
           props: {
             href: "https://www.medicaid.gov/federal-policy-guidance/downloads/cib073117.pdf",
             target: "_blank",
-            "aria-label": "Link opens in new tab",
+            "aria-description": "Link opens in new tab",
           },
         },
         {

--- a/services/ui-src/src/verbiage/pages/accordion.ts
+++ b/services/ui-src/src/verbiage/pages/accordion.ts
@@ -14,7 +14,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-B/section-438.74",
             target: "_blank",
-            "aria-label": "42 CFR § 438.74. Link opens in new tab.",
+            "aria-label": "42 CFR § 438.74 (link opens in new tab)",
           },
         },
         {
@@ -29,7 +29,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
             target: "_blank",
-            "aria-label": "42 CFR § 438.8(k). Link opens in new tab.",
+            "aria-label": "42 CFR § 438.8(k) (link opens in new tab)",
           },
         },
         {
@@ -45,7 +45,7 @@ export default {
             href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#MLR",
             target: "_blank",
             "aria-label":
-              "Learn more about the Medical Loss Ratio report. Link opens in new tab.",
+              "Learn more about the Medical Loss Ratio report (link opens in new tab)",
           },
         },
         {
@@ -75,7 +75,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-B/section-438.74",
             target: "_blank",
-            "aria-label": "42 CFR § 438.74. Link opens in new tab.",
+            "aria-label": "42 CFR § 438.74 (link opens in new tab)",
           },
         },
         {
@@ -90,7 +90,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
             target: "_blank",
-            "aria-label": "42 CFR § 438.8(k). Link opens in new tab.",
+            "aria-label": "42 CFR § 438.8(k) (link opens in new tab)",
           },
         },
         {
@@ -106,7 +106,7 @@ export default {
             href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#MLR",
             target: "_blank",
             "aria-label":
-              "Learn more about the Medical Loss Ratio report. Link opens in new tab.",
+              "Learn more about the Medical Loss Ratio report (link opens in new tab)",
           },
         },
         {
@@ -133,7 +133,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
             target: "_blank",
-            "aria-label": "42 CFR § 438.8(k). Link opens in new tab.",
+            "aria-label": "42 CFR § 438.8(k) (link opens in new tab)",
           },
         },
         {
@@ -148,7 +148,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(l)",
             target: "_blank",
-            "aria-label": "42 CFR § 438.8(l). Link opens in new tab.",
+            "aria-label": "42 CFR § 438.8(l) (link opens in new tab)",
           },
         },
         {
@@ -177,7 +177,7 @@ export default {
             href: "https://www.medicaid.gov/federal-policy-guidance/downloads/cib073117.pdf",
             target: "_blank",
             "aria-label":
-              "CMCS Informational Bulletin dated July 31, 2017. Link opens in new tab.",
+              "CMCS Informational Bulletin dated July 31, 2017 (link opens in new tab)",
           },
         },
         {

--- a/services/ui-src/src/verbiage/pages/accordion.ts
+++ b/services/ui-src/src/verbiage/pages/accordion.ts
@@ -14,7 +14,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-B/section-438.74",
             target: "_blank",
-            "aria-description": "Link opens in new tab",
+            "aria-label": "42 CFR § 438.74. Link opens in new tab.",
           },
         },
         {
@@ -29,7 +29,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
             target: "_blank",
-            "aria-description": "Link opens in new tab",
+            "aria-label": "42 CFR § 438.8(k). Link opens in new tab.",
           },
         },
         {
@@ -44,7 +44,8 @@ export default {
           props: {
             href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#MLR",
             target: "_blank",
-            "aria-description": "Link opens in new tab",
+            "aria-label":
+              "Learn more about the Medical Loss Ratio report. Link opens in new tab.",
           },
         },
         {
@@ -74,7 +75,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-B/section-438.74",
             target: "_blank",
-            "aria-description": "Link opens in new tab",
+            "aria-label": "42 CFR § 438.74. Link opens in new tab.",
           },
         },
         {
@@ -89,7 +90,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
             target: "_blank",
-            "aria-description": "Link opens in new tab",
+            "aria-label": "42 CFR § 438.8(k). Link opens in new tab.",
           },
         },
         {
@@ -104,7 +105,8 @@ export default {
           props: {
             href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#MLR",
             target: "_blank",
-            "aria-description": "Link opens in new tab",
+            "aria-label":
+              "Learn more about the Medical Loss Ratio report. Link opens in new tab.",
           },
         },
         {
@@ -131,7 +133,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
             target: "_blank",
-            "aria-description": "Link opens in new tab",
+            "aria-label": "42 CFR § 438.8(k). Link opens in new tab.",
           },
         },
         {
@@ -146,7 +148,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(l)",
             target: "_blank",
-            "aria-description": "Link opens in new tab",
+            "aria-label": "42 CFR § 438.8(l). Link opens in new tab.",
           },
         },
         {
@@ -174,7 +176,8 @@ export default {
           props: {
             href: "https://www.medicaid.gov/federal-policy-guidance/downloads/cib073117.pdf",
             target: "_blank",
-            "aria-description": "Link opens in new tab",
+            "aria-label":
+              "CMCS Informational Bulletin dated July 31, 2017. Link opens in new tab.",
           },
         },
         {

--- a/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard-without-yoy.ts
+++ b/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard-without-yoy.ts
@@ -18,7 +18,7 @@ export default {
         props: {
           href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#AMCPR",
           target: "_blank",
-          "aria-label": "Learn more (link opens in new tab).",
+          "aria-description": "Link opens in new tab",
         },
       },
     ],

--- a/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard-without-yoy.ts
+++ b/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard-without-yoy.ts
@@ -18,7 +18,7 @@ export default {
         props: {
           href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#AMCPR",
           target: "_blank",
-          "aria-description": "Link opens in new tab",
+          "aria-label": "Learn more. Link opens in new tab.",
         },
       },
     ],

--- a/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard-without-yoy.ts
+++ b/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard-without-yoy.ts
@@ -18,7 +18,7 @@ export default {
         props: {
           href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#AMCPR",
           target: "_blank",
-          "aria-label": "Learn more. Link opens in new tab.",
+          "aria-label": "Learn more (link opens in new tab)",
         },
       },
     ],

--- a/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard.ts
+++ b/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard.ts
@@ -18,7 +18,7 @@ export default {
         props: {
           href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#AMCPR",
           target: "_blank",
-          "aria-label": "Learn more (link opens in new tab).",
+          "aria-description": "Link opens in new tab",
         },
       },
     ],

--- a/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard.ts
+++ b/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard.ts
@@ -18,7 +18,7 @@ export default {
         props: {
           href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#AMCPR",
           target: "_blank",
-          "aria-description": "Link opens in new tab",
+          "aria-label": "Learn more. Link opens in new tab.",
         },
       },
     ],

--- a/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard.ts
+++ b/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard.ts
@@ -18,7 +18,7 @@ export default {
         props: {
           href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#AMCPR",
           target: "_blank",
-          "aria-label": "Learn more. Link opens in new tab.",
+          "aria-label": "Learn more (link opens in new tab)",
         },
       },
     ],

--- a/services/ui-src/src/verbiage/pages/mlr/mlr-review-and-submit.ts
+++ b/services/ui-src/src/verbiage/pages/mlr/mlr-review-and-submit.ts
@@ -21,7 +21,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-B/section-438.74",
             target: "_blank",
-            "aria-label": "42 CFR § 438.74. Link opens in new tab.",
+            "aria-label": "42 CFR § 438.74 (link opens in new tab)",
           },
         },
         {

--- a/services/ui-src/src/verbiage/pages/mlr/mlr-review-and-submit.ts
+++ b/services/ui-src/src/verbiage/pages/mlr/mlr-review-and-submit.ts
@@ -21,7 +21,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-B/section-438.74",
             target: "_blank",
-            "aria-description": "Link opens in new tab",
+            "aria-label": "42 CFR § 438.74. Link opens in new tab.",
           },
         },
         {

--- a/services/ui-src/src/verbiage/pages/mlr/mlr-review-and-submit.ts
+++ b/services/ui-src/src/verbiage/pages/mlr/mlr-review-and-submit.ts
@@ -21,7 +21,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-B/section-438.74",
             target: "_blank",
-            "aria-label": "Link opens in new tab",
+            "aria-description": "Link opens in new tab",
           },
         },
         {

--- a/services/ui-src/src/verbiage/pages/mlr/mlr-review-and-submit.ts
+++ b/services/ui-src/src/verbiage/pages/mlr/mlr-review-and-submit.ts
@@ -21,7 +21,7 @@ export default {
           props: {
             href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-B/section-438.74",
             target: "_blank",
-            ariaLabel: "Link opens in new tab",
+            "aria-label": "Link opens in new tab",
           },
         },
         {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Fix aria-label parsing (`ariaLabel` was not converting to `aria-label`)
Update label text to announce content of link as well as the fact that it opens in a new tab.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-3030
MDCT-2981

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Login as state user
Navigate to MLR and/or MCPAR dashboard 
Turn on your MacOS screen reader
  - Settings -> Accessibility -> VoiceOver -> Toggle On

Tab between links in description text and validate they announce the content of the text and that it opens in a new tab

Navigate to the revew-and-submit page for MLR.
Validate the link in the description text announces the content of the text and that it opens in a new tab

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
---
