### PR TITLE
remove smaMfcu items from plans to copy

### DIFF
--- a/services/app-api/utils/constants/constants.ts
+++ b/services/app-api/utils/constants/constants.ts
@@ -126,8 +126,6 @@ export const McparFieldsToCopy = {
     "plan_medicalLossRatioReportingPeriodEndDate",
     "program_encounterDataSubmissionTimelinessStandardDefinition",
     "plan_programIntegrityReferralPath",
-    "plan_smaMfcuConcurrentProgramIntegrityReferrals",
-    "plan_smaMfcuAggregateProgramIntegrityReferrals",
     "plan_beneficiaryCircumstanceChangeReportingFrequency",
   ],
   qualityMeasures: [


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The last 2 radio button options of question D1.X.7 were being copied over when using the YoY Copy feature, and should not have been. 
This PR removes those 2 ids from the constants of what to copy over.
<img width="532" alt="Screenshot 2023-10-19 at 12 30 50 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/10237149/7d3d7d1c-40d2-4773-b515-616e48200802">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-315

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
submit a MCPAR
create a new MCPAR using the submitted one to copy from
view D1.X.7 and see that D1.X.6 was copied over, but D1.X.7 was not copied over.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
