### PR TITLE
Update MCPAR PDF Header Tags

### DIFF
--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -963,7 +963,7 @@
                   "info": [
                     {
                       "type": "heading",
-                      "as": "h3",
+                      "as": "h4",
                       "content": "Network Adequacy"
                     }
                   ]
@@ -1006,7 +1006,7 @@
                   "info": [
                     {
                       "type": "heading",
-                      "as": "h3",
+                      "as": "h4",
                       "content": "Access Measures"
                     },
                     {
@@ -1753,7 +1753,7 @@
                   "info": [
                     {
                       "type": "heading",
-                      "as": "h3",
+                      "as": "h4",
                       "content": "Appeals Overview"
                     }
                   ]
@@ -1957,7 +1957,7 @@
                   "info": [
                     {
                       "type": "heading",
-                      "as": "h3",
+                      "as": "h4",
                       "content": "Appeals by Service"
                     },
                     {
@@ -2111,7 +2111,7 @@
                   "info": [
                     {
                       "type": "heading",
-                      "as": "h3",
+                      "as": "h4",
                       "content": "State Fair Hearings"
                     }
                   ]
@@ -2217,7 +2217,7 @@
                   "info": [
                     {
                       "type": "heading",
-                      "as": "h3",
+                      "as": "h4",
                       "content": "Grievances Overview"
                     }
                   ]
@@ -2312,7 +2312,7 @@
                   "info": [
                     {
                       "type": "heading",
-                      "as": "h3",
+                      "as": "h4",
                       "content": "Grievances by Service"
                     },
                     {
@@ -2472,7 +2472,7 @@
                   "info": [
                     {
                       "type": "heading",
-                      "as": "h3",
+                      "as": "h4",
                       "content": "Grievances by Reason"
                     },
                     {

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
@@ -1,24 +1,27 @@
+import { useState, useEffect } from "react";
 // components
 import { Grid, GridItem, Heading, Text } from "@chakra-ui/react";
 // utils
 import { AnyObject, ModalDrawerEntityTypes } from "types";
-import { useLocation } from "react-router-dom";
 
 export const EntityCardTopSection = ({
   entityType,
   formattedEntityData,
   printVersion,
 }: Props) => {
-  const { pathname } = useLocation();
+  const [isPDF, setIsPDF] = useState(false);
+
+  useEffect(() => {
+    if (window.location.pathname === "/mcpar/export") {
+      setIsPDF(true);
+    }
+  }, []);
 
   switch (entityType) {
     case ModalDrawerEntityTypes.ACCESS_MEASURES:
       return (
         <>
-          <Heading
-            as={pathname === "/mcpar/export" ? "p" : "h4"}
-            sx={sx.heading}
-          >
+          <Heading as={isPDF ? "p" : "h4"} sx={sx.heading}>
             {`${printVersion ? "C2.V.1 General category: " : ""}${
               formattedEntityData.category
             }`}
@@ -38,10 +41,7 @@ export const EntityCardTopSection = ({
     case ModalDrawerEntityTypes.SANCTIONS:
       return (
         <>
-          <Heading
-            as={pathname === "/mcpar/export" ? "p" : "h4"}
-            sx={sx.heading}
-          >
+          <Heading as={isPDF ? "p" : "h4"} sx={sx.heading}>
             {`${printVersion ? "D3.VIII.1 Intervention type: " : ""}${
               formattedEntityData.interventionType
             }`}
@@ -73,10 +73,7 @@ export const EntityCardTopSection = ({
     case ModalDrawerEntityTypes.QUALITY_MEASURES:
       return (
         <>
-          <Heading
-            as={pathname === "/mcpar/export" ? "p" : "h4"}
-            sx={sx.heading}
-          >
+          <Heading as={isPDF ? "p" : "h4"} sx={sx.heading}>
             {`${printVersion ? "D2.VII.1 Measure Name: " : ""}${
               formattedEntityData.name
             }`}

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
@@ -2,17 +2,23 @@
 import { Grid, GridItem, Heading, Text } from "@chakra-ui/react";
 // utils
 import { AnyObject, ModalDrawerEntityTypes } from "types";
+import { useLocation } from "react-router-dom";
 
 export const EntityCardTopSection = ({
   entityType,
   formattedEntityData,
   printVersion,
 }: Props) => {
+  const { pathname } = useLocation();
+
   switch (entityType) {
     case ModalDrawerEntityTypes.ACCESS_MEASURES:
       return (
         <>
-          <Heading as="h4" sx={sx.heading}>
+          <Heading
+            as={pathname === "/mcpar/export" ? "p" : "h4"}
+            sx={sx.heading}
+          >
             {`${printVersion ? "C2.V.1 General category: " : ""}${
               formattedEntityData.category
             }`}
@@ -32,7 +38,10 @@ export const EntityCardTopSection = ({
     case ModalDrawerEntityTypes.SANCTIONS:
       return (
         <>
-          <Heading as="h4" sx={sx.heading}>
+          <Heading
+            as={pathname === "/mcpar/export" ? "p" : "h4"}
+            sx={sx.heading}
+          >
             {`${printVersion ? "D3.VIII.1 Intervention type: " : ""}${
               formattedEntityData.interventionType
             }`}
@@ -64,7 +73,10 @@ export const EntityCardTopSection = ({
     case ModalDrawerEntityTypes.QUALITY_MEASURES:
       return (
         <>
-          <Heading as="h4" sx={sx.heading}>
+          <Heading
+            as={pathname === "/mcpar/export" ? "p" : "h4"}
+            sx={sx.heading}
+          >
             {`${printVersion ? "D2.VII.1 Measure Name: " : ""}${
               formattedEntityData.name
             }`}

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 // components
-import { Box, Heading, Text } from "@chakra-ui/react";
+import { Box, Text } from "@chakra-ui/react";
 import { EntityCard, ReportContext } from "components";
 // utils
 import { getFormattedEntityData } from "utils";
@@ -22,14 +22,14 @@ export const ExportedModalDrawerReportSection = ({
       data-testid="exportedModalDrawerReportSection"
       sx={sx.container}
     >
-      <Heading as="h3" sx={sx.dashboardTitle} data-testid="headerCount">
+      <Text as="p" sx={sx.dashboardTitle} data-testid="headerCount">
         {`${verbiage.dashboardTitle} ${entityCount > 0 ? entityCount : ""}`}
         {!entityCount && (
           <Text as="span" sx={sx.notAnswered} data-testid="entityMessage">
             {emptyEntityMessage[entityType as keyof typeof emptyEntityMessage]}
           </Text>
         )}
-      </Heading>
+      </Text>
       {entities?.map((entity: EntityShape, entityIndex: number) => (
         <EntityCard
           key={entity.id}
@@ -70,6 +70,5 @@ const sx = {
     marginBottom: "1.25rem",
     fontSize: "md",
     fontWeight: "bold",
-    color: "palette.gray_medium",
   },
 };

--- a/services/ui-src/src/components/export/ExportedSectionHeading.tsx
+++ b/services/ui-src/src/components/export/ExportedSectionHeading.tsx
@@ -71,7 +71,7 @@ const sx = {
   heading: {
     fontWeight: "bold",
     h2: {
-      fontSize: "xl",
+      fontSize: "2xl",
       margin: "1.5rem 0",
     },
     h3: {

--- a/services/ui-src/src/components/export/ExportedSectionHeading.tsx
+++ b/services/ui-src/src/components/export/ExportedSectionHeading.tsx
@@ -13,7 +13,8 @@ export const ExportedSectionHeading = ({
 }: Props) => {
   const sectionHeading = verbiage?.intro?.exportSectionHeader
     ? verbiage?.intro?.exportSectionHeader
-    : verbiage?.intro?.subsection || heading;
+    : verbiage?.intro?.section;
+  const sectionSubHeader = verbiage?.intro?.subsection || heading;
   const sectionInfo = verbiage?.intro?.exportSectionHeader
     ? null
     : verbiage?.intro?.info;
@@ -21,9 +22,16 @@ export const ExportedSectionHeading = ({
 
   return (
     <Box data-testid="exportedSectionHeading" sx={sx.container}>
-      <Heading as="h2" sx={sx.heading}>
-        {sectionHeading}
-      </Heading>
+      {sectionHeading ? (
+        <Heading as="h2" sx={sx.heading.h2}>
+          {sectionHeading}
+        </Heading>
+      ) : null}
+      {sectionSubHeader ? (
+        <Heading as="h3" sx={sx.heading.h3}>
+          {sectionSubHeader}
+        </Heading>
+      ) : null}
       {sectionInfo && (
         <Box sx={sx.info}>
           <Text>
@@ -59,9 +67,15 @@ const sx = {
     },
   },
   heading: {
-    margin: "1.5rem 0",
-    fontSize: "xl",
     fontWeight: "bold",
+    h2: {
+      fontSize: "xl",
+      margin: "1.5rem 0",
+    },
+    h3: {
+      fontSize: "lg",
+      margin: "1.5rem 0",
+    },
   },
   info: {
     p: {

--- a/services/ui-src/src/components/export/ExportedSectionHeading.tsx
+++ b/services/ui-src/src/components/export/ExportedSectionHeading.tsx
@@ -11,46 +11,48 @@ export const ExportedSectionHeading = ({
   reportType,
   verbiage,
 }: Props) => {
-  const sectionHeading = verbiage?.intro?.exportSectionHeader
-    ? verbiage?.intro?.exportSectionHeader
-    : verbiage?.intro?.section;
   const sectionSubHeader = verbiage?.intro?.subsection || heading;
   const sectionInfo = verbiage?.intro?.exportSectionHeader
     ? null
     : verbiage?.intro?.info;
   const sectionSpreadsheet = verbiage?.intro?.spreadsheet;
+  const sectionInfoHeader: any =
+    verbiage?.intro?.info && verbiage?.intro?.info[0];
+  const sectionIntroType = sectionInfoHeader && sectionInfoHeader.type;
+  const sectionIntroContent = sectionInfoHeader && sectionInfoHeader.content;
 
   return (
-    <Box data-testid="exportedSectionHeading" sx={sx.container}>
-      {sectionHeading ? (
-        <Heading as="h2" sx={sx.heading.h2}>
-          {sectionHeading}
-        </Heading>
-      ) : null}
+    <>
       {sectionSubHeader ? (
         <Heading as="h3" sx={sx.heading.h3}>
-          {sectionSubHeader}
+          {sectionIntroType === "heading" &&
+          sectionIntroContent !== "Appeals Overview" &&
+          sectionIntroContent !== "Network Adequacy"
+            ? ""
+            : sectionSubHeader}
         </Heading>
       ) : null}
-      {sectionInfo && (
-        <Box sx={sx.info}>
-          <Text>
-            {typeof sectionInfo === "string"
-              ? sectionInfo
-              : parseCustomHtml(sectionInfo)}
-          </Text>
-        </Box>
-      )}
-      {sectionSpreadsheet && (
-        <Box sx={sx.spreadsheet}>
-          <SpreadsheetWidget
-            description={sectionSpreadsheet}
-            isPdf={true}
-            reportType={reportType}
-          />
-        </Box>
-      )}
-    </Box>
+      <Box data-testid="exportedSectionHeading" sx={sx.container}>
+        {sectionInfo && (
+          <Box sx={sx.info}>
+            <Text>
+              {typeof sectionInfo === "string"
+                ? sectionInfo
+                : parseCustomHtml(sectionInfo)}
+            </Text>
+          </Box>
+        )}
+        {sectionSpreadsheet && (
+          <Box sx={sx.spreadsheet}>
+            <SpreadsheetWidget
+              description={sectionSpreadsheet}
+              isPdf={true}
+              reportType={reportType}
+            />
+          </Box>
+        )}
+      </Box>
+    </>
   );
 };
 
@@ -73,8 +75,11 @@ const sx = {
       margin: "1.5rem 0",
     },
     h3: {
-      fontSize: "lg",
+      fontSize: "xl",
       margin: "1.5rem 0",
+    },
+    h4: {
+      fontSize: "lg",
     },
   },
   info: {
@@ -82,6 +87,9 @@ const sx = {
       margin: "1.5rem 0",
     },
     h3: {
+      fontSize: "xl",
+    },
+    h4: {
       fontSize: "lg",
     },
   },

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -143,9 +143,9 @@ export const renderReportSections = (
       section?.pageType !== PageTypes.REVIEW_SUBMIT && (
         <Box key={section.path} mt="5rem">
           {/*  render top-level section headings */}
-          {/* <Heading as="h2" sx={sx.sectionHeading}>
+          <Heading as="h2" sx={sx.sectionHeading}>
             {`Section ${section.name}`}
-          </Heading> */}
+          </Heading>
           {renderSection(section)}
         </Box>
       )

--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -45,6 +45,7 @@ export const parseCustomHtml = (element: CustomHtmlElement[] | string) => {
         as,
         ...props,
       };
+
       if (type === "html") {
         // sanitize and parse html
         content = sanitizeAndParseHtml(content);


### PR DESCRIPTION
### Description
For Acrobat PDF readers the PDF html headers need to be correct for bookmarking. Some of the headers where also different from what was on the figma mockup. Those have been updated as well.

Note: Per Kim's note on the ticket, Acrobat needs a plugin or additional functionality to even use bookmarks. I'm not completely sure if users have that set up or not but, if they do the html headers are set up for it. 

UPDATES: The ticket has been updated to only display H2 tags (section headers) once to reduce redundancy in screenreaders. 

```Evan: I’m going with Approach 1 - while it may not be ideal for understanding exactly which section a user is in due to <h3> text repeating in multiple sections, I still feel like a user will have a better experience than hearing long <h2> text every time. Users will assume they’re in Section A when hearing the subsequent headings until they get to Section B, so it shouldn’t stump seasoned SR users. Also, SR users tend to navigate via headings so they should hear the new section headings when going through the doc.```

UPDATES 2:
On the PDF page only the `h4` tags from 'Quality Measures, Access Measures, and Sanctions' cards had to be changed to `p` tags because the PDF reader was treating the cards as header sections for bookmarking.


### Related ticket(s)
CMDCT- https://jiraent.cms.gov/secure/RapidBoard.jspa?rapidView=5874&projectKey=CMDCT&view=detail&selectedIssue=CMDCT-3274

---
### How to test
Fill out MCPAR report and view PDF - Inspect the headers and checl them against the tags from the mockup


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
