### PR TITLE
Restrict requests by assigned state for state users

### DIFF
--- a/services/app-api/handlers/reports/archive.test.ts
+++ b/services/app-api/handlers/reports/archive.test.ts
@@ -39,18 +39,12 @@ const archiveEvent: APIGatewayProxyEvent = {
 };
 
 describe("Test archiveReport method", () => {
-  beforeEach(() => {
-    // fail state and pass admin auth checks
-    mockAuthUtil.hasPermissions
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(false);
-  });
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   test("Test archive report passes with valid data", async () => {
+    mockAuthUtil.hasPermissions.mockReturnValue(true);
     const dynamoPutSpy = jest.spyOn(dynamodbLib, "put");
     dynamoPutSpy.mockResolvedValue(mockDynamoPutCommandOutput);
     mockedFetchReport.mockResolvedValue({
@@ -69,6 +63,7 @@ describe("Test archiveReport method", () => {
   });
 
   test("Test archive report with no existing record throws 404", async () => {
+    mockAuthUtil.hasPermissions.mockReturnValue(true);
     mockedFetchReport.mockResolvedValue({
       statusCode: 200,
       headers: {
@@ -83,6 +78,7 @@ describe("Test archiveReport method", () => {
   });
 
   test("Test archive report without admin permissions throws 403", async () => {
+    mockAuthUtil.hasPermissions.mockReturnValue(false);
     mockedFetchReport.mockResolvedValue({
       statusCode: 200,
       headers: {

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -32,16 +32,8 @@ import {
 } from "../../utils/reports/reports";
 
 export const createReport = handler(async (event, _context) => {
-  if (!hasPermissions(event, [UserRoles.STATE_USER])) {
-    return {
-      status: StatusCodes.UNAUTHORIZED,
-      body: error.UNAUTHORIZED,
-    };
-  }
-
   const requiredParams = ["reportType", "state"];
-
-  // Return error if no state is passed.
+  // Return bad request if missing required parameters
   if (
     !event.pathParameters ||
     !hasReportPathParams(event.pathParameters, requiredParams)
@@ -57,6 +49,12 @@ export const createReport = handler(async (event, _context) => {
     return {
       status: StatusCodes.BAD_REQUEST,
       body: error.NO_KEY,
+    };
+  }
+  if (!hasPermissions(event, [UserRoles.STATE_USER], state)) {
+    return {
+      status: StatusCodes.UNAUTHORIZED,
+      body: error.UNAUTHORIZED,
     };
   }
   const unvalidatedPayload = JSON.parse(event.body!);

--- a/services/app-api/handlers/reports/fetch.test.ts
+++ b/services/app-api/handlers/reports/fetch.test.ts
@@ -42,7 +42,7 @@ const testReadEventByState: APIGatewayProxyEvent = {
 
 describe("Test fetchReport API method", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
     dynamoClientMock.reset();
     mockAuthUtil.hasPermissions.mockReturnValueOnce(true);
   });
@@ -137,7 +137,7 @@ describe("Test fetchReport API method", () => {
 
 describe("Test fetchReportsByState API method", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
     dynamoClientMock.reset();
     mockAuthUtil.hasPermissions.mockReturnValueOnce(true);
   });
@@ -174,7 +174,7 @@ describe("Test fetchReportsByState API method", () => {
 
 describe("Test state user permission control", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
     dynamoClientMock.reset();
   });
 
@@ -221,7 +221,7 @@ describe("Test state user permission control", () => {
 
 describe("Test failing state user permission control", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
   test("Test fetchReport request unauthorized when both permission checks fail", async () => {
     // fail both state user with state and other roles checks

--- a/services/app-api/handlers/reports/fetch.test.ts
+++ b/services/app-api/handlers/reports/fetch.test.ts
@@ -42,7 +42,7 @@ const testReadEventByState: APIGatewayProxyEvent = {
 
 describe("Test fetchReport API method", () => {
   beforeEach(() => {
-    jest.restoreAllMocks();
+    jest.clearAllMocks();
     dynamoClientMock.reset();
     mockAuthUtil.hasPermissions.mockReturnValueOnce(true);
   });
@@ -137,7 +137,7 @@ describe("Test fetchReport API method", () => {
 
 describe("Test fetchReportsByState API method", () => {
   beforeEach(() => {
-    jest.restoreAllMocks();
+    jest.clearAllMocks();
     dynamoClientMock.reset();
     mockAuthUtil.hasPermissions.mockReturnValueOnce(true);
   });
@@ -174,7 +174,7 @@ describe("Test fetchReportsByState API method", () => {
 
 describe("Test state user permission control", () => {
   beforeEach(() => {
-    jest.restoreAllMocks();
+    jest.clearAllMocks();
     dynamoClientMock.reset();
   });
 
@@ -221,7 +221,7 @@ describe("Test state user permission control", () => {
 
 describe("Test failing state user permission control", () => {
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
   test("Test fetchReport request unauthorized when both permission checks fail", async () => {
     // fail both state user with state and other roles checks

--- a/services/app-api/handlers/reports/fetch.test.ts
+++ b/services/app-api/handlers/reports/fetch.test.ts
@@ -221,7 +221,7 @@ describe("Test state user permission control", () => {
 
 describe("Test failing state user permission control", () => {
   beforeEach(() => {
-    jest.restoreAllMocks();
+    jest.resetAllMocks();
   });
   test("Test fetchReport request unauthorized when both permission checks fail", async () => {
     // fail both state user with state and other roles checks

--- a/services/app-api/handlers/reports/fetch.ts
+++ b/services/app-api/handlers/reports/fetch.ts
@@ -16,34 +16,9 @@ import {
   calculateCompletionStatus,
   isComplete,
 } from "../../utils/validation/completionStatus";
-import { hasPermissions } from "../../utils/auth/authorization";
+import { isAuthorizedToFetchState } from "../../utils/auth/authorization";
 // types
-import {
-  AnyObject,
-  APIGatewayProxyEvent,
-  isState,
-  S3Get,
-  StatusCodes,
-  UserRoles,
-} from "../../utils/types";
-
-const isAuthorizedToFetchState = (
-  event: APIGatewayProxyEvent,
-  state: string
-) => {
-  let isAuthorized = false;
-  // check permissions for state user and matching state
-  isAuthorized = hasPermissions(event, [UserRoles.STATE_USER], state);
-  // if not, check all other roles which don't have a state assignment
-  if (!isAuthorized) {
-    const nonStateUserRoles = Object.values(UserRoles).filter(
-      (role) => role !== UserRoles.STATE_USER
-    );
-    isAuthorized = hasPermissions(event, nonStateUserRoles);
-  }
-
-  return isAuthorized;
-};
+import { AnyObject, isState, S3Get, StatusCodes } from "../../utils/types";
 
 export const fetchReport = handler(async (event, _context) => {
   const requiredParams = ["reportType", "id", "state"];

--- a/services/app-api/handlers/reports/release.test.ts
+++ b/services/app-api/handlers/reports/release.test.ts
@@ -39,18 +39,13 @@ const releaseEvent: APIGatewayProxyEvent = {
 describe("Test releaseReport method", () => {
   beforeEach(() => {
     dynamoClientMock.reset();
-    // fail state and pass admin auth checks
-    mockAuthUtil.hasPermissions
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(false);
   });
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   test("Test release report passes with valid data", async () => {
+    mockAuthUtil.hasPermissions.mockReturnValue(true);
     // s3 mocks
     const s3GetSpy = jest.spyOn(s3Lib, "get");
     s3GetSpy
@@ -76,6 +71,7 @@ describe("Test releaseReport method", () => {
   });
 
   test("Test release report passes with valid data, but it's been more than the first submission", async () => {
+    mockAuthUtil.hasPermissions.mockReturnValue(true);
     // s3 mocks
     const s3GetSpy = jest.spyOn(s3Lib, "get");
     s3GetSpy
@@ -107,6 +103,7 @@ describe("Test releaseReport method", () => {
   });
 
   test("Test release report with no existing record throws 404", async () => {
+    mockAuthUtil.hasPermissions.mockReturnValue(true);
     dynamoClientMock.on(GetCommand).resolves({
       Item: undefined,
     });
@@ -116,6 +113,7 @@ describe("Test releaseReport method", () => {
   });
 
   test("Test release report without admin permissions throws 403", async () => {
+    mockAuthUtil.hasPermissions.mockReturnValue(false);
     dynamoClientMock.on(GetCommand).resolves({
       Item: mockDynamoDataMLRLocked,
     });

--- a/services/app-api/handlers/reports/submit.ts
+++ b/services/app-api/handlers/reports/submit.ts
@@ -13,6 +13,7 @@ import s3Lib, {
   getFormTemplateKey,
 } from "../../utils/s3/s3-lib";
 import { convertDateUtcToEt } from "../../utils/time/time";
+import { hasReportPathParams } from "../../utils/dynamo/hasReportPathParams";
 // types
 import {
   isState,
@@ -23,21 +24,14 @@ import {
 } from "../../utils/types";
 
 export const submitReport = handler(async (event, _context) => {
+  const requiredParams = ["id", "reportType", "state"];
   if (
-    !event.pathParameters?.id ||
-    !event.pathParameters?.state ||
-    !event.pathParameters.reportType
+    !event.pathParameters ||
+    !hasReportPathParams(event.pathParameters, requiredParams)
   ) {
     return {
       status: StatusCodes.BAD_REQUEST,
       body: error.NO_KEY,
-    };
-  }
-
-  if (!hasPermissions(event, [UserRoles.STATE_USER])) {
-    return {
-      status: StatusCodes.UNAUTHORIZED,
-      body: error.UNAUTHORIZED,
     };
   }
 
@@ -47,6 +41,12 @@ export const submitReport = handler(async (event, _context) => {
     return {
       status: StatusCodes.BAD_REQUEST,
       body: error.NO_KEY,
+    };
+  }
+  if (!hasPermissions(event, [UserRoles.STATE_USER], state)) {
+    return {
+      status: StatusCodes.UNAUTHORIZED,
+      body: error.UNAUTHORIZED,
     };
   }
 

--- a/services/app-api/handlers/reports/update.ts
+++ b/services/app-api/handlers/reports/update.ts
@@ -27,7 +27,10 @@ import { isState, ReportJson, StatusCodes, UserRoles } from "../../utils/types";
 
 export const updateReport = handler(async (event, context) => {
   const requiredParams = ["reportType", "id", "state"];
-  if (!hasReportPathParams(event.pathParameters!, requiredParams)) {
+  if (
+    !event.pathParameters ||
+    !hasReportPathParams(event.pathParameters!, requiredParams)
+  ) {
     return {
       status: StatusCodes.BAD_REQUEST,
       body: error.NO_KEY,
@@ -89,7 +92,7 @@ export const updateReport = handler(async (event, context) => {
   }
 
   // Ensure user has correct permissions to update a report.
-  if (!hasPermissions(event, [UserRoles.STATE_USER])) {
+  if (!hasPermissions(event, [UserRoles.STATE_USER], state)) {
     return {
       status: StatusCodes.UNAUTHORIZED,
       body: error.UNAUTHORIZED,

--- a/services/app-api/utils/auth/authorization.test.ts
+++ b/services/app-api/utils/auth/authorization.test.ts
@@ -148,3 +148,32 @@ describe("Check deprectated state rep role coalesces to state user", () => {
     expect(hasPermissions(noApiKeyEvent, [UserRoles.STATE_USER])).toBeFalsy();
   });
 });
+
+describe("Check state user permissions", () => {
+  test("has permissions should pass when role and state match expected role and state", () => {
+    mockedDecode.mockReturnValue({
+      "custom:cms_roles": UserRoles.STATE_USER,
+      "custom:cms_state": "AL",
+    });
+    expect(
+      hasPermissions(apiKeyEvent, [UserRoles.STATE_USER], "AL")
+    ).toBeTruthy();
+  });
+  test("has permissions should fail if state is expected but not in role", () => {
+    mockedDecode.mockReturnValue({
+      "custom:cms_roles": UserRoles.STATE_USER,
+    });
+    expect(
+      hasPermissions(apiKeyEvent, [UserRoles.STATE_USER], "AL")
+    ).toBeFalsy();
+  });
+  test("has permissions should fail if requested state does not match role", () => {
+    mockedDecode.mockReturnValue({
+      "custom:cms_roles": UserRoles.STATE_USER,
+      "custom:cms_state": "TX",
+    });
+    expect(
+      hasPermissions(apiKeyEvent, [UserRoles.STATE_USER], "AL")
+    ).toBeFalsy();
+  });
+});

--- a/services/app-api/utils/auth/authorization.ts
+++ b/services/app-api/utils/auth/authorization.ts
@@ -84,16 +84,27 @@ export const hasPermissions = (
       mcrUserRole = UserRoles.STATE_USER;
     }
 
-    if (state) {
-      if (allowedRoles.includes(mcrUserRole) && idmUserState?.includes(state)) {
-        isAllowed = true;
-      }
-    } else {
-      if (allowedRoles.includes(mcrUserRole)) {
-        isAllowed = true;
-      }
-    }
+    isAllowed =
+      allowedRoles.includes(mcrUserRole) &&
+      (!state || idmUserState?.includes(state))!;
   }
 
   return isAllowed;
+};
+
+export const isAuthorizedToFetchState = (
+  event: APIGatewayProxyEvent,
+  state: string
+) => {
+  // If this is a state user for the matching state, authorize them.
+  if (hasPermissions(event, [UserRoles.STATE_USER], state)) {
+    return true;
+  }
+
+  const nonStateUserRoles = Object.values(UserRoles).filter(
+    (role) => role !== UserRoles.STATE_USER
+  );
+
+  // If they are any other user type, they don't need to belong to this state.
+  return hasPermissions(event, nonStateUserRoles);
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
We have an auth utility called `hasPermissions` that verifies the requesting user has the role expected for a given request (ex: ADMIN for create banner, STATE USER for submit report, etc.)

Key changes:
- `services/app-api/utils/auth/authorization.ts` the `hasPermissions()` method is updated to optionally accept `state`. It performs different verification logic as a result.
- `services/app-api/handlers/reports/fetch.ts` added the `isAuthorizedToFetchState()` method to verify that if they are a state user, they are a state user for the requested state. Admins and other types can request any state.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3196

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Note: there was a recent aws sdk upgrade so you may need to `yarn` a bunch of directories. `./dev local` should do it for you, but in case you see issues.

To verify the `create` updates (same logic as `update` and `submit`)
- Log in as a state user
- With the network tab open, create a MCPAR report
- Manipulate the POST network request to send it to a different state
- Verify that request returns a 403 (on `main` it is a 201 😬 )

https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/57802560/4de0591a-e8f9-4862-86cc-ff0d8d947a2b

You can do a similar test to verify `fetch` permissions checks
- Log in as a state user
- With the network tab open, refresh the MCPAR reports dashboard
- Manipulate the GET network request to request reports from a different state
- Verify that request returns a 403 (on `main` it is a 200 😬 )

You can also verify admin functions still work as expected (like create and delete banner)

On Chrome you can right-click the command and select "Copy as cURL or Copy as Fetch". The former you can paste in a terminal and edit. The latter you can paste in the browser's console and edit (I found this easier). Resend the command and verify the status code.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
---

### Looking for feedback
`services/app-api/handlers/reports/fetch.test.ts` I added tests to check the new `isAuthorizedToFetchState()` method. However, these tests were failing when their `beforeEach` included `jest.restoreAllMocks()`. I changed it to `jest.resetAllMocks()` and now they pass. However, if they are moved and run before other tests they cause the subsequent tests to fail. I determined that if you leave `restoreAllMocks` and comment out the 4 tests that test for 400s, then everything passes. The 400 tests have the fewest mocks of all so I'm at a loss as to how those are interfering. Please lend me your knowledge! 

WAIT NOW THEY ALL PASS?!?! WHAT IS GOING ON!

