### PR TITLE
Pccm field mods 3136

### DIFF
--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -29,7 +29,10 @@ import {
 } from "../../utils/types";
 import { getOrCreateFormTemplate } from "../../utils/formTemplates/formTemplates";
 import { logger } from "../../utils/logging";
-import { copyFieldDataFromSource } from "../../utils/reports/reports";
+import {
+  copyFieldDataFromSource,
+  makePCCMModifications,
+} from "../../utils/reports/reports";
 
 export const createReport = handler(async (event, _context) => {
   if (!hasPermissions(event, [UserRoles.STATE_USER, UserRoles.STATE_REP])) {
@@ -140,6 +143,12 @@ export const createReport = handler(async (event, _context) => {
   } else {
     newFieldData = validatedFieldData;
   }
+
+  // make necessary modifications for PCCM
+  if (isProgramPCCM) {
+    newFieldData = makePCCMModifications(newFieldData);
+  }
+
   const fieldDataParams: S3Put = {
     Bucket: reportBucket,
     Key: getFieldDataKey(state, fieldDataId),

--- a/services/app-api/utils/formTemplates/formTemplates.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.ts
@@ -316,5 +316,10 @@ export const generatePCCMTemplate = (originalReportTemplate: any) => {
 
 const makePCCMTemplateModifications = (reportTemplate: ReportJson) => {
   // Find Question C1.I.3 Program type in Section C.I and disable it
-  reportTemplate.routes[2].children![0].form!.fields[3].props!.disabled = true;
+  const programTypeQuestion =
+    reportTemplate.routes[2].children![0].form!.fields[3];
+  if (programTypeQuestion.id !== "program_type") {
+    throw new Error("Update PCCM logic!");
+  }
+  programTypeQuestion.props!.disabled = true;
 };

--- a/services/app-api/utils/formTemplates/formTemplates.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.ts
@@ -308,5 +308,27 @@ export const generatePCCMTemplate = (originalReportTemplate: any) => {
     }
   }
 
+  // make additional form modifications as necessary
+  makePCCMTemplateModifications(reportTemplate);
+
   return reportTemplate;
+};
+
+const makePCCMTemplateModifications = (reportTemplate: ReportJson) => {
+  // Find Section C.I
+  const sectionC = reportTemplate.routes.find(
+    (route: ReportRoute) => route.name === "C: Program-Level Indicators"
+  );
+
+  if (sectionC) {
+    // Find Question C1.I.3 Program type in Section C.I
+    const questionC1I3 = sectionC.children?.[0].form?.fields?.find(
+      (field) => field.id === "program_type"
+    );
+
+    if (questionC1I3) {
+      // Disable the field
+      questionC1I3.props!.disabled = true;
+    }
+  }
 };

--- a/services/app-api/utils/formTemplates/formTemplates.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.ts
@@ -315,20 +315,6 @@ export const generatePCCMTemplate = (originalReportTemplate: any) => {
 };
 
 const makePCCMTemplateModifications = (reportTemplate: ReportJson) => {
-  // Find Section C.I
-  const sectionC = reportTemplate.routes.find(
-    (route: ReportRoute) => route.name === "C: Program-Level Indicators"
-  );
-
-  if (sectionC) {
-    // Find Question C1.I.3 Program type in Section C.I
-    const questionC1I3 = sectionC.children?.[0].form?.fields?.find(
-      (field) => field.id === "program_type"
-    );
-
-    if (questionC1I3) {
-      // Disable the field
-      questionC1I3.props!.disabled = true;
-    }
-  }
+  // Find Question C1.I.3 Program type in Section C.I and disable it
+  reportTemplate.routes[2].children![0].form!.fields[3].props!.disabled = true;
 };

--- a/services/app-api/utils/reports/reports.test.ts
+++ b/services/app-api/utils/reports/reports.test.ts
@@ -1,4 +1,4 @@
-import { copyFieldDataFromSource } from "./reports";
+import { copyFieldDataFromSource, makePCCMModifications } from "./reports";
 import { ReportType } from "../../utils/types";
 import { mockReportJson } from "../../utils/testing/setupJest";
 describe("Test copyFieldDataFromSource", () => {
@@ -12,5 +12,18 @@ describe("Test copyFieldDataFromSource", () => {
       ReportType.MLR
     );
     expect(res).toEqual({ stateName: "Minnesota" });
+  });
+
+  test("Test makePCCMModifications sets correct field data", () => {
+    let testFieldData = {};
+    testFieldData = makePCCMModifications(testFieldData);
+    expect(testFieldData).toEqual({
+      program_type: [
+        {
+          key: "program_type-atiwcA9QUE2eoTchV2ZLtw", // pragma: allowlist secret
+          value: "Primary Care Case Management (PCCM) Entity",
+        },
+      ],
+    });
   });
 });

--- a/services/app-api/utils/reports/reports.ts
+++ b/services/app-api/utils/reports/reports.ts
@@ -82,3 +82,15 @@ function isEntity(rootKey: string): rootKey is keyof typeof McparFieldsToCopy {
 function nonEmptyObject(obj: AnyObject) {
   return Object.keys(obj).length > 0;
 }
+
+export function makePCCMModifications(fieldData: any) {
+  // Section C.I, Question C1.I.3 Program type; select PCCM option
+  fieldData.program_type = [
+    {
+      key: "program_type-atiwcA9QUE2eoTchV2ZLtw", // pragma: allowlist secret
+      value: "Primary Care Case Management (PCCM) Entity",
+    },
+  ];
+
+  return fieldData;
+}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
There is a question within the MCPAR report that asks for program type, including PCCM as an option. If a user selects PCCM when creating the report, we want this question to reflect that as well.

I tried to write these functions/pathways so that they could be extensible

The form template creation flow now has an additional step that calls a function to make any necessary modifications to the template for PCCM.
The overall report creation flow now has a branch that makes any necessary modifications to formData for PCCM.

Feedback requested on:
- modifying these two separate things (template and fieldData) in a way that makes sense and keeps them somewhat in sync
- Is this the most logical way to do this?

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3136

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a MCPAR report and select "Yes" in the modal to indicate it's a PCCM report
- Go into the report -> Section C -> I
- Verify that C1.I.3 is disabled and has the PCCM option already selected

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
---