### PR TITLE
Admin Banner Zustandification™️  (Karla's Version)

### DIFF
--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -41,7 +41,8 @@
     "react-scripts": "^5.0.0",
     "react-uuid": "^1.0.3",
     "sass": "^1.37.5",
-    "yup": "^0.32.11"
+    "yup": "^0.32.11",
+    "zustand": "^4.4.6"
   },
   "devDependencies": {
     "@aws-sdk/types": "^3.38.0",

--- a/services/ui-src/src/components/banners/AdminBannerProvider.test.tsx
+++ b/services/ui-src/src/components/banners/AdminBannerProvider.test.tsx
@@ -91,7 +91,9 @@ describe("Test AdminBannerProvider deleteAdminBanner method", () => {
     });
     expect(mockAPI.deleteBanner).toHaveBeenCalledTimes(1);
     expect(mockAPI.deleteBanner).toHaveBeenCalledWith(mockBannerData.key);
-    await waitFor(() => expect(mockAPI.getBanner).toHaveBeenCalledTimes(1));
+
+    // 1 call on render + 1 call on button click
+    await waitFor(() => expect(mockAPI.getBanner).toHaveBeenCalledTimes(2));
   });
 });
 

--- a/services/ui-src/src/components/banners/AdminBannerProvider.test.tsx
+++ b/services/ui-src/src/components/banners/AdminBannerProvider.test.tsx
@@ -5,6 +5,7 @@ import { act } from "react-dom/test-utils";
 // components
 import { AdminBannerContext, AdminBannerProvider } from "./AdminBannerProvider";
 // utils
+import { useStore } from "utils";
 import { mockBannerData } from "utils/testing/setupJest";
 import { bannerErrors } from "verbiage/errors";
 
@@ -27,7 +28,6 @@ const TestComponent = () => {
       <button onClick={() => context.deleteAdminBanner(mockBannerData.key)}>
         Delete
       </button>
-      {context.errorMessage && <p>{context.errorMessage}</p>}
     </div>
   );
 };
@@ -70,7 +70,9 @@ describe("Test AdminBannerProvider fetchAdminBanner method", () => {
     await act(async () => {
       await render(testComponent);
     });
-    expect(screen.queryByText(bannerErrors.GET_BANNER_FAILED)).toBeVisible();
+    expect(useStore.getState().bannerErrorMessage).toBe(
+      bannerErrors.GET_BANNER_FAILED
+    );
   });
 });
 

--- a/services/ui-src/src/components/pages/Admin/AdminPage.test.tsx
+++ b/services/ui-src/src/components/pages/Admin/AdminPage.test.tsx
@@ -8,7 +8,10 @@ import { AdminPage, AdminBannerContext } from "components";
 import {
   RouterWrappedComponent,
   mockBannerData,
+  mockBannerStore,
 } from "utils/testing/setupJest";
