### PR TITLE
MDCT-3023: MCPAR Admin Dashboard Update (UI Changes)

### DIFF
--- a/services/app-api/handlers/reports/release.test.ts
+++ b/services/app-api/handlers/reports/release.test.ts
@@ -63,18 +63,6 @@ describe("Test releaseReport method", () => {
     expect(body.fieldDataId).not.toBe(mockDynamoDataMLRLocked.fieldDataId);
   });
 
-  test("Test release report fails if its not a real MLR report", async () => {
-    mockDocumentClient.get.promise.mockReturnValueOnce({
-      Item: {
-        ...mockDynamoDataMLRLocked,
-        locked: undefined,
-      },
-    });
-    const res = await releaseReport(releaseEvent, null);
-    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
-    expect(res.body).toContain(error.NO_MATCHING_RECORD);
-  });
-
   test("Test release report passes with valid data, but it's been more than the first submission", async () => {
     const newPreviousId = KSUID.randomSync().string;
     mockDocumentClient.get.promise.mockReturnValueOnce({

--- a/services/app-api/handlers/reports/release.test.ts
+++ b/services/app-api/handlers/reports/release.test.ts
@@ -42,7 +42,6 @@ describe("Test releaseReport method", () => {
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
       .mockReturnValueOnce(false);
   });
   afterEach(() => {

--- a/services/app-api/handlers/reports/release.ts
+++ b/services/app-api/handlers/reports/release.ts
@@ -175,6 +175,7 @@ export const releaseReport = handler(async (event) => {
     locked: false,
     isComplete: reportType === ReportType.MLR ? false : true,
     archived: isArchived,
+    submissionCount: metadata.submissionCount,
     previousRevisions,
   };
 

--- a/services/app-api/handlers/reports/release.ts
+++ b/services/app-api/handlers/reports/release.ts
@@ -17,7 +17,7 @@ import {
   DynamoGet,
   DynamoWrite,
   FormJson,
-  MLRReportMetadata,
+  ReportMetadata,
   S3Get,
   S3Put,
   StatusCodes,
@@ -27,7 +27,7 @@ import { calculateCompletionStatus } from "../../utils/validation/completionStat
 import { AnyObject } from "yup/lib/types";
 
 /**
- * Locked MLR reports can be released by admins.
+ * Locked reports can be released by admins.
  *
  * When reports are released:
  *
@@ -156,17 +156,24 @@ export const releaseReport = handler(async (event) => {
     "versionControlDescription-otherText": null,
   };
 
-  const newReportMetadata: MLRReportMetadata = {
+  const newReportMetadata: ReportMetadata = {
     ...metadata,
+    id: metadata.id,
+    formTemplateId: metadata.formTemplateId,
     fieldDataId: newFieldDataId,
-    locked: false,
-    previousRevisions,
     status: "In progress",
+    lastAltered: metadata.lastAltered,
+    lastAlteredBy: metadata.lastAlteredBy,
+    reportType: metadata.reportType,
+    createdAt: metadata.createdAt,
+    state: metadata.state,
     completionStatus: await calculateCompletionStatus(
       updatedFieldData,
       formTemplate
     ),
     isComplete: false,
+    archived: isArchived,
+    previousRevisions,
   };
 
   const putReportMetadataParams: DynamoWrite = {

--- a/services/app-api/handlers/reports/release.ts
+++ b/services/app-api/handlers/reports/release.ts
@@ -25,7 +25,6 @@ import {
   UserRoles,
 } from "../../utils/types";
 import { calculateCompletionStatus } from "../../utils/validation/completionStatus";
-import { AnyObject } from "yup/lib/types";
 
 /**
  * Locked reports can be released by admins.
@@ -86,7 +85,7 @@ export const releaseReport = handler(async (event) => {
     };
   }
 
-  const metadata: AnyObject = reportMetadata.Item;
+  const metadata = reportMetadata.Item as ReportMetadata;
 
   // check if report is locked
   const isLocked = metadata.locked;
@@ -159,20 +158,13 @@ export const releaseReport = handler(async (event) => {
 
   const newReportMetadata: ReportMetadata = {
     ...metadata,
-    id: metadata.id,
-    formTemplateId: metadata.formTemplateId,
     fieldDataId: newFieldDataId,
     status: "In progress",
-    lastAltered: metadata.lastAltered,
-    lastAlteredBy: metadata.lastAlteredBy,
-    reportType: metadata.reportType,
-    createdAt: metadata.createdAt,
-    state: metadata.state,
+    locked: false,
     completionStatus: await calculateCompletionStatus(
       updatedFieldData,
       formTemplate
     ),
-    locked: false,
     isComplete: reportType === ReportType.MLR ? false : true,
     archived: isArchived,
     submissionCount: metadata.submissionCount,

--- a/services/app-api/handlers/reports/release.ts
+++ b/services/app-api/handlers/reports/release.ts
@@ -17,7 +17,6 @@ import {
   DynamoGet,
   DynamoWrite,
   FormJson,
-  isMLRReportMetadata,
   MLRReportMetadata,
   S3Get,
   S3Put,
@@ -25,6 +24,7 @@ import {
   UserRoles,
 } from "../../utils/types";
 import { calculateCompletionStatus } from "../../utils/validation/completionStatus";
+import { AnyObject } from "yup/lib/types";
 
 /**
  * Locked MLR reports can be released by admins.
@@ -85,16 +85,9 @@ export const releaseReport = handler(async (event) => {
     };
   }
 
-  const metadata = reportMetadata.Item;
+  const metadata: AnyObject = reportMetadata.Item;
 
-  // Non MLR reports cannot be released.
-  if (!isMLRReportMetadata(metadata)) {
-    return {
-      status: StatusCodes.NOT_FOUND,
-      body: error.NO_MATCHING_RECORD,
-    };
-  }
-
+  // check if report is locked
   const isLocked = metadata.locked;
 
   // Report is not locked.
@@ -107,6 +100,7 @@ export const releaseReport = handler(async (event) => {
     };
   }
 
+  // check if report is archived
   const isArchived = metadata.archived;
 
   if (isArchived) {

--- a/services/app-api/handlers/reports/release.ts
+++ b/services/app-api/handlers/reports/release.ts
@@ -172,6 +172,7 @@ export const releaseReport = handler(async (event) => {
       updatedFieldData,
       formTemplate
     ),
+    locked: false,
     isComplete: reportType === ReportType.MLR ? false : true,
     archived: isArchived,
     previousRevisions,

--- a/services/app-api/handlers/reports/release.ts
+++ b/services/app-api/handlers/reports/release.ts
@@ -18,6 +18,7 @@ import {
   DynamoWrite,
   FormJson,
   ReportMetadata,
+  ReportType,
   S3Get,
   S3Put,
   StatusCodes,
@@ -171,7 +172,7 @@ export const releaseReport = handler(async (event) => {
       updatedFieldData,
       formTemplate
     ),
-    isComplete: false,
+    isComplete: reportType === ReportType.MLR ? false : true,
     archived: isArchived,
     previousRevisions,
   };

--- a/services/app-api/handlers/reports/submit.test.ts
+++ b/services/app-api/handlers/reports/submit.test.ts
@@ -60,7 +60,9 @@ describe("Test submitReport API method", () => {
     expect(body.status).toStrictEqual("Submitted");
     expect(body.submittedBy).toStrictEqual("Thelonious States");
     expect(body.submittedOnDate).toBeTruthy();
-    expect(body.locked).toBe(undefined);
+    // new functionality for MCPAR
+    expect(body.locked).toBe(true);
+    expect(body.submissionCount).toBe(1);
   });
 
   test("Test MLR reports get locked and have submission count updated.", async () => {

--- a/services/app-api/handlers/reports/submit.ts
+++ b/services/app-api/handlers/reports/submit.ts
@@ -19,7 +19,6 @@ import s3Lib, {
 import { convertDateUtcToEt } from "../../utils/time/time";
 // types
 import {
-  isMLRReportMetadata,
   isState,
   MCPARReportMetadata,
   MLRReportMetadata,
@@ -109,14 +108,13 @@ export const submitReport = handler(async (event, _context) => {
 
     const date = Date.now();
     const fullName = `${jwt.given_name} ${jwt.family_name}`;
-    const isMLR = isMLRReportMetadata(reportMetadata);
     const newItem = {
       ...reportMetadata,
       submittedBy: fullName,
       submittedOnDate: date,
       status: "Submitted",
-      locked: isMLR ? true : undefined,
-      submissionCount: isMLR ? reportMetadata.submissionCount + 1 : undefined,
+      locked: true,
+      submissionCount: reportMetadata.submissionCount + 1,
     };
 
     const submitReportParams = {

--- a/services/app-api/utils/formTemplates/formTemplates.test.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.test.ts
@@ -150,6 +150,7 @@ describe("Test getOrCreateFormTemplate MCPAR", () => {
     expect(result.formTemplateVersion?.md5Hash).toEqual(currentMCPARFormHash);
   });
 });
+
 describe("Test getOrCreateFormTemplate MLR", () => {
   beforeEach(() => {
     jest.restoreAllMocks();

--- a/services/app-api/utils/testing/setupJest.ts
+++ b/services/app-api/utils/testing/setupJest.ts
@@ -171,6 +171,8 @@ export const mockDynamoDataCompleted: MCPARReportMetadata = {
   submittedBy: "",
   submittedOnDate: "",
   submissionCount: 0,
+  locked: false,
+  previousRevisions: [],
 };
 
 export const mockDynamoDataMLRComplete: MLRReportMetadata = {

--- a/services/app-api/utils/testing/setupJest.ts
+++ b/services/app-api/utils/testing/setupJest.ts
@@ -170,6 +170,7 @@ export const mockDynamoDataCompleted: MCPARReportMetadata = {
   archived: false,
   submittedBy: "",
   submittedOnDate: "",
+  submissionCount: 0,
 };
 
 export const mockDynamoDataMLRComplete: MLRReportMetadata = {

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -134,13 +134,13 @@ export interface ReportMetadata {
   status: string;
   isComplete: boolean;
   completionStatus?: CompletionData;
+  submissionCount: number;
 }
 
 export interface MLRReportMetadata extends ReportMetadata {
   locked: boolean;
   reportType: "MLR";
   submissionName: string;
-  submissionCount: number;
   previousRevisions: string[];
 }
 

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -134,14 +134,14 @@ export interface ReportMetadata {
   status: string;
   isComplete: boolean;
   completionStatus?: CompletionData;
-  submissionCount: number;
+  previousRevisions: string[];
 }
 
 export interface MLRReportMetadata extends ReportMetadata {
-  locked: boolean;
   reportType: "MLR";
   submissionName: string;
-  previousRevisions: string[];
+  submissionCount: number;
+  locked: boolean;
 }
 
 export interface MCPARReportMetadata extends ReportMetadata {
@@ -152,6 +152,8 @@ export interface MCPARReportMetadata extends ReportMetadata {
   dueDate: number;
   combinedData: boolean;
   programIsPCCM: Choice[];
+  submissionCount: number;
+  locked: boolean;
 }
 
 export enum ReportType {

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -154,24 +154,6 @@ export interface MCPARReportMetadata extends ReportMetadata {
   programIsPCCM: Choice[];
 }
 
-/**
- * Type guard to perform run-time checks on report types.
- *
- * Use this function on data retrieved from Dynamo allow your data to be safely typed.
- * @param report any report type
- * @returns
- */
-export function isMLRReportMetadata(
-  report: unknown
-): report is MLRReportMetadata {
-  return (
-    (report as MLRReportMetadata).reportType === "MLR" &&
-    (report as MLRReportMetadata).locked !== undefined &&
-    (report as MLRReportMetadata).submissionCount !== undefined &&
-    (report as MLRReportMetadata).previousRevisions !== undefined
-  );
-}
-
 export enum ReportType {
   MCPAR = "MCPAR",
   MLR = "MLR",

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -135,13 +135,13 @@ export interface ReportMetadata {
   isComplete: boolean;
   completionStatus?: CompletionData;
   previousRevisions: string[];
+  submissionCount: number;
+  locked: boolean;
 }
 
 export interface MLRReportMetadata extends ReportMetadata {
   reportType: "MLR";
   submissionName: string;
-  submissionCount: number;
-  locked: boolean;
 }
 
 export interface MCPARReportMetadata extends ReportMetadata {
@@ -152,8 +152,6 @@ export interface MCPARReportMetadata extends ReportMetadata {
   dueDate: number;
   combinedData: boolean;
   programIsPCCM: Choice[];
-  submissionCount: number;
-  locked: boolean;
 }
 
 export enum ReportType {

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -120,7 +120,6 @@ export interface ModalOverlayReportPageVerbiage extends ReportPageVerbiage {
 // REPORT METADATA
 
 export interface ReportMetadata {
-  archived: boolean;
   reportType: string;
   submittedBy?: string;
   createdAt: number;
@@ -137,6 +136,7 @@ export interface ReportMetadata {
   previousRevisions: string[];
   submissionCount: number;
   locked: boolean;
+  archived?: boolean;
 }
 
 export interface MLRReportMetadata extends ReportMetadata {

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -100,6 +100,9 @@ export const AddEditReportModal = ({
         lastAlteredBy: full_name,
         copyFieldDataSourceId: copyFieldDataSourceId?.value,
         programIsPCCM,
+        locked: false,
+        submissionCount: 0,
+        previousRevisions: [],
       },
       fieldData: {
         reportingPeriodStartDate: convertDateUtcToEt(reportingPeriodStartDate),
@@ -167,7 +170,7 @@ export const AddEditReportModal = ({
         fieldData: {
           ...dataToWrite.fieldData,
           stateName: States[activeState as keyof typeof States],
-          submissionCount: reportType === "MLR" ? 0 : undefined,
+          submissionCount: 0,
           // All new MLR reports are NOT resubmissions by definition.
           versionControl:
             reportType === "MLR"

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -21,6 +21,8 @@ import {
   mockReportContextWithError,
   mockDashboardLockedReportContext,
   mockLDFlags,
+  mockMlrReportContext,
+  mockMlrDashboardReportContext,
 } from "utils/testing/setupJest";
 import { useBreakpoint, makeMediaQueryClasses, useUser } from "utils";
 // verbiage
@@ -58,7 +60,7 @@ const dashboardViewWithReports = (
 
 const mlrDashboardViewWithReports = (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockDashboardReportContext}>
+    <ReportContext.Provider value={mockMlrDashboardReportContext}>
       <DashboardPage reportType="MLR" />
     </ReportContext.Provider>
   </RouterWrappedComponent>
@@ -360,11 +362,12 @@ describe("Test Dashboard report releasing privileges (desktop)", () => {
     });
     const releaseProgramButton = screen.getAllByText("Unlock")[0];
     expect(releaseProgramButton).toBeVisible();
+    expect(releaseProgramButton).toBeEnabled();
     await userEvent.click(releaseProgramButton);
-    await expect(mockMcparReportContext.releaseReport).toHaveBeenCalledTimes(1);
+    await expect(mockMlrReportContext.releaseReport).toHaveBeenCalledTimes(1);
     // once for render, once for release
     await expect(
-      mockMcparReportContext.fetchReportsByState
+      mockMlrReportContext.fetchReportsByState
     ).toHaveBeenCalledTimes(2);
   });
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
@@ -1,36 +1,25 @@
-import { ReportType } from "types";
 import { getStatus } from "./DashboardTable";
 describe("Test getStatus utility", () => {
   test("should render the correct status if report has been unlocked", () => {
-    expect(getStatus(ReportType.MLR, "In progress", false, 1)).toBe(
+    expect(getStatus("In progress", false, 1)).toBe(
       "In revision"
     );
   });
   test("should render the correct status if report has been unlocked", () => {
-    expect(getStatus(ReportType.MLR, "In progress", false, 0)).toBe(
+    expect(getStatus("In progress", false, 0)).toBe(
       "In progress"
     );
   });
   test("should render the correct status if report has been archived", () => {
-    expect(getStatus(ReportType.MLR, "In progress", true, 1)).toBe("Archived");
+    expect(getStatus("In progress", true, 1)).toBe("Archived");
   });
   test("should render the correct status if report has been unlocked", () => {
-    expect(getStatus(ReportType.MLR, "Submitted", false, 1)).toBe("Submitted");
+    expect(getStatus("Submitted", false, 1)).toBe("Submitted");
   });
 
   test("should render the correct status if report has been unlocked", () => {
-    expect(getStatus(ReportType.MLR, "Not started", false, 1)).toBe(
+    expect(getStatus("Not started", false, 1)).toBe(
       "In revision"
-    );
-  });
-  test("should render the correct status for MCPAR reports", () => {
-    expect(getStatus(ReportType.MCPAR, "In progress", false, 1)).toBe(
-      "In progress"
-    );
-  });
-  test("should render the correct status for MCPAR reports", () => {
-    expect(getStatus(ReportType.MCPAR, "Not started", false, 1)).toBe(
-      "Not started"
     );
   });
 });

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
@@ -1,14 +1,10 @@
 import { getStatus } from "./DashboardTable";
 describe("Test getStatus utility", () => {
   test("should render the correct status if report has been unlocked", () => {
-    expect(getStatus("In progress", false, 1)).toBe(
-      "In revision"
-    );
+    expect(getStatus("In progress", false, 1)).toBe("In revision");
   });
   test("should render the correct status if report has been unlocked", () => {
-    expect(getStatus("In progress", false, 0)).toBe(
-      "In progress"
-    );
+    expect(getStatus("In progress", false, 0)).toBe("In progress");
   });
   test("should render the correct status if report has been archived", () => {
     expect(getStatus("In progress", true, 1)).toBe("Archived");
@@ -18,8 +14,6 @@ describe("Test getStatus utility", () => {
   });
 
   test("should render the correct status if report has been unlocked", () => {
-    expect(getStatus("Not started", false, 1)).toBe(
-      "In revision"
-    );
+    expect(getStatus("Not started", false, 1)).toBe("In revision");
   });
 });

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -132,14 +132,12 @@ export const getStatus = (
   if (archived) {
     return `Archived`;
   }
-  if (reportType === "MLR") {
-    if (
-      submissionCount &&
-      submissionCount >= 1 &&
-      !status.includes("Submitted")
-    ) {
-      return `In revision`;
-    }
+  if (
+    submissionCount &&
+    submissionCount >= 1 &&
+    !status.includes("Submitted")
+  ) {
+    return `In revision`;
   }
   return status;
 };

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -5,7 +5,6 @@ import { Table } from "components";
 import {
   AnyObject,
   ReportMetadataShape,
-  ReportType,
   TableContentShape,
 } from "types";
 import { convertDateUtcToEt } from "utils";
@@ -52,7 +51,6 @@ export const DashboardTable = ({
         {/* Report Status */}
         <Td>
           {getStatus(
-            reportType as ReportType,
             report.status,
             report.archived,
             report.submissionCount
@@ -124,7 +122,6 @@ interface DashboardTableProps {
 }
 
 export const getStatus = (
-  reportType: ReportType,
   status: string,
   archived?: boolean,
   submissionCount?: number

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -58,8 +58,8 @@ export const DashboardTable = ({
             report.submissionCount
           )}
         </Td>
-        {/* MLR-ONLY: Submission count */}
-        {reportType === "MLR" && isAdmin && (
+        {/* ADMIN ONLY: Submission count */}
+        {isAdmin && (
           <Td> {report.submissionCount === 0 ? 1 : report.submissionCount} </Td>
         )}
         {/* Action Buttons */}
@@ -81,16 +81,14 @@ export const DashboardTable = ({
         </Td>
         {isAdmin && (
           <>
-            {reportType === "MLR" && (
-              <AdminReleaseButton
-                report={report}
-                reportType={reportType}
-                reportId={reportId}
-                releaseReport={releaseReport}
-                releasing={releasing}
-                sxOverride={sxOverride}
-              />
-            )}
+            <AdminReleaseButton
+              report={report}
+              reportType={reportType}
+              reportId={reportId}
+              releaseReport={releaseReport}
+              releasing={releasing}
+              sxOverride={sxOverride}
+            />
             <AdminArchiveButton
               report={report}
               reportType={reportType}

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -2,11 +2,7 @@
 import { Button, Image, Td, Tr, Spinner } from "@chakra-ui/react";
 import { Table } from "components";
 // utils
-import {
-  AnyObject,
-  ReportMetadataShape,
-  TableContentShape,
-} from "types";
+import { AnyObject, ReportMetadataShape, TableContentShape } from "types";
 import { convertDateUtcToEt } from "utils";
 // assets
 import editIcon from "assets/icons/icon_edit_square_gray.png";
@@ -50,11 +46,7 @@ export const DashboardTable = ({
         <Td>{report?.lastAlteredBy || "-"}</Td>
         {/* Report Status */}
         <Td>
-          {getStatus(
-            report.status,
-            report.archived,
-            report.submissionCount
-          )}
+          {getStatus(report.status, report.archived, report.submissionCount)}
         </Td>
         {/* ADMIN ONLY: Submission count */}
         {isAdmin && (

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
@@ -1,7 +1,7 @@
 // components
 import { Box, Button, Flex, Image, Text, Spinner } from "@chakra-ui/react";
 // utils
-import { AnyObject, ReportMetadataShape, ReportType } from "types";
+import { AnyObject, ReportMetadataShape } from "types";
 import { convertDateUtcToEt } from "utils";
 // assets
 import editIcon from "assets/icons/icon_edit_square_gray.png";
@@ -57,7 +57,6 @@ export const MobileDashboardTable = ({
           <Text sx={sx.label}>Status</Text>
           <Text>
             {getStatus(
-              reportType as ReportType,
               report.status,
               report.archived,
               report.submissionCount

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
@@ -56,11 +56,7 @@ export const MobileDashboardTable = ({
         <Box sx={sx.labelGroup}>
           <Text sx={sx.label}>Status</Text>
           <Text>
-            {getStatus(
-              report.status,
-              report.archived,
-              report.submissionCount
-            )}
+            {getStatus(report.status, report.archived, report.submissionCount)}
           </Text>
         </Box>
         <Box sx={sx.labelGroup}>

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
@@ -64,13 +64,11 @@ export const MobileDashboardTable = ({
             )}
           </Text>
         </Box>
-        {reportType === "MLR" && (
-          <Box sx={sx.labelGroup}>
-            <Text sx={sx.label}>
-              {report.submissionCount === 0 ? 1 : report.submissionCount}
-            </Text>
-          </Box>
-        )}
+        <Box sx={sx.labelGroup}>
+          <Text sx={sx.label}>
+            {report.submissionCount === 0 ? 1 : report.submissionCount}
+          </Text>
+        </Box>
         <Flex alignContent="flex-start" gap={2}>
           <Box sx={sxOverride.editReportButtonCell}>
             <Button
@@ -90,15 +88,13 @@ export const MobileDashboardTable = ({
           <Box sx={sxOverride.adminActionCell}>
             {isAdmin && (
               <>
-                {reportType === "MLR" && (
-                  <AdminReleaseButton
-                    report={report}
-                    reportId={reportId}
-                    releaseReport={releaseReport}
-                    releasing={releasing}
-                    sxOverride={sxOverride}
-                  />
-                )}
+                <AdminReleaseButton
+                  report={report}
+                  reportId={reportId}
+                  releaseReport={releaseReport}
+                  releasing={releasing}
+                  sxOverride={sxOverride}
+                />
                 <AdminArchiveButton
                   report={report}
                   reportId={reportId}

--- a/services/ui-src/src/types/reportContext.ts
+++ b/services/ui-src/src/types/reportContext.ts
@@ -9,7 +9,7 @@ export interface ReportKeys {
 }
 
 export interface ReportMetadataShape extends ReportKeys {
-  submissionCount?: number;
+  submissionCount: number;
   reportType: string;
   programName: string;
   submissionName?: string;
@@ -25,10 +25,11 @@ export interface ReportMetadataShape extends ReportKeys {
   submitterEmail?: string;
   submittedOnDate?: number;
   archived?: boolean;
-  locked?: boolean;
+  locked: boolean;
   fieldDataId: string;
   copyFieldDataSourceId?: string;
   programIsPCCM?: Choice[];
+  previousRevisions: string[];
 }
 
 export interface ReportShape extends ReportMetadataShape {

--- a/services/ui-src/src/utils/testing/mockReport.tsx
+++ b/services/ui-src/src/utils/testing/mockReport.tsx
@@ -382,7 +382,7 @@ export const mockMlrReport = {
   submittedOnDate: Date.now(),
   fieldData: mockMlrReportFieldData,
   fieldDataId: "mockFieldDataId",
-  locked: false,
+  locked: true,
   submissionCount: 0,
   previousRevisions: [],
 };
@@ -622,6 +622,17 @@ export const mockDashboardReportContext = {
   reportsByState: [
     {
       ...mockMcparReport,
+      formTemplate: undefined,
+      fieldData: undefined,
+    },
+  ],
+};
+
+export const mockMlrDashboardReportContext = {
+  ...mockMlrReportContext,
+  reportsByState: [
+    {
+      ...mockMlrReport,
       formTemplate: undefined,
       fieldData: undefined,
     },

--- a/services/ui-src/src/utils/testing/mockReport.tsx
+++ b/services/ui-src/src/utils/testing/mockReport.tsx
@@ -325,6 +325,9 @@ export const mockMcparReport = {
     },
   },
   isComplete: false,
+  locked: false,
+  submissionCount: 0,
+  previousRevisions: [],
 };
 
 export const mockMcparReportCombinedData = {
@@ -358,6 +361,9 @@ export const mockMcparReportCombinedData = {
     },
   },
   isComplete: false,
+  locked: false,
+  submissionCount: 0,
+  previousRevisions: [],
 };
 
 export const mockMlrReport = {
@@ -376,6 +382,9 @@ export const mockMlrReport = {
   submittedOnDate: Date.now(),
   fieldData: mockMlrReportFieldData,
   fieldDataId: "mockFieldDataId",
+  locked: false,
+  submissionCount: 0,
+  previousRevisions: [],
 };
 
 export const mockMLRLockedReport = {
@@ -395,6 +404,8 @@ export const mockMLRLockedReport = {
   fieldData: mockMlrReportFieldData,
   fieldDataId: "mockFieldDataId",
   locked: true,
+  submissionCount: 0,
+  previousRevisions: [],
 };
 
 export const mockMLRReportEmptyFieldData = {
@@ -456,6 +467,9 @@ export const mockMLRNewReport = {
   submittedOnDate: Date.now(),
   fieldData: mockMLRReportEmptyFieldData,
   fieldDataId: "mockFieldDataId",
+  locked: false,
+  submissionCount: 0,
+  previousRevisions: [],
 };
 
 export const mockMlrModalOverlayReport = {

--- a/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard.ts
+++ b/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard.ts
@@ -33,6 +33,7 @@ export default {
         "Last edited",
         "Edited by",
         "Status",
+        "#",
         { hiddenName: "Actions" },
       ],
     },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Bringing the `Unlock/Lock` admin functionality from the MLR dashboard to the MCPAR dashboard.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3023

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Create a MCPAR report
- Log in as `adminuser@test.com`
- Navigate to the MCPAR reports for the state you've created a report under

You should see a version number column and a (disabled) Unlock button.

- Log back in as a state user
- Submit the report
- Log in as the admin again, navigate to that report

You should see the Unlock button is now enabled and functioning as expected.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
