### PR TITLE
breaking vpn ip configuration to unique step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -226,7 +226,7 @@ jobs:
     needs: 
       - deploy
       - register-runner
-    if: ${{ always() && !cancelled() && needs.deploy.result == 'success' && github.ref_name != 'waf-fix-refactor' && github.ref_name != 'production' }}
+    if: ${{ always() && !cancelled() && needs.deploy.result == 'success' && github.ref_name != 'production' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -264,7 +264,7 @@ jobs:
     needs: 
       - deploy
       - register-runner
-    if: ${{ always() && !cancelled() && needs.deploy.result == 'success' && github.ref_name != 'waf-fix-refactor' && github.ref_name != 'production' }}
+    if: ${{ always() && !cancelled() && needs.deploy.result == 'success' && github.ref_name != 'production' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description
When the vpn restriction code was merged into mcr we noticed a few things 
1) the a11y tests and e2e both had a reliance on the registering of github ip's. The registering of IPs happened in e2e, there is a scenario where the ip's don't register in time and a11y tests fail because lack of access 
2) registering ip's to the ip set and delisting them from the ip set for environments that were not restricted by vpn originally was considered "fine to run" in those environments but we've seen issues specifically in val

This PR aims to fix the above issues by doing the following 
1) moving the registering of IPs out to its own unique step so that we can ensure downstream jobs have the requirement.
2) only running IP registering and ip cleanup steps only on ephemeral branches or branches that have vpn enabled 

In addition I've added some debug into the cleanup step for future debugging should issues arise similar to what we saw where IPs could not be cleaned up in val. 

When we merge this the expectation is that main, and val will no longer register IP's and run the cleanup step 
if/when we want to add ip restrictions we'll need to update the Serverless conditional as well as the if statements in both register and cleanup steps. 


### Related ticket(s)

---
### How to test
I wanted to ensure that we know what will happen in upper environments. I pushed a branch that created the waf and ipsets. The job ran through successfully including running the cleanup step that removes cidr blocks from the ipset after a successful run. 
I modified the code and added this branch (waf-fix-refactor) as part of the conditional to mirror that of an upper environment where we do not have vpn restriction but also want to run tests, and also do not need to run the cleanup step. see screenshots below ... note the register IP step and the cleanup steps are being skipped but tests are still running:

configuration:
![Screenshot 2024-03-07 at 6 10 57 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/52459927/40641c30-8df0-44bc-9175-225d486ca285)

results: 
![Screenshot 2024-03-07 at 6 14 28 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/52459927/67c0866f-c7fe-4a48-a2ee-c8e1ff09bc3d)

I then removed my branch from the branch restrictions to ensure that registering the ip's and cleanup runs successfully. See below.... note register ip and cleanup run when then conditional for this branch is removed:

configuration:
![Screenshot 2024-03-07 at 6 19 18 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/52459927/4e0c694c-4bed-4fd8-ad88-a72061a75867)

results:

![Screenshot 2024-03-07 at 7 02 17 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/52459927/da3be8b4-fb7e-40a5-ab1c-4902e6761bb4)




### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
