### PR TITLE
CMDCT-2975: Fix Admin User Access to Reports

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -76,9 +76,11 @@ export const DashboardPage = ({ reportType }: Props) => {
   const dashboardVerbiage = dashboardVerbiageMap[reportType]!;
   const { intro, body } = dashboardVerbiage;
 
-  // get active state
+  // if an admin has selected a state, retrieve it from local storage
   const adminSelectedState = localStorage.getItem("selectedState") || undefined;
-  const activeState = userState || adminSelectedState;
+
+  // if a user is an admin type, use the selected state, otherwise use their assigned state
+  const activeState = userIsAdmin ? adminSelectedState : userState;
 
   useEffect(() => {
     // if no activeState, go to homepage


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
In IDM, states are assigned by profile, not by role. If an IDM user is a `state user` in one application (e.g. MFP) and an `admin user` in a different one (e.g. MCR), their IDM profile carries over the assigned state. Because of this, the current check in the Admin User Dashboard is sometimes ignored for that user's IDM profile assigned state. That state should be ignored / not relevant when the user is logged in as an admin.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-2796

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Log in as an admin and as a state user, verify that you are able to navigate to the correct reports.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_