### PR TITLE
Adding cleanup step to be run in dev and val environments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -273,7 +273,7 @@ jobs:
   
   cleanup:
     name: Delist GHA Runner CIDR Blocks
-    if: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/val' && github.ref != 'refs/heads/production' }}
+    if: ${{ github.ref != 'refs/heads/production' }}
     runs-on: ubuntu-latest
     needs:
       - deploy


### PR DESCRIPTION
### Description
The vpn changes were brought over from QMR. QMR is the outlier in terms of running tests in integration environments. This fixes that for MCR.

The reason for this change is when tests run we want to delist the GitHub runner cidr blocks from its unique IP set after a successful run. If this change was not made the ip set would just grow and grow and potentially reach a limit.

### Related ticket(s)
https://jiraent.cms.gov/browse/CMDCT-3242
---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
n/a


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
