### PR TITLE
fix flaky profile cypress test

### DIFF
--- a/tests/cypress/tests/e2e/profile.spec.js
+++ b/tests/cypress/tests/e2e/profile.spec.js
@@ -4,10 +4,6 @@ const menuOptionManageAccount =
   '[data-testid="header-menu-option-manage-account"]';
 const adminButton = 'button:contains("Banner Editor")';
 
-afterEach(() => {
-  cy.navigateToHomePage();
-});
-
 describe("Profile integration tests", () => {
   it("Allows admin user to navigate to /admin", () => {
     cy.authenticate("adminUser");


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The profile cypress spec flakes relatively frequently. Below is a video from a recent PR cypress run of it failing. You can see it doesn't get back to the login page, but stays on the admin home page when it's trying to authenticate as a state user.
I saw it fail locally with the same issue. I wondered if the navigate home was somehow interfering with the next tests authenticate call. When I removed navigateHome it seemed to help. Test locally and verify it passes in this PR and we'll see if this helps!

https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/57802560/8cd111e0-0a1b-44d4-b25b-33f5e417da1d



---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
See description

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
---