### PR TITLE
CMDCT-3272: PDF Table Column Update

### DIFF
--- a/services/ui-src/src/components/export/ExportedReportFieldRow.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldRow.tsx
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 // components
-import { Box, Tr, Td, Text } from "@chakra-ui/react";
+import { Box, Tr, Td, Text, Th } from "@chakra-ui/react";
 import { ReportContext } from "components";
 // types
 import { FormField, FormLayoutElement, isFieldElement } from "types";
@@ -27,11 +27,11 @@ export const ExportedReportFieldRow = ({
     <Tr data-testid="exportRow">
       {/* number column/cell */}
       {!isDynamicField && (
-        <Td sx={sx.numberColumn}>
+        <Th sx={sx.numberColumn}>
           <Text sx={sx.fieldNumber}>
             {formFieldInfo?.number?.replace(".", "") || "N/A"}
           </Text>
-        </Td>
+        </Th>
       )}
 
       {/* label column/cell */}
@@ -83,11 +83,13 @@ export interface Props {
 const sx = {
   numberColumn: {
     width: "5.5rem",
-    paddingLeft: 0,
+    paddingTop: "0.5rem",
   },
   fieldNumber: {
     fontSize: "sm",
     fontWeight: "bold",
+    textTransform: "none",
+    paddingLeft: "0.5rem",
   },
   labelColumn: {
     width: "14rem",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
For the PDF export, the `Number` column of the MCPAR report tables should be a `<Th />` type to ease screen reader navigation.  

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3272

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
When you create a MCPAR PDF and inspect a table, the first column should be a `<th />`

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
