### PR TITLE
consolidate state rep to state user role

### DIFF
--- a/services/app-api/utils/auth/authorization.ts
+++ b/services/app-api/utils/auth/authorization.ts
@@ -81,9 +81,14 @@ export const hasPermissions = (
   if (event?.headers["x-api-key"]) {
     const decoded = jwt_decode(event.headers["x-api-key"]) as DecodedToken;
     const idmUserRoles = decoded["custom:cms_roles"];
-    const mcrUserRole = idmUserRoles
+    let mcrUserRole = idmUserRoles
       ?.split(",")
       .find((role) => role.includes("mdctmcr")) as UserRoles;
+
+    // consolidate "STATE_REP" role into "STATE_USER" role
+    if (mcrUserRole === UserRoles.STATE_REP) {
+      mcrUserRole = UserRoles.STATE_USER;
+    }
 
     if (allowedRoles.includes(mcrUserRole)) {
       isAllowed = true;

--- a/services/app-api/utils/types/users.ts
+++ b/services/app-api/utils/types/users.ts
@@ -6,4 +6,6 @@ export enum UserRoles {
   INTERNAL = "mdctmcr-internal-user", // "MDCT MCR Internal User"
   APPROVER = "mdctmcr-approver", // "MDCT MCR Approver"
   STATE_USER = "mdctmcr-state-user", // "MDCT MCR State User"
+  // old roles
+  STATE_REP = "mdctmcr-state-rep", // removed Jan 2024 (consolidated to STATE_USER)
 }

--- a/services/ui-src/src/types/users.ts
+++ b/services/ui-src/src/types/users.ts
@@ -6,6 +6,8 @@ export enum UserRoles {
   INTERNAL = "mdctmcr-internal-user", // "MDCT MCR Internal User"
   APPROVER = "mdctmcr-approver", // "MDCT MCR Approver"
   STATE_USER = "mdctmcr-state-user", // "MDCT MCR State User"
+  // old roles
+  STATE_REP = "mdctmcr-state-rep", // removed Jan 2024 (consolidated to STATE_USER)
 }
 
 export interface MCRUser {

--- a/services/ui-src/src/utils/auth/UserProvider.tsx
+++ b/services/ui-src/src/utils/auth/UserProvider.tsx
@@ -64,7 +64,12 @@ export const UserProvider = ({ children }: Props) => {
 
       // "custom:cms_roles" is an string of concat roles so we need to check for the one applicable to MCR
       const cms_role = payload["custom:cms_roles"] as string;
-      const userRole = cms_role.split(",").find((r) => r.includes("mdctmcr"));
+      let userRole = cms_role.split(",").find((r) => r.includes("mdctmcr"));
+
+      // consolidate "STATE_REP" role into "STATE_USER" role
+      if (userRole === UserRoles.STATE_REP) {
+        userRole = UserRoles.STATE_USER;
+      }
 
       const state = payload["custom:cms_state"] as string | undefined;
       const full_name = [given_name, " ", family_name].join("");


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
If a user has the IDM user role "mdctmcr-state-rep" we need to treat them as if they are a state user. This is related to a recent change (#11552) to retire the state rep role, but because there are legacy users who will still have the state rep role in IDM, we need to treat them as state users in the app. 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
[CMDCT-3165](https://jiraent.cms.gov/browse/CMDCT-3165)

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
You could try logging in as a state rep user, but we removed that user from the test accounts, so you could just take my word for it I guess?

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] ~~I have added [thorough](https://shorturl.at/aejkF) tests, if necessary~~
- [ ] ~~I have updated relevant documentation, if necessary~~
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
