### PR TITLE
Disable MCPAR fields after submission

### DIFF
--- a/services/ui-src/src/components/forms/Form.test.tsx
+++ b/services/ui-src/src/components/forms/Form.test.tsx
@@ -131,10 +131,10 @@ describe("Test Form component", () => {
     });
   });
 
-  test("MCPAR forms should NOT be disabled after being submitted", async () => {
+  test("MCPAR forms should be disabled after being submitted", async () => {
     const { container } = render(mcparFormSubmitted);
     await container.querySelectorAll("input").forEach((x) => {
-      expect(x).not.toBeDisabled();
+      expect(x).toBeDisabled();
     });
   });
 });

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -26,7 +26,6 @@ import {
   isFieldElement,
   FormLayoutElement,
   ReportStatus,
-  ReportType,
 } from "types";
 import { ReportContext } from "components/reports/ReportProvider";
 
@@ -50,8 +49,7 @@ export const Form = ({
   let location = useLocation();
   const fieldInputDisabled =
     ((userIsAdmin || userIsReadOnly) && !formJson.editableByAdmins) ||
-    (report?.status === ReportStatus.SUBMITTED &&
-      report?.reportType === ReportType.MLR);
+    report?.status === ReportStatus.SUBMITTED;
 
   // create validation schema
   const formValidationJson = compileValidationJsonFromFields(


### PR DESCRIPTION
### Description
We have existing functionality to disable inputs for submitted MCR reports. This PR extends that behavior to MCPAR reports.

---
NOTE: The other place where we check form editability is in the ReportPageFooter, which will render a plain navigate button for admins (who are always in readonly mode), but will render a form submit button for state users (since they may have changes to save). This logic does not take report status into account - but maybe it should?

I would say yes, IF it were possible for the user to have made any changes on the page, and IF we were not protecting submitted reports from updates on the backend. Since it's not possible for the user to make changes (because inputs are disabled), and since submitted reports are protected on the backend, I decided it would not be worthwhile to address this seeming inconsistency.

### Related ticket(s)
CMDCT-2232

---
### How to test
1. Create a MCPAR
2. Submit it
3. Re-enter it as a state user
4. Observe that all inputs are disabled

### Important updates
n/a

---
### Author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
