### PR TITLE
Have entity's in the drawer use the id to save to prevent same names overwriting other entities on save

### DIFF
--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -61,7 +61,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
       };
       const currentEntities = [...(report?.fieldData[entityType] || {})];
       const selectedEntityIndex = report?.fieldData[entityType].findIndex(
-        (entity: EntityShape) => entity.name === selectedEntity?.name
+        (entity: EntityShape) => entity.id === selectedEntity?.id
       );
       const filteredFormData = filterFormData(
         enteredData,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
If you had a multiple plans of the same name then it would overwrite the data of the first one whenever you update the others specifically through the drawer. This fixes it to use the ID of the plan instead of the name of the plan.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Create a MCPAR
Create 2 plans of the same name
Go to the Grievances by Reason page and edit the second one
See that it doesn't submit data for the first one!

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---
