### PR TITLE
[CMDCT-2] Fix clear prop hiding users answers when they click cancel but come back

### DIFF
--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -19,6 +19,7 @@ import {
   entityWasUpdated,
   getEntriesToClear,
   setClearedEntriesToDefaultValue,
+  resetClearProp,
 } from "utils";
 // types
 import {
@@ -69,6 +70,7 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
 
   const closeAddEditEntityModal = () => {
     setSelectedEntity(undefined);
+    resetClearProp(modalForm.fields);
     addEditEntityModalOnCloseHandler();
   };
 
@@ -103,6 +105,7 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
 
   const closeDrawer = () => {
     setSelectedEntity(undefined);
+    resetClearProp(drawerForm.fields);
     drawerOnCloseHandler();
   };
 

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -30,6 +30,7 @@ import {
   setClearedEntriesToDefaultValue,
   useBreakpoint,
   useUser,
+  resetClearProp,
 } from "utils";
 // verbiage
 import accordionVerbiage from "../../verbiage/pages/accordion";
@@ -80,6 +81,7 @@ export const ModalOverlayReportPage = ({
 
   const closeAddEditEntityModal = () => {
     setCurrentEntity(undefined);
+    resetClearProp(modalForm.fields);
     addEditEntityModalOnCloseHandler();
   };
 

--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -5,13 +5,15 @@ import {
   formFieldFactory,
   hydrateFormFields,
   initializeChoiceListFields,
+  resetClearProp,
   setClearedEntriesToDefaultValue,
   sortFormErrors,
 } from "./forms";
 // types
-import { isEntityType } from "types";
+import { FormField, isEntityType } from "types";
 // utils
 import {
+  mockDateField,
   mockDrawerFormField,
   mockFormField,
   mockNestedFormField,
@@ -381,5 +383,34 @@ describe("Test setClearedEntriesToDefaultValue", () => {
       ...mockSanctionsEntity,
       sanction_remediationDate: "",
     });
+  });
+});
+
+describe("Test resetClearProp", () => {
+  it("should reset clear for choicelist fields and its nested children", async () => {
+    const fields: FormField[] = [mockNestedFormField];
+    resetClearProp(fields);
+    expect(fields[0].props!.clear).toBe(false);
+    for (let choice of fields[0].props!.choices) {
+      expect(choice.props!.clear).toBe(false);
+    }
+  });
+
+  it("should reset clear for text fields", async () => {
+    const fields: FormField[] = [mockFormField];
+    resetClearProp(fields);
+    expect(fields[0].props?.clear).toBe(false);
+  });
+
+  it("should reset clear for number fields", async () => {
+    const fields: FormField[] = [mockNumberField];
+    resetClearProp(fields);
+    expect(fields[0].props?.clear).toBe(false);
+  });
+
+  it("should reset clear for date fields", async () => {
+    const fields: FormField[] = [mockDateField];
+    resetClearProp(fields);
+    expect(fields[0].props?.clear).toBe(false);
   });
 });

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -238,3 +238,28 @@ export const sortFormErrors = (
   }
   return sortedErrorArray;
 };
+
+/*
+ * This function resets the 'clear' prop on each field after a ChoiceListField calls
+ * clearUncheckedNestedFields(). Upon re-entering a drawer or modal, the field values will
+ * be correctly hydrated.
+ */
+export const resetClearProp = (fields: (FormField | FormLayoutElement)[]) => {
+  fields.forEach((field: FormField | FormLayoutElement) => {
+    switch (field.type) {
+      case "radio":
+      case "checkbox":
+        field.props?.choices.forEach((childField: FieldChoice) => {
+          if (childField?.children) {
+            resetClearProp(childField.children);
+          }
+        });
+        field.props = { ...field.props, clear: false };
+        resetClearProp(field.props?.choices);
+        break;
+      default:
+        field.props = { ...field.props, clear: false };
+        break;
+    }
+  });
+};

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -27,6 +27,15 @@ export const mockNumberField = {
   },
 };
 
+export const mockDateField = {
+  id: "mock-date-field",
+  type: "date",
+  validation: "date",
+  props: {
+    label: "mock date field",
+  },
+};
+
 export const mockRepeatedFormField = {
   id: "mock-text-field",
   type: "text",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
If you edit a field when inside of a drawer or a modal and then click cancel, it would end up showing that field as edited (Though the backend still had its original answer). This can be very jarring to the user, so this PR fixes the clear prop thats causing this discrepancy!

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-2

---
### How to test ###
<!-- Step-by-step instructions on how to test, if necessary -->
Create a MCPAR form
Go to Access Measures (Or any drawer form or modal form you want)
Create an Access Measure
Click edit Access Measure to reopen to modal.
Edit a text field
Click Cancel
Click edit Access Measure again
See your text field has your original answer!

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
