### PR TITLE
Add a backfill script for previousRevisions, submissionCount

### DIFF
--- a/services/app-api/handlers/etl/addRevisionsToMcpar.test.ts
+++ b/services/app-api/handlers/etl/addRevisionsToMcpar.test.ts
@@ -1,0 +1,77 @@
+import { addRevisionsHandler } from "./addRevisionsToMcpar";
+import dynamodbLib from "../../utils/dynamo/dynamodb-lib";
+import { ReportStatus } from "../../utils/types";
+
+jest.mock("../../utils/constants/constants", () => ({
+  ...jest.requireActual("../../utils/constants/constants"),
+  reportTables: {
+    MCPAR: "local-mcpar-reports",
+  },
+}));
+
+jest.mock("../../utils/dynamo/dynamodb-lib", () => ({
+  scanIterator: jest.fn(),
+  put: jest.fn(),
+}));
+
+describe("addRevisionsHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should add previousRevisions to reports without them", async () => {
+    (dynamodbLib.scanIterator as jest.Mock).mockReturnValue([
+      {
+        reportId: "mock-id-1",
+        status: ReportStatus.SUBMITTED,
+      },
+      {
+        reportId: "mock-id-2",
+        status: ReportStatus.IN_PROGRESS,
+      },
+      {
+        reportId: "mock-id-3",
+        status: ReportStatus.NOT_STARTED,
+        previousRevisions: [],
+        submissionCount: 0,
+        locked: false,
+      },
+    ]);
+
+    const result = await addRevisionsHandler();
+
+    expect(result.statusCode).toBe(200);
+    const mockedPut = dynamodbLib.put as jest.Mock;
+    expect(mockedPut).toBeCalledTimes(2);
+    expect(mockedPut.mock.calls[0][0]).toEqual({
+      TableName: "local-mcpar-reports",
+      Item: {
+        reportId: "mock-id-1",
+        status: ReportStatus.SUBMITTED,
+        previousRevisions: [],
+        submissionCount: 1,
+        locked: true,
+      },
+    });
+    expect(mockedPut.mock.calls[1][0]).toEqual({
+      TableName: "local-mcpar-reports",
+      Item: {
+        reportId: "mock-id-2",
+        status: ReportStatus.IN_PROGRESS,
+        previousRevisions: [],
+        submissionCount: 0,
+        locked: false,
+      },
+    });
+  });
+
+  test("should return 500 if dynamo errors", async () => {
+    (dynamodbLib.scanIterator as jest.Mock).mockRejectedValue(
+      new Error("no DB for you")
+    );
+
+    const result = await addRevisionsHandler();
+
+    expect(result.statusCode).toBe(500);
+  });
+});

--- a/services/app-api/handlers/etl/addRevisionsToMcpar.test.ts
+++ b/services/app-api/handlers/etl/addRevisionsToMcpar.test.ts
@@ -66,9 +66,11 @@ describe("addRevisionsHandler", () => {
   });
 
   test("should return 500 if dynamo errors", async () => {
-    (dynamodbLib.scanIterator as jest.Mock).mockRejectedValue(
-      new Error("no DB for you")
-    );
+    jest.spyOn(console, "error").mockImplementationOnce(() => undefined);
+
+    (dynamodbLib.scanIterator as jest.Mock).mockImplementationOnce(() => {
+      throw new Error("no DB for you");
+    });
 
     const result = await addRevisionsHandler();
 

--- a/services/app-api/handlers/etl/addRevisionsToMcpar.ts
+++ b/services/app-api/handlers/etl/addRevisionsToMcpar.ts
@@ -1,0 +1,45 @@
+/* eslint-disable no-console */
+import { APIGatewayProxyResult } from "aws-lambda";
+import { ReportStatus, ReportType } from "../../utils/types";
+import { reportTables } from "../../utils/constants/constants";
+import dynamodbLib from "../../utils/dynamo/dynamodb-lib";
+
+export const addRevisionsHandler = async (): Promise<APIGatewayProxyResult> => {
+  try {
+    await addRevisionsToExistingMcparReports();
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        message: "Update complete",
+      }),
+    };
+  } catch (err: any) {
+    console.error(err);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        message: err.message,
+      }),
+    };
+  }
+};
+
+const addRevisionsToExistingMcparReports = async () => {
+  const TableName = reportTables[ReportType.MCPAR];
+  for await (const reportMetadata of dynamodbLib.scanIterator({ TableName })) {
+    if (reportMetadata.previousRevisions === undefined) {
+      const wasSubmitted = reportMetadata.status === ReportStatus.SUBMITTED;
+
+      // TODO should we change lastAltered?
+      reportMetadata.previousRevisions = [];
+      reportMetadata.submissionCount = wasSubmitted ? 1 : 0;
+      reportMetadata.locked = wasSubmitted ? true : false;
+
+      await dynamodbLib.put({
+        TableName,
+        Item: reportMetadata,
+      });
+    }
+  }
+};

--- a/services/app-api/handlers/etl/addRevisionsToMcpar.ts
+++ b/services/app-api/handlers/etl/addRevisionsToMcpar.ts
@@ -28,18 +28,19 @@ export const addRevisionsHandler = async (): Promise<APIGatewayProxyResult> => {
 const addRevisionsToExistingMcparReports = async () => {
   const TableName = reportTables[ReportType.MCPAR];
   for await (const reportMetadata of dynamodbLib.scanIterator({ TableName })) {
-    if (reportMetadata.previousRevisions === undefined) {
-      const wasSubmitted = reportMetadata.status === ReportStatus.SUBMITTED;
-
-      // TODO should we change lastAltered?
-      reportMetadata.previousRevisions = [];
-      reportMetadata.submissionCount = wasSubmitted ? 1 : 0;
-      reportMetadata.locked = wasSubmitted ? true : false;
-
-      await dynamodbLib.put({
-        TableName,
-        Item: reportMetadata,
-      });
+    if (reportMetadata.previousRevisions !== undefined) {
+      continue;
     }
+
+    const wasSubmitted = reportMetadata.status === ReportStatus.SUBMITTED;
+
+    reportMetadata.previousRevisions = [];
+    reportMetadata.submissionCount = wasSubmitted ? 1 : 0;
+    reportMetadata.locked = wasSubmitted ? true : false;
+
+    await dynamodbLib.put({
+      TableName,
+      Item: reportMetadata,
+    });
   }
 };

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -160,6 +160,13 @@ provider:
     PRINCE_API_PATH: ${self:custom.princeApiPath}
 
 functions:
+  addRevisionsToMcpar:
+    handler: handlers/etl/addRevisionsToMcpar.addRevisionsHandler
+    timeout: 300
+    warmup:
+      default:
+        enabled: false
+    maximumRetryAttempts: 0
   numberFieldDataToFile:
     handler: handlers/etl/numberFieldDataToFile.exportNumericData
     timeout: 300


### PR DESCRIPTION
### Description
Recent work has added the ability to count revisions and track previous submissions for MCPAR reports. This involved adding new properties to MCPAR metadata. Unfortunately, those properties will be missing from existing reports. This ETL script will add them.

### Related ticket(s)
CMDCT-2265

---
### How to test
1. Checkout this branch
2. Debug locally
3. Create a MCPAR report
4. Invoke the ETL locally
5. Without stopping the app, check out branch `admin-dash-3023`
6. Ensure the existing report behaves as expected

### Important updates
n/a

---
### Author checklist

- [ ] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
---
