### PR TITLE
Add x-frame-options header

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -246,6 +246,7 @@ resources:
             headers['x-content-type-options'] = { value: 'nosniff' };
             headers['x-xss-protection'] = { value: '0' };
             headers["content-security-policy"] = { value: "default-src 'self'; img-src 'self' data: https://www.google-analytics.com; script-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com tags.tiqcdn.com tags.tiqcdn.cn tags-eu.tiqcdn.com https://*.adoberesources.net 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src https://*.amazonaws.com/ https://*.amazoncognito.com https://www.google-analytics.com https://*.launchdarkly.us https://adobe-ep.cms.gov https://adobedc.demdex.net; frame-ancestors 'none'; object-src 'none'"};
+            headers['x-frame-options'] = { value: 'DENY' };
             return response;
           }
         FunctionConfig:


### PR DESCRIPTION
### Description
This PR adds an additional HTTP header when serving the website, which instructs browsers not to serve our content within an iframe.

### Related ticket(s)
CMDCT-271

---
### How to test
We don't use iframes to serve this website, so this PR shouldn't change anything. A quick smoke test (as provided by Cypress) should be sufficient.

### Important updates
n/a

---
### Author checklist

- [x] I have performed a self-review of my code
- ~[ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary~
- ~[ ] I have updated relevant documentation, if necessary~

