### PR TITLE
Add help page and create report modal PCCM content

### DIFF
--- a/services/ui-src/src/components/accordions/FaqAccordion.tsx
+++ b/services/ui-src/src/components/accordions/FaqAccordion.tsx
@@ -10,9 +10,9 @@ export const FaqAccordion = ({ accordionItems, ...props }: Props) => {
   return (
     <Accordion allowToggle={true} allowMultiple={true} {...props}>
       {accordionItems.map((item: AnyObject, index: number) => (
-        <AccordionItem key={index} label={item.header} sx={sx.item}>
+        <AccordionItem key={index} label={item.question} sx={sx.item}>
           <Box sx={sx.answerBox}>
-            <Text>{parseCustomHtml(item.body)}</Text>
+            <Text>{parseCustomHtml(item.answer)}</Text>
           </Box>
         </AccordionItem>
       ))}

--- a/services/ui-src/src/components/accordions/FaqAccordion.tsx
+++ b/services/ui-src/src/components/accordions/FaqAccordion.tsx
@@ -1,16 +1,18 @@
 // components
 import { Accordion, Box, Text } from "@chakra-ui/react";
 import { AccordionItem } from "components";
-// utils
+// types
 import { AnyObject } from "types";
+// utils
+import { parseCustomHtml } from "utils";
 
 export const FaqAccordion = ({ accordionItems, ...props }: Props) => {
   return (
     <Accordion allowToggle={true} allowMultiple={true} {...props}>
       {accordionItems.map((item: AnyObject, index: number) => (
-        <AccordionItem key={index} label={item.question} sx={sx.item}>
+        <AccordionItem key={index} label={item.header} sx={sx.item}>
           <Box sx={sx.answerBox}>
-            <Text>{item.answer}</Text>
+            <Text>{parseCustomHtml(item.body)}</Text>
           </Box>
         </AccordionItem>
       ))}

--- a/services/ui-src/src/forms/addEditMcparReport/addEditMcparReport.json
+++ b/services/ui-src/src/forms/addEditMcparReport/addEditMcparReport.json
@@ -63,6 +63,7 @@
       "validation": "radio",
       "props": {
         "label": "Is your program a Primary Care Case Management (PCCM) entity?",
+        "hint": "If you designate the managed care program as a Primary Care Case Management Entity (PCCM-E), you are not required to complete the entire MCPAR Report. Please <a href='/help'>visit the “Get Help”</a> section for more information on how to complete the PCCM-E specific form.",
         "choices": [
           {
             "id": "yes_programIsPCCM",

--- a/services/ui-src/src/forms/addEditMcparReport/addEditMcparReportWithoutYoY.json
+++ b/services/ui-src/src/forms/addEditMcparReport/addEditMcparReportWithoutYoY.json
@@ -54,6 +54,7 @@
       "validation": "radio",
       "props": {
         "label": "Is your program a Primary Care Case Management (PCCM) entity?",
+        "hint": "If you designate the managed care program as a Primary Care Case Management Entity (PCCM-E), you are not required to complete the entire MCPAR Report. Please <a href='/help'>visit the “Get Help”</a> section for more information on how to complete the PCCM-E specific form.",
         "choices": [
           {
             "id": "yes_programIsPCCM",

--- a/services/ui-src/src/verbiage/pages/help.ts
+++ b/services/ui-src/src/verbiage/pages/help.ts
@@ -19,8 +19,8 @@ export default {
   },
   accordionItems: [
     {
-      header: "MCPAR: Primary Care Case Management Entity (PCCM-E) reports",
-      body: [
+      question: "MCPAR: Primary Care Case Management Entity (PCCM-E) reports",
+      answer: [
         {
           type: "text",
           as: "span",

--- a/services/ui-src/src/verbiage/pages/help.ts
+++ b/services/ui-src/src/verbiage/pages/help.ts
@@ -25,7 +25,7 @@ export default {
           type: "text",
           as: "span",
           content:
-            "States are only required to report certain sections of the MCPAR for Primary Care Case Management Entities (PCCM-Es). These include Program Information, Enrollment and Service Expansions as well and Sanctions (see  and ",
+            "States are only required to report certain sections of the MCPAR for Primary Care Case Management Entities (PCCM-Es). These include Program Information, Enrollment and Service Expansions as well as Sanctions (see ",
         },
         {
           type: "externalLink",
@@ -43,7 +43,7 @@ export default {
         },
         {
           type: "externalLink",
-          content: "(viii))",
+          content: "(viii)",
           props: {
             href: "https://www.ecfr.gov/current/title-42/part-438/section-438.66#p-438.66(e)(2)(viii)",
             target: "_blank",
@@ -53,7 +53,7 @@ export default {
         {
           type: "text",
           as: "span",
-          content: ".",
+          content: ").",
         },
         {
           type: "html",

--- a/services/ui-src/src/verbiage/pages/help.ts
+++ b/services/ui-src/src/verbiage/pages/help.ts
@@ -18,12 +18,128 @@ export default {
     },
   },
   accordionItems: [
-    /*
-     *  accordion items are in the following format:
-     *  {
-     *    question: "",
-     *    answer: "",
-     *  }
-     */
+    {
+      header: "MCPAR: Primary Care Case Management Entity (PCCM-E) reports",
+      body: [
+        {
+          type: "text",
+          as: "span",
+          content:
+            "States are only required to report certain sections of the MCPAR for Primary Care Case Management Entities (PCCM-Es). These include Program Information, Enrollment and Service Expansions as well and Sanctions (see  and ",
+        },
+        {
+          type: "externalLink",
+          content: "42 CFR 438.66(e)(2)(iii)",
+          props: {
+            href: "https://www.ecfr.gov/current/title-42/part-438/section-438.66#p-438.66(e)(2)(iii)",
+            target: "_blank",
+            "aria-label": "42 CFR 438.66(e)(2)(iii) (link opens in new tab)",
+          },
+        },
+        {
+          type: "text",
+          as: "span",
+          content: " and ",
+        },
+        {
+          type: "externalLink",
+          content: "(viii))",
+          props: {
+            href: "https://www.ecfr.gov/current/title-42/part-438/section-438.66#p-438.66(e)(2)(viii)",
+            target: "_blank",
+            "aria-label": "42 CFR 438.66(e)(2)(viii) (link opens in new tab)",
+          },
+        },
+        {
+          type: "text",
+          as: "span",
+          content: ".",
+        },
+        {
+          type: "html",
+          content: "<br></br>",
+        },
+        {
+          type: "text",
+          as: "p",
+          content:
+            "Please follow these section-by-section instructions for PCCM-Es:",
+        },
+        {
+          type: "html",
+          content: "<br>",
+        },
+        {
+          type: "ul",
+          content: "",
+          children: [
+            {
+              type: "li",
+              children: [
+                {
+                  type: "html",
+                  content:
+                    "<span>In <b>section A.7, Program Information</b>, write the name of the PCCM-E as the Plan.</span><br></br>",
+                },
+              ],
+            },
+            {
+              type: "li",
+              children: [
+                {
+                  type: "html",
+                  content:
+                    "<span>In <b>section C1.I.3 Topic 1, Program Characteristics</b>, the radio button for PCCM-E <span style='color:#bf1aba;'>will be pre-selected</span>.</span><br></br>",
+                },
+              ],
+            },
+            {
+              type: "li",
+              children: [
+                {
+                  type: "html",
+                  content:
+                    "<span>In <b>section D.VIII, Sanctions</b>, PCCM-Es should describe sanctions the state has issued against the PCCM-E itself.</span><br></br>",
+                },
+              ],
+            },
+            {
+              type: "li",
+              children: [
+                {
+                  type: "span",
+                  content:
+                    "Report all known actions across the following domains: sanctions, administrative penalties, corrective action plans, other. Include any pending or unresolved actions.",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "html",
+          content: "<br>",
+        },
+        {
+          type: "text",
+          as: "b",
+          content: "Please note:",
+        },
+        {
+          type: "text",
+          as: "span",
+          content:
+            " States can voluntarily report additional information about their PCCM-Es beyond the designated sections in the PCCM-E specific form. If a state wants to report additional information, please contact ",
+        },
+        {
+          type: "externalLink",
+          content: "ManagedCareTA@cms.hhs.gov",
+          props: {
+            href: "mailto:ManagedCareTA@cms.hhs.gov",
+            target: "_blank",
+            "aria-label": "Mail to ManagedCareTA@cms.hhs.gov",
+          },
+        },
+      ],
+    },
   ],
 };

--- a/services/ui-src/src/verbiage/pages/help.ts
+++ b/services/ui-src/src/verbiage/pages/help.ts
@@ -89,7 +89,7 @@ export default {
                 {
                   type: "html",
                   content:
-                    "<span>In <b>section C1.I.3 Topic 1, Program Characteristics</b>, the radio button for PCCM-E <span style='color:#bf1aba;'>will be pre-selected</span>.</span><br></br>",
+                    "<span>In <b>section C1.I.3 Topic 1, Program Characteristics</b>, the radio button for PCCM-E will be pre-selected.</span><br></br>",
                 },
               ],
             },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Add PCCM-related content to help page and create report modal

Open to suggestions on cleaner ways to put this together! I could do all the html in one block and it'd be shorter, though less readable

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3080

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Go to "Get Help" or `/help`
- Open the new accordion and verify it matches the [Figma](https://www.figma.com/file/GBktI8ZIJM9YYcdNva0ltg/MDCT---MCR?type=design&node-id=9730-46029&mode=design&t=iB0eOLTQkUCf37dY-0)
- Go to the mcpar dashboard or `/mcpar`
- Click to create a new report
- Verify the last question with the PCCM radio now has hint content, and that the link in the hint opens the help page in a new tab

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
---