### PR TITLE
stop running tests from .build

### DIFF
--- a/services/app-api/package.json
+++ b/services/app-api/package.json
@@ -82,6 +82,9 @@
     "moduleDirectories": [
       "node_modules"
     ],
+    "modulePathIgnorePatterns": [
+      "<rootDir>/.build/"
+    ],
     "setupFilesAfterEnv": [
       "<rootDir>/utils/testing/setupJest.ts"
     ]


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Stop jest from detecting and running tests in the .build/ directory of app-api (this somehow only happens in MCR)

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Make sure you have a .build/ directory in app-api (this is generated by running the app locally)
- Run `yarn test` in `app-api` and ensure it does not include .build!
