### PR TITLE
Fix branch validation

### DIFF
--- a/.github/branch-name-validation.sh
+++ b/.github/branch-name-validation.sh
@@ -4,10 +4,18 @@ set -e
 
 local_branch=${1}
 
-valid_branch="^[a-z][a-z-0-9-]*$"
+valid_branch='^[a-z][a-z0-9-]*$'
 
+reserved_words=(
+    cognito
+)
 
-if [[ ! $local_branch =~ $valid_branch ]] && [[ $local_branch -gt 128 ]]; then
+join_by() { local IFS='|'; echo "$*"; }
+
+#creates glob match to check for reserved words used in branch names which would trigger failures
+glob=$(join_by $(for i in ${reserved_words[@]}; do echo "^$i-|-$i$|-$i-|^$i$"; done;))
+
+if [[ ! $local_branch =~ $valid_branch ]] || [[ $local_branch =~ $glob ]] || [[ ${#local_branch} -gt 128 ]]; then
     echo """
      ------------------------------------------------------------------------------------------------------------------------------
      ERROR:  Please read below

--- a/.github/branch-name-validation.sh
+++ b/.github/branch-name-validation.sh
@@ -15,11 +15,7 @@ join_by() { local IFS='|'; echo "$*"; }
 #creates glob match to check for reserved words used in branch names which would trigger failures
 glob=$(join_by $(for i in ${reserved_words[@]}; do echo "^$i-|-$i$|-$i-|^$i$"; done;))
 
-<<<<<<< Updated upstream
-if [[ ! $local_branch =~ $valid_branch ]] || [[ $local_branch =~ $glob ]] || [[ ${#local_branch} -gt 128 ]]; then
-=======
 if [[ ! $local_branch =~ $valid_branch ]] || [[ $local_branch =~ $glob ]] || [[ ${#local_branch} -gt 64 ]]; then
->>>>>>> Stashed changes
     echo """
      ------------------------------------------------------------------------------------------------------------------------------
      ERROR:  Please read below

--- a/.github/branch-name-validation.sh
+++ b/.github/branch-name-validation.sh
@@ -15,7 +15,11 @@ join_by() { local IFS='|'; echo "$*"; }
 #creates glob match to check for reserved words used in branch names which would trigger failures
 glob=$(join_by $(for i in ${reserved_words[@]}; do echo "^$i-|-$i$|-$i-|^$i$"; done;))
 
+<<<<<<< Updated upstream
 if [[ ! $local_branch =~ $valid_branch ]] || [[ $local_branch =~ $glob ]] || [[ ${#local_branch} -gt 128 ]]; then
+=======
+if [[ ! $local_branch =~ $valid_branch ]] || [[ $local_branch =~ $glob ]] || [[ ${#local_branch} -gt 64 ]]; then
+>>>>>>> Stashed changes
     echo """
      ------------------------------------------------------------------------------------------------------------------------------
      ERROR:  Please read below


### PR DESCRIPTION
### Description
The branch validation script has never worked.

The logic was wrong
if branch name not valid AND branch name longer than 64 chars

The regex was invalid
"^[a-z][a-z-0-9-]*$"
(the - between z and 0 is not valid)

It was also discovered that fully qualified function names must be less than 64 characters.  For instance, if a branch name is `test`, a service name is `database`, and a function name is `seedUsers`, the fully qualified name would be `database-test-seedUsers`.  The character limit for a branch has been set to 64 characters which won't prohibit fully qualified names from throwing errors, but is longer than Snyk and Dependabot generated branch nanes.

This PR fixes this, but it also adds the ability to filter on known reserved words.  I did some digging and wasn't able to locate a reserved word list that is comprehensive, because it seems each service has it's own set of reserved words, so without compiling a comprehensive list, the additional functionality essentially creates a glob matching rule.

Let's say we two reserved words, in this case **cognito**, and let's just say **test** is also reserved....

This iterates through the reserved words and creates a matchable set for each reserved word and then joins them to create a large glob string to match on

^cognito-|-cognito$|-cognito-|^cognito$
^test-|-test$|-test-|^test$

So the result would be 
^cognito-|-cognito$|-cognito-|^cognito$|^test-|-test$|-test-|^test$

Essentialy we're looking for matches where the branch name
begins with reservedWord-
ends with -reservedWord
contains -reservedWord-
is only reservedWord

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3222

---
### How to test
Execute the script and verify output.  No error message and $? not equal to 1 means it passed validation (Note in the above example **test** is used as a reserved word to illustrate how the glob is generated, but it is NOT actually reserved)
./branch-name-validation.sh Test //fail upper case char
./branch-name-validation.sh test_test //fail underscore
./branch-name-validation.sh testTest //fail upper case char
./branch-name-validation.sh 7test //fail begins with something other than lower case char
./branch-name-validation.sh -test //fail begins with something other than lower case char
./branch-name-validation.sh test-test //pass valid name
./branch-name-validation.sh congnitotest //pass valid name
./branch-name-validation.sh test-cognito //fail ends with -reservedWord
./branch-name-validation.sh cognito //fail is only reservedWord
./branch-name-validation.sh cognito-test //fail begins with reservedWord-
./branch-name-validation.sh test-cognito-test //fail contains -reservedWord-
./branch-name-validation.sh $(printf 'z%.0s' {1..32}) //pass branch is 128 'z's
./branch-name-validation.sh $(printf 'z%.0s' {1..33}) //fail too many 'z's

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
