### PR TITLE
MDCT-2983: Cleaning Up LD Feature Flags

### DIFF
--- a/services/ui-src/src/components/export/ExportedReportBanner.tsx
+++ b/services/ui-src/src/components/export/ExportedReportBanner.tsx
@@ -1,10 +1,7 @@
-import { useFlags } from "launchdarkly-react-client-sdk";
 // assets
 import pdfIcon from "assets/icons/icon_pdf_white.png";
 // components
 import { Box, Button, Image, Text } from "@chakra-ui/react";
-// utils
-import { printPdf } from "utils";
 // verbiage
 import mcparVerbiage from "verbiage/pages/mcpar/mcpar-export";
 import mlrVerbiage from "verbiage/pages/mlr/mlr-export";
@@ -25,11 +22,9 @@ export const ExportedReportBanner = () => {
 
   const verbiage = verbiageMap[reportType];
   const { reportBanner } = verbiage;
-  const printExperience = useFlags()?.printExperience;
 
   const onClickHandler = () => {
-    if (printExperience === "prince") printPdf();
-    else window?.print();
+    window?.print();
   };
 
   return (

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.test.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.test.tsx
@@ -8,10 +8,8 @@ import { ReportStatus } from "types";
 // utils
 import {
   mockAdminUser,
-  mockLDFlags,
   mockMcparReport,
   mockMcparReportContext,
-  mockMlrReportContext,
   mockStateUser,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
@@ -22,8 +20,6 @@ import reviewVerbiage from "verbiage/pages/mcpar/mcpar-review-and-submit";
 
 jest.mock("utils/auth/useUser");
 const mockedUseUser = useUser as jest.MockedFunction<typeof useUser>;
-
-mockLDFlags.setDefault({ pdfExport: false });
 
 describe("MCPAR Review and Submit Page Functionality", () => {
   beforeEach(() => {
@@ -245,38 +241,13 @@ describe("MCPAR Review and Submit Page - Launch Darkly", () => {
     </RouterWrappedComponent>
   );
 
-  const MlrReviewSubmitPage_InProgress = (
-    <RouterWrappedComponent>
-      <ReportContext.Provider value={mockMlrReportContext}>
-        <ReviewSubmitPage />
-      </ReportContext.Provider>
-    </RouterWrappedComponent>
-  );
-
   describe("When loading an in-progress report", () => {
-    it("if pdfExport flag is true, Review PDF button should be visible and correctly formed", async () => {
-      mockLDFlags.set({ pdfExport: true });
+    it("Review PDF button should be visible and correctly formed", async () => {
       render(McparReviewSubmitPage_InProgress);
       const printButton = screen.getByText("Review PDF");
       expect(printButton).toBeVisible();
       expect(printButton.getAttribute("href")).toEqual("/mcpar/export");
       expect(printButton.getAttribute("target")).toEqual("_blank");
-    });
-
-    it("if pdfExport flag is true and type is MLR, Review PDF button should be visible and correctly formed", async () => {
-      mockLDFlags.set({ pdfExport: true });
-      render(MlrReviewSubmitPage_InProgress);
-      const printButton = screen.getByText("Review PDF");
-      expect(printButton).toBeVisible();
-      expect(printButton.getAttribute("href")).toEqual("/mlr/export");
-      expect(printButton.getAttribute("target")).toEqual("_blank");
-    });
-
-    it("if pdfExport flag is false, Review PDF button should not render", async () => {
-      mockLDFlags.set({ pdfExport: false });
-      render(McparReviewSubmitPage_InProgress);
-      const printButton = screen.queryByText("Review PDF");
-      expect(printButton).not.toBeInTheDocument();
     });
   });
 
@@ -298,20 +269,12 @@ describe("MCPAR Review and Submit Page - Launch Darkly", () => {
         </ReportContext.Provider>
       </RouterWrappedComponent>
     );
-    it("if pdfExport flag is true, Review PDF button should be visible and correctly formed", async () => {
-      mockLDFlags.set({ pdfExport: true });
+    it("Review PDF button should be visible and correctly formed", async () => {
       render(McparReviewSubmitPage_Submitted);
       const printButton = screen.getByRole("link");
       expect(printButton).toBeVisible();
       expect(printButton.getAttribute("href")).toEqual("/mcpar/export");
       expect(printButton.getAttribute("target")).toEqual("_blank");
-    });
-
-    it("if pdfExport flag is false, Review PDF button should not render", async () => {
-      mockLDFlags.set({ pdfExport: false });
-      render(McparReviewSubmitPage_Submitted);
-      const printButton = screen.queryByText("Review PDF");
-      expect(printButton).not.toBeInTheDocument();
     });
   });
 });

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -1,6 +1,5 @@
 import { MouseEventHandler, useContext, useEffect, useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
-import { useFlags } from "launchdarkly-react-client-sdk";
 // components
 import {
   Box,
@@ -156,7 +155,6 @@ const ReadyToSubmit = ({
 }: ReadyToSubmitProps) => {
   const { review } = reviewVerbiage;
   const { intro, modal, pageLink } = review;
-  const pdfExport = useFlags()?.pdfExport;
 
   return (
     <Flex sx={sx.contentContainer} data-testid="ready-view">
@@ -174,7 +172,7 @@ const ReadyToSubmit = ({
         </Box>
       </Box>
       <Flex sx={sx.submitContainer}>
-        {pdfExport && <PrintButton reviewVerbiage={reviewVerbiage} />}
+        <PrintButton reviewVerbiage={reviewVerbiage} />
         <Button
           type="submit"
           onClick={onOpen as MouseEventHandler}
@@ -255,7 +253,6 @@ export const SuccessMessage = ({
     submittedBy,
     stateName
   );
-  const pdfExport = useFlags()?.pdfExport;
 
   return (
     <Flex sx={sx.contentContainer}>
@@ -275,11 +272,9 @@ export const SuccessMessage = ({
         <Text sx={sx.additionalInfoHeader}>{intro.additionalInfoHeader}</Text>
         <Text sx={sx.additionalInfo}>{intro.additionalInfo}</Text>
       </Box>
-      {pdfExport && (
-        <Box sx={sx.infoTextBox}>
-          <PrintButton reviewVerbiage={reviewVerbiage} />
-        </Box>
-      )}
+      <Box sx={sx.infoTextBox}>
+        <PrintButton reviewVerbiage={reviewVerbiage} />
+      </Box>
     </Flex>
   );
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Removing the `printExperience` and `pdfExport` feature flags from our codebase since they are no longer being used.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-2983

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Create any report (MCPAR or MLR)
- Review its PDF on the `Review & submit` page

Expected behavior is as follows:
- You are able to review the PDF in a new tab
- If you click **Print**, the `window.print()` function is called (_not Prince_)

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
