### PR TITLE
Fix blank header cells for screen readers

### DIFF
--- a/services/ui-src/src/components/tables/Table.tsx
+++ b/services/ui-src/src/components/tables/Table.tsx
@@ -13,7 +13,11 @@ import {
 // utils
 import { sanitizeAndParseHtml } from "utils";
 // types
-import { AnyObject, TableContentShape } from "types";
+import {
+  AnyObject,
+  ScreenReaderOnlyHeaderName,
+  TableContentShape,
+} from "types";
 
 export const Table = ({
   content,
@@ -37,15 +41,26 @@ export const Table = ({
         <Thead>
           {/* Head Row */}
           <Tr>
-            {content.headRow.map((headerCell: string, index: number) => (
-              <Th
-                key={index}
-                scope="col"
-                sx={{ ...sx.tableHeader, ...sxOverride }}
-              >
-                {sanitizeAndParseHtml(headerCell)}
-              </Th>
-            ))}
+            {content.headRow.map(
+              (
+                headerCell: string | ScreenReaderOnlyHeaderName,
+                index: number
+              ) => (
+                <Th
+                  key={index}
+                  scope="col"
+                  sx={{ ...sx.tableHeader, ...sxOverride }}
+                >
+                  {typeof headerCell === "object" ? (
+                    <VisuallyHidden>
+                      {sanitizeAndParseHtml(headerCell.hiddenName)}
+                    </VisuallyHidden>
+                  ) : (
+                    sanitizeAndParseHtml(headerCell)
+                  )}
+                </Th>
+              )
+            )}
           </Tr>
         </Thead>
       )}

--- a/services/ui-src/src/types/other.ts
+++ b/services/ui-src/src/types/other.ts
@@ -42,9 +42,13 @@ export interface InputChangeEvent extends React.ChangeEvent<HTMLInputElement> {}
 
 export type { IconType } from "react-icons";
 
+export interface ScreenReaderOnlyHeaderName {
+  hiddenName: string;
+}
+
 export interface TableContentShape {
   caption?: string;
-  headRow?: string[];
+  headRow?: Array<string | ScreenReaderOnlyHeaderName>;
   bodyRows?: string[][];
 }
 

--- a/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard.ts
+++ b/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard.ts
@@ -27,13 +27,13 @@ export default {
     table: {
       caption: "MCPAR Programs",
       headRow: [
-        "",
+        { hiddenName: "Edit report name and details" },
         "Program name",
         "Due date",
         "Last edited",
         "Edited by",
         "Status",
-        "",
+        { hiddenName: "Actions" },
       ],
     },
     empty:

--- a/services/ui-src/src/verbiage/pages/mcpar/mcpar-review-and-submit.ts
+++ b/services/ui-src/src/verbiage/pages/mcpar/mcpar-review-and-submit.ts
@@ -11,7 +11,7 @@ export default {
       info: "Double check that everything in your MCPAR Report is accurate. You will be able to make edits after submitting, and resubmit. Once you’ve reviewed your report, certify that it’s in compliance with 42 CFR § 438.66(e).",
     },
     table: {
-      headRow: ["Section", "Status", ""],
+      headRow: ["Section", "Status", { hiddenName: "Actions" }],
     },
     modal: {
       structure: {

--- a/services/ui-src/src/verbiage/pages/mlr/mlr-dashboard.ts
+++ b/services/ui-src/src/verbiage/pages/mlr/mlr-dashboard.ts
@@ -17,13 +17,13 @@ export default {
     table: {
       caption: "MLR Submissions",
       headRow: [
-        "",
+        { hiddenName: "Edit report name" },
         "Submission name",
         "Last edited",
         "Edited by",
         "Status",
         "#",
-        "",
+        { hiddenName: "Actions" },
       ],
     },
     empty:

--- a/services/ui-src/src/verbiage/pages/mlr/mlr-review-and-submit.ts
+++ b/services/ui-src/src/verbiage/pages/mlr/mlr-review-and-submit.ts
@@ -31,6 +31,9 @@ export default {
         },
       ],
     },
+    table: {
+      headRow: ["Section", "Status", { hiddenName: "Actions" }],
+    },
     modal: {
       structure: {
         heading: "Are you sure you want to submit MLR?",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Adds descriptive labels to the table columns that have no visible header

Uses [Chakra's Visually Hidden component](https://chakra-ui.com/docs/components/visually-hidden)

Please comment with better ideas for carrying and parsing the hidden names. I considered just a text string like `hidden.Actions` and checking for that with `includes` but the object seems more...formal. Less hacky. I'm sure there is an even smarter way.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-3031
MDCT-2981

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Launch and login as state user
Go to MLR dashboard
Add a report if there are none
Turn on your MacOS screen reader
  Settings -> Accessibility -> VoiceOver -> Toggle On
From here you can test one of two ways:
1. Refresh the page and let VoiceOver start reading all content
  - When it gets to the empty columns (first and last) it should announce something relevant to that column
  - "Edit report name" for first column and "Actions" for last column
2. Click on or near the dashboard table (use tabs to move focus as needed)
  - Once in the table, use `ctrl` + `option` + `arrow keys` to move around
  - When you are at the heading or underneath the first or last column it should announce the column name (I think if you start at the top and go straight down it will not, but if you switch columns side to side it will)

Can also verify review and submit page has "actions" as its third header for the page table

Please reach out to me if you want to learn more about how to test this!

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
---
