### PR TITLE
[Bug Fix] CMDCT-3297: Read-Only Users Access to Report Dashboard

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -54,6 +54,7 @@ export const DashboardPage = ({ reportType }: Props) => {
     state: userState,
     userIsEndUser,
     userIsAdmin,
+    userIsReadOnly,
   } = useStore().user ?? {};
   const { isTablet, isMobile } = useBreakpoint();
   const [reportsToDisplay, setReportsToDisplay] = useState<
@@ -76,11 +77,11 @@ export const DashboardPage = ({ reportType }: Props) => {
   const dashboardVerbiage = dashboardVerbiageMap[reportType]!;
   const { intro, body } = dashboardVerbiage;
 
-  // if an admin has selected a state, retrieve it from local storage
-  const adminSelectedState = localStorage.getItem("selectedState") || undefined;
+  // if an admin or a read-only user has selected a state, retrieve it from local storage
+  const selectedState = localStorage.getItem("selectedState") || undefined;
 
-  // if a user is an admin type, use the selected state, otherwise use their assigned state
-  const activeState = userIsAdmin ? adminSelectedState : userState;
+  // if a user is an admin or a read-only type, use the selected state, otherwise use their assigned state
+  const activeState = userIsAdmin || userIsReadOnly ? selectedState : userState;
 
   useEffect(() => {
     // if no activeState, go to homepage
@@ -178,7 +179,7 @@ export const DashboardPage = ({ reportType }: Props) => {
       setArchiving(true);
       const reportKeys = {
         reportType: reportType,
-        state: adminSelectedState,
+        state: selectedState,
         id: report.id,
       };
       await archiveReport(reportKeys);
@@ -194,7 +195,7 @@ export const DashboardPage = ({ reportType }: Props) => {
       setReleasing(true);
       const reportKeys = {
         reportType: reportType,
-        state: adminSelectedState,
+        state: selectedState,
         id: report.id,
       };
       await releaseReport!(reportKeys);


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Internal and Help-Desk users weren't able to view the Reports Dashboard because their selected state was coming back `undefined`

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3297

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Log in as `internaluser@test.com` or `helpdeskuser@test.com` and selected any state / report combination. The report dashboard should load correctly.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