+import { useStore } from "utils";
+import { bannerErrors } from "verbiage/errors";
 
 const mockBannerMethods = {
   fetchAdminBanner: jest.fn(() => {}),
@@ -16,19 +19,8 @@ const mockBannerMethods = {
   deleteAdminBanner: jest.fn(() => {}),
 };
 
-const mockContextWithoutBanner = {
-  ...mockBannerMethods,
-  bannerData: undefined,
-  isLoading: false,
-  errorData: null,
-};
-
-const mockContextWithBanner = {
-  ...mockBannerMethods,
-  bannerData: mockBannerData,
-  isLoading: false,
-  errorData: null,
-};
+jest.mock("utils/state/useStore");
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 
 const adminView = (context: any) => (
   <RouterWrappedComponent>
@@ -41,12 +33,13 @@ const adminView = (context: any) => (
 describe("Test AdminPage banner manipulation functionality", () => {
   it("Deletes current banner on delete button click", async () => {
     await act(async () => {
-      await render(adminView(mockContextWithBanner));
+      mockedUseStore.mockReturnValue(mockBannerStore);
+      await render(adminView(mockBannerMethods));
     });
     const deleteButton = screen.getByText("Delete Current Banner");
     await userEvent.click(deleteButton);
     await waitFor(() =>
-      expect(mockContextWithBanner.deleteAdminBanner).toHaveBeenCalled()
+      expect(mockBannerMethods.deleteAdminBanner).toHaveBeenCalled()
     );
   });
 });
@@ -54,7 +47,11 @@ describe("Test AdminPage banner manipulation functionality", () => {
 describe("Test AdminPage without banner", () => {
   beforeEach(async () => {
     await act(async () => {
-      await render(adminView(mockContextWithoutBanner));
+      mockedUseStore.mockReturnValue({
+        ...mockBannerStore,
+        bannerData: undefined,
+      });
+      await render(adminView(mockBannerMethods));
     });
   });
 
@@ -75,7 +72,8 @@ describe("Test AdminPage without banner", () => {
 describe("Test AdminPage with banner", () => {
   beforeEach(async () => {
     await act(async () => {
-      await render(adminView(mockContextWithBanner));
+      mockedUseStore.mockReturnValue(mockBannerStore);
+      await render(adminView(mockBannerMethods));
     });
   });
 
@@ -101,12 +99,21 @@ describe("Test AdminPage with banner", () => {
 describe("Test AdminPage with active/inactive banner", () => {
   const currentTime = Date.now(); // 'current' time in ms since unix epoch
   const oneDay = 1000 * 60 * 60 * 24; // 1000ms * 60s * 60m * 24h = 86,400,000ms
-  const context = mockContextWithBanner;
+  const context = mockBannerMethods;
+  mockedUseStore.mockReturnValue(mockBannerStore);
 
   test("Active banner shows 'active' status", async () => {
-    context.bannerData.startDate = currentTime - oneDay;
-    context.bannerData.endDate = currentTime + oneDay;
+    const activeBannerData = {
+      ...mockBannerData,
+      startDate: currentTime - oneDay,
+      endDate: currentTime + oneDay,
+    };
     await act(async () => {
+      mockedUseStore.mockReturnValue({
+        ...mockBannerStore,
+        bannerData: activeBannerData,
+        bannerActive: true,
+      });
       await render(adminView(context));
     });
     const currentBannerStatus = screen.getByText("Status:");
@@ -114,9 +121,16 @@ describe("Test AdminPage with active/inactive banner", () => {
   });
 
   test("Inactive banner shows 'inactive' status", async () => {
-    context.bannerData.startDate = currentTime + oneDay;
-    context.bannerData.endDate = currentTime + oneDay + oneDay;
+    const inactiveBannerData = {
+      ...mockBannerData,
+      startDate: currentTime + oneDay,
+      endDate: currentTime + oneDay + oneDay,
+    };
     await act(async () => {
+      mockedUseStore.mockReturnValue({
+        ...mockBannerStore,
+        bannerData: inactiveBannerData,
+      });
       await render(adminView(context));
     });
     const currentBannerStatus = screen.getByText("Status:");
@@ -126,14 +140,14 @@ describe("Test AdminPage with active/inactive banner", () => {
 
 describe("Test AdminPage delete banner error handling", () => {
   it("Displays error if deleteBanner throws error", async () => {
-    window.HTMLElement.prototype.scrollIntoView = jest.fn();
-    const context = mockContextWithBanner;
-    context.deleteAdminBanner = jest.fn(() => {
-      throw new Error();
-    });
     await act(async () => {
-      await render(adminView(context));
+      mockedUseStore.mockReturnValue({
+        ...mockBannerStore,
+        bannerErrorMessage: bannerErrors.DELETE_BANNER_FAILED,
+      });
+      await render(adminView(mockBannerMethods));
     });
+
     const deleteButton = screen.getByText("Delete Current Banner");
     await userEvent.click(deleteButton);
     expect(screen.getByText("Error")).toBeVisible();
@@ -142,14 +156,14 @@ describe("Test AdminPage delete banner error handling", () => {
 
 describe("Test AdminPage accessibility", () => {
   it("Should not have basic accessibility issues without banner", async () => {
-    const { container } = render(adminView(mockContextWithoutBanner));
+    const { container } = render(adminView(mockBannerMethods));
     await act(async () => {
       expect(await axe(container)).toHaveNoViolations();
     });
   });
 
   it("Should not have basic accessibility issues with banner", async () => {
-    const { container } = render(adminView(mockContextWithBanner));
+    const { container } = render(adminView(mockBannerMethods));
     await act(async () => {
       expect(await axe(container)).toHaveNoViolations();
     });

--- a/services/ui-src/src/components/pages/Admin/AdminPage.tsx
+++ b/services/ui-src/src/components/pages/Admin/AdminPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext, useEffect } from "react";
+import { useContext, MouseEventHandler } from "react";
 // components
 import {
   Box,
@@ -17,50 +17,25 @@ import {
   PageTemplate,
 } from "components";
 // utils
-import { checkDateRangeStatus, convertDateUtcToEt } from "utils";
-import { bannerErrors } from "verbiage/errors";
+import { convertDateUtcToEt, useStore } from "utils";
 import verbiage from "verbiage/pages/admin";
 
 export const AdminPage = () => {
+  const { deleteAdminBanner, writeAdminBanner } =
+    useContext(AdminBannerContext);
+
+  // state management
   const {
     bannerData,
-    deleteAdminBanner,
-    writeAdminBanner,
-    isLoading,
-    errorMessage,
-  } = useContext(AdminBannerContext);
-  const [error, setError] = useState<string | undefined>(errorMessage);
-  const [deleting, setDeleting] = useState<boolean>(false);
-  const [isBannerActive, setIsBannerActive] = useState<boolean>(false);
-
-  useEffect(() => {
-    let bannerActivity = false;
-    if (bannerData) {
-      bannerActivity = checkDateRangeStatus(
-        bannerData.startDate,
-        bannerData.endDate
-      );
-    }
-    setIsBannerActive(bannerActivity);
-  }, [bannerData]);
-
-  useEffect(() => {
-    setError(errorMessage);
-  }, [errorMessage]);
-
-  const deleteBanner = async () => {
-    setDeleting(true);
-    try {
-      await deleteAdminBanner();
-    } catch (error: any) {
-      setError(bannerErrors.DELETE_BANNER_FAILED);
-    }
-    setDeleting(false);
-  };
+    bannerActive,
+    bannerLoading,
+    bannerErrorMessage,
+    bannerDeleting,
+  } = useStore();
 
   return (
     <PageTemplate sxOverride={sx.layout} data-testid="admin-view">
-      <ErrorAlert error={error} sxOverride={sx.errorAlert} />
+      <ErrorAlert error={bannerErrorMessage} sxOverride={sx.errorAlert} />
       <Box sx={sx.introTextBox}>
         <Heading as="h1" id="AdminHeader" tabIndex={-1} sx={sx.headerText}>
           {verbiage.intro.header}
@@ -69,7 +44,7 @@ export const AdminPage = () => {
       </Box>
       <Box sx={sx.currentBannerSectionBox}>
         <Text sx={sx.sectionHeader}>Current Banner</Text>
-        {isLoading ? (
+        {bannerLoading ? (
           <Flex sx={sx.spinnerContainer}>
             <Spinner size="md" />
           </Flex>
@@ -81,8 +56,8 @@ export const AdminPage = () => {
                   <Flex sx={sx.currentBannerInfo}>
                     <Text sx={sx.currentBannerStatus}>
                       Status:{" "}
-                      <span className={isBannerActive ? "active" : "inactive"}>
-                        {isBannerActive ? "Active" : "Inactive"}
+                      <span className={bannerActive ? "active" : "inactive"}>
+                        {bannerActive ? "Active" : "Inactive"}
                       </span>
                     </Text>
                     <Text sx={sx.currentBannerDate}>
@@ -99,9 +74,9 @@ export const AdminPage = () => {
                     <Button
                       variant="danger"
                       sx={sx.deleteBannerButton}
-                      onClick={deleteBanner}
+                      onClick={deleteAdminBanner as MouseEventHandler}
                     >
-                      {deleting ? (
+                      {bannerDeleting ? (
                         <Spinner size="md" />
                       ) : (
                         "Delete Current Banner"
@@ -111,7 +86,7 @@ export const AdminPage = () => {
                 </>
               )}
             </Collapse>
-            {!bannerData && <Text>There is no current banner</Text>}
+            {!bannerData?.key && <Text>There is no current banner</Text>}
           </>
         )}
       </Box>

--- a/services/ui-src/src/components/pages/Home/HomePage.tsx
+++ b/services/ui-src/src/components/pages/Home/HomePage.tsx
@@ -1,22 +1,20 @@
-import { useContext, useState, useEffect } from "react";
+import { useEffect } from "react";
 // components
 import { Box, Collapse, Heading, Link, Text } from "@chakra-ui/react";
 import {
-  AdminBannerContext,
   AdminDashSelector,
   Banner,
   PageTemplate,
   TemplateCard,
 } from "components";
 // utils
-import { checkDateRangeStatus, useUser } from "utils";
+import { checkDateRangeStatus, useStore, useUser } from "utils";
 // verbiage
 import verbiage from "verbiage/pages/home";
 
 export const HomePage = () => {
-  const { bannerData } = useContext(AdminBannerContext);
+  const { bannerData, bannerActive, setBannerActive } = useStore();
   const { userIsEndUser, userReports } = useUser().user ?? {};
-  const [isBannerActive, setIsBannerActive] = useState(false);
 
   useEffect(() => {
     let bannerActivity = false;
@@ -26,10 +24,10 @@ export const HomePage = () => {
         bannerData.endDate
       );
     }
-    setIsBannerActive(bannerActivity);
+    setBannerActive(bannerActivity);
   }, [bannerData]);
 
-  const showBanner = !!bannerData?.key && isBannerActive;
+  const showBanner = !!bannerData?.key && bannerActive;
   const { intro, cards } = verbiage;
 
   return (

--- a/services/ui-src/src/types/banners.ts
+++ b/services/ui-src/src/types/banners.ts
@@ -19,9 +19,3 @@ export interface AdminBannerMethods {
   writeAdminBanner: Function;
   deleteAdminBanner: Function;
 }
-
-export interface AdminBannerShape extends AdminBannerMethods {
-  bannerData?: AdminBannerData;
-  isLoading: boolean;
-  errorMessage?: string;
-}

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -4,4 +4,5 @@ export * from "./formFields";
 export * from "./other";
 export * from "./reportContext";
 export * from "./reports";
+export * from "./states";
 export * from "./users";

--- a/services/ui-src/src/types/states.ts
+++ b/services/ui-src/src/types/states.ts
@@ -1,0 +1,18 @@
+import { AdminBannerData } from "types";
+
+// initial admin banner state
+export interface AdminBannerState {
+  // INITIAL STATE
+  bannerData: AdminBannerData | undefined;
+  bannerActive: boolean;
+  bannerLoading: boolean;
+  bannerErrorMessage: string;
+  bannerDeleting: boolean;
+  // ACTIONS
+  setBannerData: (newBannerData: AdminBannerData | undefined) => void;
+  clearAdminBanner: () => void;
+  setBannerActive: (bannerStatus: boolean) => void;
+  setBannerLoading: (bannerLoading: boolean) => void;
+  setBannerErrorMessage: (bannerErrorMessage: string) => void;
+  setBannerDeleting: (bannerDeleting: boolean) => void;
+}

--- a/services/ui-src/src/utils/index.ts
+++ b/services/ui-src/src/utils/index.ts
@@ -36,3 +36,5 @@ export * from "./other/useBreakpoint";
 export * from "./other/rendering";
 export * from "./other/parsing";
 export * from "./other/typing";
+// state management (zustand)
+export * from "./state/useStore";

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -1,0 +1,49 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+// types
+import { AdminBannerData, AdminBannerState } from "types";
+
+// USER STORE
+
+// ADMIN BANNER STORE
+const bannerStore = (set: Function) => ({
+  // initial state
+  bannerData: undefined,
+  bannerActive: false,
+  bannerLoading: false,
+  bannerErrorMessage: "",
+  bannerDeleting: false,
+  // actions
+  setBannerData: (newBanner: AdminBannerData | undefined) =>
+    set(() => ({ bannerData: newBanner }), false, { type: "setBannerData" }),
+  clearAdminBanner: () =>
+    set(() => ({ bannerData: undefined }), false, { type: "clearAdminBanner" }),
+  setBannerActive: (bannerStatus: boolean) =>
+    set(() => ({ bannerActive: bannerStatus }), false, {
+      type: "setBannerActive",
+    }),
+  setBannerLoading: (loading: boolean) =>
+    set(() => ({ bannerLoading: loading }), false, {
+      type: "setBannerLoading",
+    }),
+  setBannerErrorMessage: (errorMessage: string) =>
+    set(() => ({ bannerErrorMessage: errorMessage }), false, {
+      type: "setBannerErrorMessage",
+    }),
+  setBannerDeleting: (deleting: boolean) =>
+    set(() => ({ bannerDeleting: deleting }), false, {
+      type: "setBannerDeleting",
+    }),
+});
+
+export const useStore = create(
+  // persist and devtools are being used for debugging state
+  persist(
+    devtools<AdminBannerState>((set) => ({
+      ...bannerStore(set),
+    })),
+    {
+      name: "mcr-store",
+    }
+  )
+);

--- a/services/ui-src/src/utils/testing/mockZustand.tsx
+++ b/services/ui-src/src/utils/testing/mockZustand.tsx
@@ -1,0 +1,19 @@
+import { mockBannerData } from "./setupJest";
+// types
+import { AdminBannerState } from "types";
+
+//  BANNER STATES / STORE
+
+export const mockBannerStore: AdminBannerState = {
+  bannerData: mockBannerData,
+  bannerActive: false,
+  bannerLoading: false,
+  bannerErrorMessage: "",
+  bannerDeleting: false,
+  setBannerData: () => {},
+  clearAdminBanner: () => {},
+  setBannerActive: () => {},
+  setBannerLoading: () => {},
+  setBannerErrorMessage: () => {},
+  setBannerDeleting: () => {},
+};

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -72,3 +72,5 @@ export * from "./mockReport";
 export * from "./mockRouter";
 // USERS
 export * from "./mockUsers";
+// STATE MANAGEMENT (ZUSTAND)
+export * from "./mockZustand";

--- a/services/ui-src/src/verbiage/errors.ts
+++ b/services/ui-src/src/verbiage/errors.ts
@@ -4,6 +4,7 @@ export const bannerErrors = {
     "Current banner could not be replaced. Please contact support.",
   DELETE_BANNER_FAILED:
     "Current banner could not be deleted. Please contact support.",
+  CREATE_BANNER_FAILED: "Could not create a banner. Please contact support.",
 };
 
 export const validationErrors = {

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -13654,6 +13654,11 @@ use-sidecar@^1.0.1, use-sidecar@^1.0.5:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
 
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -14287,3 +14292,10 @@ zen-push@0.2.1:
   integrity sha512-Qv4qvc8ZIue51B/0zmeIMxpIGDVhz4GhJALBvnKs/FRa2T7jy4Ori9wFwaHVt0zWV7MIFglKAHbgnVxVTw7U1w==
   dependencies:
     zen-observable "^0.7.0"
+
+zustand@^4.4.6:
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.4.6.tgz#03c78e3e2686c47095c93714c0c600b72a6512bd"
+  integrity sha512-Rb16eW55gqL4W2XZpJh0fnrATxYEG3Apl2gfHTyDSE965x/zxslTikpNch0JgNjJA9zK6gEFW8Fl6d1rTZaqgg==
+  dependencies:
+    use-sync-external-store "1.2.0"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Converting the state management of MCR from `Context API` to `Zustand` (following the patterns implemented in MFP).

This PR covers some initial setup:

- Installation of Zustand in MCR
- AdminBannerProvider

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-2794

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Running this locally, you should be able to create, edit, and delete banners as an Admin.

Optionally: install the [Redux Devtools Chrome extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd) or the [Firefox Redux Devtools extension](https://addons.mozilla.org/en-US/firefox/addon/reduxdevtools/)

- Open devtools
- Log in
- You should see the `bannerData` object and a few other initial states on the extension ✨

<img width="380" alt="Screenshot 2023-11-17 at 2 40 23 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/99458559/68d23041-c782-45af-88ef-d16f583fb08d">

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
