### PR TITLE
CMDCT-3173: Convert ReportProvider to Zustand

### DIFF
--- a/services/ui-src/src/components/app/AppRoutes.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.tsx
@@ -21,8 +21,8 @@ import { Fragment, useContext } from "react";
 import { Flex, Spinner } from "@chakra-ui/react";
 
 export const AppRoutes = () => {
-  const { userIsAdmin } = useStore().user ?? {};
-  const { report, contextIsLoaded } = useContext(ReportContext);
+  const { user: userIsAdmin, report } = useStore();
+  const { contextIsLoaded } = useContext(ReportContext);
 
   // LaunchDarkly
   const mlrReport = useFlags()?.mlrReport;

--- a/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
@@ -1,13 +1,11 @@
-import { useContext } from "react";
 // components
 import {
   Card,
   EntityCardBottomSection,
   EntityCardTopSection,
-  ReportContext,
 } from "components";
 import { Box, Button, Image, Text } from "@chakra-ui/react";
-// utils
+// types
 import { AnyObject, EntityShape, ModalDrawerEntityTypes } from "types";
 // assets
 import { svgFilters } from "styles/theme";
@@ -15,6 +13,8 @@ import completedIcon from "assets/icons/icon_check_circle.png";
 import deleteIcon from "assets/icons/icon_cancel_x_circle.png";
 import editIcon from "assets/icons/icon_edit.png";
 import unfinishedIcon from "assets/icons/icon_error_circle.png";
+// utils
+import { useStore } from "utils";
 
 export const EntityCard = ({
   entity,
@@ -28,7 +28,7 @@ export const EntityCard = ({
   printVersion,
   ...props
 }: Props) => {
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   let entityStarted = false;
   let entityCompleted = false;
   const reportingPeriodCompletedOrOptional =

--- a/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
@@ -1,11 +1,7 @@
-import { Fragment, useContext } from "react";
+import { Fragment } from "react";
 import uuid from "react-uuid";
 // components
-import {
-  ExportedSectionHeading,
-  ExportedEntityDetailsTable,
-  ReportContext,
-} from "components";
+import { ExportedSectionHeading, ExportedEntityDetailsTable } from "components";
 import { Box, Heading } from "@chakra-ui/react";
 // types
 import {
@@ -16,7 +12,7 @@ import {
   ReportType,
 } from "types";
 // utils
-import { assertExhaustive, getEntityDetailsMLR } from "utils";
+import { assertExhaustive, getEntityDetailsMLR, useStore } from "utils";
 // verbiage
 import mcparVerbiage from "../../verbiage/pages/mcpar/mcpar-export";
 import mlrVerbiage from "../../verbiage/pages/mlr/mlr-export";
@@ -31,7 +27,7 @@ export const ExportedEntityDetailsOverlaySection = ({
   section,
   ...props
 }: ExportedEntityDetailsOverlaySectionProps) => {
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   const entityType = section.entityType;
 
   return (

--- a/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
@@ -1,7 +1,7 @@
-import { ReactElement, useContext } from "react";
+import { ReactElement } from "react";
 // components
-import { ReportContext, Table } from "components";
-// types, utils
+import { Table, ExportedEntityDetailsTableRow } from "components";
+// types
 import {
   EntityShape,
   FieldChoice,
@@ -11,16 +11,17 @@ import {
   ReportType,
   isFieldElement,
 } from "types";
+// utils
+import { useStore } from "utils";
 // verbiage
 import verbiage from "verbiage/pages/mlr/mlr-export";
-import { ExportedEntityDetailsTableRow } from "./ExportedEntityDetailsTableRow";
 
 export const ExportedEntityDetailsTable = ({
   fields,
   entity,
   ...props
 }: Props) => {
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   const { tableHeaders } = verbiage;
 
   const entityType = "program";

--- a/services/ui-src/src/components/export/ExportedEntityDetailsTableRow.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTableRow.tsx
@@ -1,7 +1,5 @@
-import { useContext } from "react";
 // components
 import { Box, Tr, Td, Text } from "@chakra-ui/react";
-import { ReportContext } from "components";
 // types
 import { FormField, FormLayoutElement, isFieldElement } from "types";
 // utils
@@ -9,6 +7,7 @@ import {
   parseFormFieldInfo,
   parseCustomHtml,
   renderOverlayEntityDataCell,
+  useStore,
 } from "utils";
 
 export const ExportedEntityDetailsTableRow = ({
@@ -19,7 +18,7 @@ export const ExportedEntityDetailsTableRow = ({
   entityId,
   optional,
 }: Props) => {
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   const reportData = report?.fieldData;
   const isDynamicField = formField.type === "dynamic";
   const formFieldInfo = parseFormFieldInfo(formField?.props!);

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -1,9 +1,8 @@
-import { useContext } from "react";
 // components
 import { Box, Text } from "@chakra-ui/react";
-import { EntityCard, ReportContext } from "components";
+import { EntityCard } from "components";
 // utils
-import { getFormattedEntityData } from "utils";
+import { getFormattedEntityData, useStore } from "utils";
 import { EntityShape, ModalDrawerReportPageShape } from "types";
 // verbiage
 import exportVerbiage from "verbiage/pages/mcpar/mcpar-export";
@@ -11,7 +10,7 @@ import exportVerbiage from "verbiage/pages/mcpar/mcpar-export";
 export const ExportedModalDrawerReportSection = ({
   section: { entityType, verbiage },
 }: Props) => {
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   const { emptyEntityMessage } = exportVerbiage;
   const entities = report?.fieldData?.[entityType];
   const entityCount = entities?.length;

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -1,11 +1,10 @@
-import { useContext } from "react";
 // components
-import { EntityStatusIcon, ReportContext, Table } from "components";
+import { EntityStatusIcon, Table } from "components";
 import { Box, Image, Td, Text, Tr } from "@chakra-ui/react";
 // types
 import { EntityShape, ModalOverlayReportPageShape, ReportType } from "types";
 // utils
-import { assertExhaustive, getEntityDetailsMLR } from "utils";
+import { assertExhaustive, getEntityDetailsMLR, useStore } from "utils";
 // verbiage
 import mcparVerbiage from "../../verbiage/pages/mcpar/mcpar-export";
 import mlrVerbiage from "../../verbiage/pages/mlr/mlr-export";
@@ -20,7 +19,7 @@ const exportVerbiageMap: { [key in ReportType]: any } = {
 };
 
 export const ExportedModalOverlayReportSection = ({ section }: Props) => {
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   const entityType = section.entityType;
 
   const verbiage = exportVerbiageMap[report?.reportType as ReportType];

--- a/services/ui-src/src/components/export/ExportedReportBanner.tsx
+++ b/services/ui-src/src/components/export/ExportedReportBanner.tsx
@@ -5,12 +5,13 @@ import { Box, Button, Image, Text } from "@chakra-ui/react";
 // verbiage
 import mcparVerbiage from "verbiage/pages/mcpar/mcpar-export";
 import mlrVerbiage from "verbiage/pages/mlr/mlr-export";
-import { useContext } from "react";
-import { ReportContext } from "components";
+// utils
+import { useStore } from "utils";
+// types
 import { ReportType } from "types";
 
 export const ExportedReportBanner = () => {
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   const reportType = (report?.reportType ||
     localStorage.getItem("selectedReportType")) as ReportType;
 

--- a/services/ui-src/src/components/export/ExportedReportFieldRow.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldRow.tsx
@@ -1,11 +1,14 @@
-import { useContext } from "react";
 // components
 import { Box, Tr, Td, Text, Th } from "@chakra-ui/react";
-import { ReportContext } from "components";
 // types
 import { FormField, FormLayoutElement, isFieldElement } from "types";
 // utils
-import { parseFormFieldInfo, parseCustomHtml, renderDataCell } from "utils";
+import {
+  parseFormFieldInfo,
+  parseCustomHtml,
+  renderDataCell,
+  useStore,
+} from "utils";
 
 export const ExportedReportFieldRow = ({
   formField,
@@ -14,7 +17,7 @@ export const ExportedReportFieldRow = ({
   parentFieldCheckedChoiceIds,
   showHintText = true,
 }: Props) => {
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   const reportData = report?.fieldData;
   const isDynamicField = formField.type === "dynamic";
   const formFieldInfo = parseFormFieldInfo(formField?.props);

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
@@ -1,7 +1,7 @@
-import { ReactElement, useContext } from "react";
+import { ReactElement } from "react";
 // components
-import { ExportedReportFieldRow, ReportContext, Table } from "components";
-// types, utils
+import { ExportedReportFieldRow, Table } from "components";
+// types
 import {
   Choice,
   EntityShape,
@@ -16,9 +16,11 @@ import {
 } from "types";
 // verbiage
 import verbiage from "verbiage/pages/mcpar/mcpar-export";
+// utils
+import { useStore } from "utils";
 
 export const ExportedReportFieldTable = ({ section }: Props) => {
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   const { tableHeaders } = verbiage;
 
   const pageType = section.pageType;

--- a/services/ui-src/src/components/export/ExportedReportMetadataTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportMetadataTable.tsx
@@ -1,16 +1,15 @@
 // components
-import { ReportContext, Table } from "components";
-import { useContext } from "react";
-// utils
+import { Table } from "components";
+// types
 import { ReportShape, ReportType } from "types";
-import { convertDateUtcToEt } from "utils";
-import { assertExhaustive } from "utils/other/typing";
+// utils
+import { assertExhaustive, convertDateUtcToEt, useStore } from "utils";
 
 export const ExportedReportMetadataTable = ({
   reportType,
   verbiage,
 }: Props) => {
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   return (
     <Table
       data-testid="exportedReportMetadataTable"

--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -3,7 +3,7 @@ import { FieldValues, useFormContext, UseFormReturn } from "react-hook-form";
 // components
 import { ChoiceList as CmsdsChoiceList } from "@cmsgov/design-system";
 import { Box } from "@chakra-ui/react";
-import { ReportContext } from "components";
+import { ReportContext, EntityContext } from "components";
 // utils
 import {
   autosaveFieldData,
@@ -13,6 +13,7 @@ import {
   parseCustomHtml,
   useStore,
 } from "utils";
+// types
 import {
   AnyObject,
   AutosaveField,
@@ -22,7 +23,6 @@ import {
   FormField,
   InputChangeEvent,
 } from "types";
-import { EntityContext } from "components/reports/EntityProvider";
 
 export const ChoiceListField = ({
   name,
@@ -41,11 +41,15 @@ export const ChoiceListField = ({
   const defaultValue: Choice[] = [];
   const [displayValue, setDisplayValue] = useState<Choice[]>(defaultValue);
 
-  const { report, updateReport } = useContext(ReportContext);
+  const { updateReport } = useContext(ReportContext);
   const { entities, entityType, updateEntities, selectedEntity } =
     useContext(EntityContext);
+
+  // state management
   const { full_name, state, userIsAdmin, userIsReadOnly } =
     useStore().user ?? {};
+  const { report } = useStore();
+
   // get form context and register field
   const form = useFormContext();
   const fieldIsRegistered = name in form.getValues();

--- a/services/ui-src/src/components/fields/DateField.tsx
+++ b/services/ui-src/src/components/fields/DateField.tsx
@@ -3,8 +3,10 @@ import { useFormContext } from "react-hook-form";
 // components
 import { SingleInputDateField as CmsdsDateField } from "@cmsgov/design-system";
 import { Box } from "@chakra-ui/react";
-// utils
+import { ReportContext, EntityContext } from "components";
+// types
 import { AnyObject, CustomHtmlElement, InputChangeEvent } from "types";
+// utils
 import {
   autosaveFieldData,
   labelTextWithOptional,
@@ -13,8 +15,6 @@ import {
   useStore,
   getAutosaveFields,
 } from "utils";
-import { ReportContext } from "components";
-import { EntityContext } from "components/reports/EntityProvider";
 
 export const DateField = ({
   name,
@@ -29,9 +29,12 @@ export const DateField = ({
 }: Props) => {
   const defaultValue = "";
   const [displayValue, setDisplayValue] = useState<string>(defaultValue);
-  const { full_name, state } = useStore().user ?? {};
 
-  const { report, updateReport } = useContext(ReportContext);
+  // state management
+  const { full_name, state } = useStore().user ?? {};
+  const { report } = useStore();
+
+  const { updateReport } = useContext(ReportContext);
   const { entities, entityType, updateEntities, selectedEntity } =
     useContext(EntityContext);
 

--- a/services/ui-src/src/components/fields/DropdownField.tsx
+++ b/services/ui-src/src/components/fields/DropdownField.tsx
@@ -3,7 +3,7 @@ import { useFormContext } from "react-hook-form";
 // components
 import { Dropdown as CmsdsDropdown } from "@cmsgov/design-system";
 import { Box } from "@chakra-ui/react";
-import { ReportContext } from "components";
+import { ReportContext, EntityContext } from "components";
 // utils
 import {
   autosaveFieldData,
@@ -13,6 +13,7 @@ import {
   useStore,
   convertDateUtcToEt,
 } from "utils";
+// types
 import {
   AnyObject,
   DropdownChoice,
@@ -23,7 +24,6 @@ import {
   ReportMetadataShape,
 } from "types";
 import { dropdownDefaultOptionText, dropdownNoReports } from "../../constants";
-import { EntityContext } from "components/reports/EntityProvider";
 
 export const DropdownField = ({
   name,
@@ -37,11 +37,13 @@ export const DropdownField = ({
   styleAsOptional,
   ...props
 }: Props) => {
-  const { report, updateReport, copyEligibleReportsByState } =
-    useContext(ReportContext);
+  const { updateReport } = useContext(ReportContext);
   const { entities, entityType, updateEntities, selectedEntity } =
     useContext(EntityContext);
+
+  // state management
   const { full_name, state } = useStore().user ?? {};
+  const { report, copyEligibleReportsByState } = useStore();
 
   // fetch the option values and format them if necessary
   const formatOptions = (options: DropdownOptions[] | string) => {

--- a/services/ui-src/src/components/fields/DynamicField.tsx
+++ b/services/ui-src/src/components/fields/DynamicField.tsx
@@ -7,9 +7,10 @@ import {
   DeleteDynamicFieldRecordModal,
   ReportContext,
   TextField,
+  EntityContext,
 } from "components";
 import { svgFilters } from "styles/theme";
-// utils
+// types
 import {
   AnyObject,
   EntityShape,
@@ -17,14 +18,17 @@ import {
   InputChangeEvent,
   ReportStatus,
 } from "types";
+// utils
 import { autosaveFieldData, getAutosaveFields, useStore } from "utils";
 // assets
 import cancelIcon from "assets/icons/icon_cancel_x_circle.png";
-import { EntityContext } from "components/reports/EntityProvider";
 
 export const DynamicField = ({ name, label, ...props }: Props) => {
+  // state management
   const { full_name, state, userIsEndUser } = useStore().user ?? {};
-  const { report, updateReport } = useContext(ReportContext);
+  const { report } = useStore();
+
+  const { updateReport } = useContext(ReportContext);
   const { entities, entityType, updateEntities, selectedEntity } =
     useContext(EntityContext);
   const [displayValues, setDisplayValues] = useState<EntityShape[]>([]);

--- a/services/ui-src/src/components/fields/NumberField.tsx
+++ b/services/ui-src/src/components/fields/NumberField.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 // components
 import { Box } from "@chakra-ui/react";
-import { ReportContext } from "components";
+import { ReportContext, EntityContext } from "components";
 import { TextField as CmsdsTextField } from "@cmsgov/design-system";
 // utils
 import {
@@ -15,8 +15,8 @@ import {
   useStore,
   makeStringParseableForDatabase,
 } from "utils";
+// types
 import { InputChangeEvent, AnyObject } from "types";
-import { EntityContext } from "components/reports/EntityProvider";
 
 export const NumberField = ({
   name,
@@ -33,8 +33,11 @@ export const NumberField = ({
 }: Props) => {
   const defaultValue = "";
   const [displayValue, setDisplayValue] = useState(defaultValue);
+  // state management
   const { full_name, state } = useStore().user ?? {};
-  const { report, updateReport } = useContext(ReportContext);
+  const { report } = useStore();
+
+  const { updateReport } = useContext(ReportContext);
   const { entities, entityType, updateEntities, selectedEntity } =
     useContext(EntityContext);
 

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -3,7 +3,7 @@ import { useFormContext } from "react-hook-form";
 // components
 import { TextField as CmsdsTextField } from "@cmsgov/design-system";
 import { Box } from "@chakra-ui/react";
-import { ReportContext } from "components";
+import { ReportContext, EntityContext } from "components";
 // utils
 import {
   autosaveFieldData,
@@ -12,8 +12,8 @@ import {
   parseCustomHtml,
   useStore,
 } from "utils";
+// types
 import { InputChangeEvent, AnyObject, CustomHtmlElement } from "types";
-import { EntityContext } from "components/reports/EntityProvider";
 
 export const TextField = ({
   name,
@@ -29,8 +29,12 @@ export const TextField = ({
 }: Props) => {
   const defaultValue = "";
   const [displayValue, setDisplayValue] = useState<string>(defaultValue);
+
+  // state management
   const { full_name, state } = useStore().user ?? {};
-  const { report, updateReport } = useContext(ReportContext);
+  const { report } = useStore();
+
+  const { updateReport } = useContext(ReportContext);
   const { entities, entityType, selectedEntity, updateEntities } =
     useContext(EntityContext);
 

--- a/services/ui-src/src/components/forms/AdminDashSelector.tsx
+++ b/services/ui-src/src/components/forms/AdminDashSelector.tsx
@@ -1,9 +1,9 @@
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useFlags } from "launchdarkly-react-client-sdk";
 // components
 import { Box, Button, Flex, Heading } from "@chakra-ui/react";
-import { Form, ReportContext } from "components";
+import { Form } from "components";
 // types
 import { AnyObject, FormJson, InputChangeEvent } from "types";
 // form
@@ -12,11 +12,12 @@ import formJson from "forms/adminDashSelector/adminDashSelector";
 import { useStore } from "utils";
 
 export const AdminDashSelector = ({ verbiage }: Props) => {
-  const { reportsByState, clearReportsByState } = useContext(ReportContext);
   const navigate = useNavigate();
   const [reportSelected, setReportSelected] = useState<boolean>(false);
 
+  // state management
   const { userIsAdmin, userIsReadOnly } = useStore().user ?? {};
+  const { reportsByState, clearReportsByState } = useStore();
 
   // create radio options
   const reportChoices = [

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useContext, useEffect } from "react";
+import { ReactNode, useEffect } from "react";
 import {
   FieldValues,
   FormProvider,
@@ -19,6 +19,7 @@ import {
   sortFormErrors,
   useStore,
 } from "utils";
+// types
 import {
   AnyObject,
   FormJson,
@@ -27,7 +28,6 @@ import {
   FormLayoutElement,
   ReportStatus,
 } from "types";
-import { ReportContext } from "components/reports/ReportProvider";
 
 export const Form = ({
   id,
@@ -45,7 +45,8 @@ export const Form = ({
 
   // determine if fields should be disabled (based on admin roles )
   const { userIsAdmin, userIsReadOnly } = useStore().user ?? {};
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
+
   let location = useLocation();
   const fieldInputDisabled =
     ((userIsAdmin || userIsReadOnly) && !formJson.editableByAdmins) ||

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -45,6 +45,7 @@ export { ExportedReportMetadataTable } from "./export/ExportedReportMetadataTabl
 export { ExportedModalOverlayReportSection } from "./export/ExportedModalOverlayReportSection";
 export { ExportedEntityDetailsOverlaySection } from "./export/ExportedEntityDetailsOverlaySection";
 export { ExportedEntityDetailsTable } from "./export/ExportedEntityDetailsTable";
+export { ExportedEntityDetailsTableRow } from "./export/ExportedEntityDetailsTableRow";
 // fields
 export { CheckboxField } from "./fields/CheckboxField";
 export { ChoiceField } from "./fields/ChoiceField";

--- a/services/ui-src/src/components/layout/Header.tsx
+++ b/services/ui-src/src/components/layout/Header.tsx
@@ -13,7 +13,7 @@ import {
 } from "@chakra-ui/react";
 import { Menu, MenuOption, ReportContext } from "components";
 // utils
-import { useBreakpoint } from "utils";
+import { useBreakpoint, useStore } from "utils";
 // assets
 import appLogo from "assets/logos/logo_mcr.png";
 import getHelpIcon from "assets/icons/icon_help.png";
@@ -22,7 +22,10 @@ import closeIcon from "assets/icons/icon_cancel_x_circle.png";
 
 export const Header = ({ handleLogout }: Props) => {
   const { isMobile } = useBreakpoint();
-  const { lastSavedTime, report, isReportPage } = useContext(ReportContext);
+  const { isReportPage } = useContext(ReportContext);
+
+  // state management
+  const { lastSavedTime, report } = useStore();
 
   const saveStatusText = "Last saved " + lastSavedTime;
 

--- a/services/ui-src/src/components/menus/Sidebar.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect } from "react";
 import { Link as RouterLink, useLocation } from "react-router-dom";
 // components
 import {
@@ -10,9 +10,9 @@ import {
   Link,
   Text,
 } from "@chakra-ui/react";
-import { ReportContext, SkipNav } from "components";
+import { SkipNav } from "components";
 // utils
-import { useBreakpoint } from "utils";
+import { useBreakpoint, useStore } from "utils";
 // assets
 import arrowDownIcon from "assets/icons/icon_arrow_down_gray.png";
 import arrowUpIcon from "assets/icons/icon_arrow_up_gray.png";
@@ -30,7 +30,7 @@ interface SidebarProps {
 export const Sidebar = ({ isHidden }: SidebarProps) => {
   const { isDesktop } = useBreakpoint();
   const [isOpen, toggleSidebar] = useState(isDesktop);
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   const reportJson = report?.formTemplate;
 
   return (

--- a/services/ui-src/src/components/modals/AddEditEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.tsx
@@ -3,7 +3,7 @@ import uuid from "react-uuid";
 // components
 import { Form, Modal, ReportContext } from "components";
 import { Text, Spinner } from "@chakra-ui/react";
-// utils
+// types
 import {
   AnyObject,
   EntityShape,
@@ -11,6 +11,7 @@ import {
   isFieldElement,
   ReportStatus,
 } from "types";
+// utils
 import {
   entityWasUpdated,
   filterFormData,
@@ -26,8 +27,12 @@ export const AddEditEntityModal = ({
   selectedEntity,
   modalDisclosure,
 }: Props) => {
-  const { report, updateReport } = useContext(ReportContext);
+  const { updateReport } = useContext(ReportContext);
+
+  // state management
   const { full_name, userIsEndUser } = useStore().user ?? {};
+  const { report } = useStore();
+
   const [submitting, setSubmitting] = useState<boolean>(false);
 
   const writeEntity = async (enteredData: any) => {

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -7,7 +7,7 @@ import { Spinner } from "@chakra-ui/react";
 import mcparFormJson from "forms/addEditMcparReport/addEditMcparReport.json";
 import mcparFormJsonWithoutYoY from "forms/addEditMcparReport/addEditMcparReportWithoutYoY.json";
 import mlrFormJson from "forms/addEditMlrReport/addEditMlrReport.json";
-// utils
+// types
 import {
   AnyObject,
   FormField,
@@ -15,13 +15,14 @@ import {
   FormLayoutElement,
   ReportStatus,
 } from "types";
-import { States } from "../../constants";
+// utils
 import {
   calculateDueDate,
   convertDateEtToUtc,
   convertDateUtcToEt,
   useStore,
 } from "utils";
+import { States } from "../../constants";
 
 export const AddEditReportModal = ({
   activeState,
@@ -29,13 +30,13 @@ export const AddEditReportModal = ({
   reportType,
   modalDisclosure,
 }: Props) => {
-  const {
-    createReport,
-    fetchReportsByState,
-    updateReport,
-    copyEligibleReportsByState,
-  } = useContext(ReportContext);
+  const { createReport, fetchReportsByState, updateReport } =
+    useContext(ReportContext);
+
+  // state management
   const { full_name } = useStore().user ?? {};
+  const { copyEligibleReportsByState } = useStore();
+
   const [submitting, setSubmitting] = useState<boolean>(false);
   const yoyCopyFlag = useFlags()?.yoyCopy;
 

--- a/services/ui-src/src/components/modals/DeleteEntityModal.tsx
+++ b/services/ui-src/src/components/modals/DeleteEntityModal.tsx
@@ -1,9 +1,10 @@
+import { useContext, useState } from "react";
 // components
 import { Text } from "@chakra-ui/react";
 import { Modal, ReportContext } from "components";
-import { useContext, useState } from "react";
 // types
 import { AnyObject, EntityShape, ReportStatus } from "types";
+// utils
 import { useStore } from "utils";
 
 export const DeleteEntityModal = ({
@@ -12,8 +13,12 @@ export const DeleteEntityModal = ({
   verbiage,
   modalDisclosure,
 }: Props) => {
-  const { report, updateReport } = useContext(ReportContext);
+  const { updateReport } = useContext(ReportContext);
+
+  // state management
   const { full_name } = useStore().user ?? {};
+  const { report } = useStore();
+
   const [deleting, setDeleting] = useState<boolean>(false);
 
   const deleteProgramHandler = async () => {

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -22,8 +22,9 @@ import {
   PageTemplate,
   ReportContext,
 } from "components";
-// utils
+// types
 import { AnyObject, ReportMetadataShape, ReportKeys, ReportShape } from "types";
+// utils
 import {
   convertDateUtcToEt,
   parseCustomHtml,
@@ -43,19 +44,22 @@ export const DashboardPage = ({ reportType }: Props) => {
     errorMessage,
     fetchReportsByState,
     fetchReport,
-    reportsByState,
     clearReportSelection,
     setReportSelection,
     archiveReport,
     releaseReport,
   } = useContext(ReportContext);
   const navigate = useNavigate();
+
+  // state management
   const {
     state: userState,
     userIsEndUser,
     userIsAdmin,
     userIsReadOnly,
   } = useStore().user ?? {};
+  const { reportsByState } = useStore();
+
   const { isTablet, isMobile } = useBreakpoint();
   const [reportsToDisplay, setReportsToDisplay] = useState<
     ReportMetadataShape[] | undefined

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -1,4 +1,3 @@
-import { useContext } from "react";
 import { Helmet } from "react-helmet";
 // components
 import { Box, Center, Heading, Text, Tr, Td, Spinner } from "@chakra-ui/react";
@@ -6,7 +5,6 @@ import {
   ExportedReportMetadataTable,
   ExportedReportWrapper,
   ExportedSectionHeading,
-  ReportContext,
   Table,
 } from "components";
 // types
@@ -18,13 +16,13 @@ import {
   ReportType,
 } from "types";
 // utils
-import { assertExhaustive } from "utils/other/typing";
+import { assertExhaustive, useStore } from "utils";
 // verbiage
 import mcparVerbiage from "verbiage/pages/mcpar/mcpar-export";
 import mlrVerbiage from "verbiage/pages/mlr/mlr-export";
 
 export const ExportedReportPage = () => {
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   const routesToRender = report?.formTemplate.routes.filter(
     (route: ReportRoute) => route
   );

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -24,7 +24,7 @@ import iconSearchDefault from "assets/icons/icon_search_blue.png";
 import iconSearchSubmitted from "assets/icons/icon_search_white.png";
 
 export const ReviewSubmitPage = () => {
-  const { report, fetchReport, submitReport } = useContext(ReportContext);
+  const { fetchReport, submitReport } = useContext(ReportContext);
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const [submitting, setSubmitting] = useState<boolean>(false);
@@ -34,6 +34,7 @@ export const ReviewSubmitPage = () => {
 
   // get user information
   const { state, userIsEndUser } = useStore().user ?? {};
+  const { report } = useStore();
 
   // get report type, state, and id from context or storage
   const reportType =
@@ -121,7 +122,7 @@ export const ReviewSubmitPage = () => {
 
 const PrintButton = ({ reviewVerbiage }: { reviewVerbiage: AnyObject }) => {
   const { print } = reviewVerbiage;
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   const reportType = report?.reportType === "MLR" ? "mlr" : "mcpar";
   const isSubmitted = report?.status === "Submitted";
   return (

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -23,6 +23,7 @@ import {
   setClearedEntriesToDefaultValue,
   useStore,
 } from "utils";
+// types
 import {
   AnyObject,
   EntityShape,
@@ -31,13 +32,18 @@ import {
   FormField,
   isFieldElement,
 } from "types";
+// assets
 import completedIcon from "assets/icons/icon_check_circle.png";
 
 export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
   const [submitting, setSubmitting] = useState<boolean>(false);
   const { isOpen, onClose, onOpen } = useDisclosure();
-  const { report, updateReport } = useContext(ReportContext);
+  const { updateReport } = useContext(ReportContext);
+
+  // state management
   const { full_name, state, userIsEndUser } = useStore().user ?? {};
+  const { report } = useStore();
+
   // make state
   const [selectedEntity, setSelectedEntity] = useState<EntityShape | undefined>(
     undefined

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -33,7 +33,9 @@ import {
 } from "types";
 
 export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
+  // state management
   const { full_name, state, userIsEndUser } = useStore().user ?? {};
+  const { report } = useStore();
   const { entityType, verbiage, modalForm, drawerForm: drawerFormJson } = route;
 
   const [submitting, setSubmitting] = useState<boolean>(false);
@@ -41,7 +43,7 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
     undefined
   );
 
-  const { report, updateReport } = useContext(ReportContext);
+  const { updateReport } = useContext(ReportContext);
   const reportFieldDataEntities = report?.fieldData[entityType] || [];
 
   // create drawerForm from json with repeated fields

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -45,15 +45,18 @@ export const ModalOverlayReportPage = ({
 
   // Context Information
   const { isTablet, isMobile } = useBreakpoint();
-  const { report, updateReport } = useContext(ReportContext);
+  const { updateReport } = useContext(ReportContext);
   const [isEntityDetailsOpen, setIsEntityDetailsOpen] = useState<boolean>();
   const [currentEntity, setCurrentEntity] = useState<EntityShape | undefined>(
     undefined
   );
   const [entering, setEntering] = useState<boolean>(false);
   const [submitting, setSubmitting] = useState<boolean>(false);
+
+  // state management
   const { userIsAdmin, userIsReadOnly, userIsEndUser, full_name, state } =
     useStore().user ?? {};
+  const { report } = useStore();
 
   // Determine whether form is locked or unlocked based on user and route
   const isAdminUserType = userIsAdmin || userIsReadOnly;

--- a/services/ui-src/src/components/reports/ReportPageFooter.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.tsx
@@ -1,8 +1,6 @@
-import { useContext } from "react";
 import { useNavigate } from "react-router-dom";
 // components
 import { Box, Button, Flex, Image, Spinner } from "@chakra-ui/react";
-import { ReportContext } from "components";
 // utils
 import { parseCustomHtml, useFindRoute, useStore } from "utils";
 import { FormJson } from "types";
@@ -12,7 +10,7 @@ import previousIcon from "assets/icons/icon_previous_blue.png";
 
 export const ReportPageFooter = ({ submitting, form, ...props }: Props) => {
   const navigate = useNavigate();
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   const { previousRoute, nextRoute } = useFindRoute(
     report?.formTemplate.flatRoutes,
     report?.formTemplate.basePath

--- a/services/ui-src/src/components/reports/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/reports/ReportPageWrapper.tsx
@@ -1,9 +1,8 @@
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 // components
 import { Flex, Spinner } from "@chakra-ui/react";
 import {
-  ReportContext,
   ReviewSubmitPage,
   ModalDrawerReportPage,
   DrawerReportPage,
@@ -25,8 +24,7 @@ import {
 } from "types";
 
 export const ReportPageWrapper = () => {
-  const { state } = useStore().user ?? {};
-  const { report } = useContext(ReportContext);
+  const { user: state, report } = useStore();
   const [sidebarHidden, setSidebarHidden] = useState<boolean>(false);
   const navigate = useNavigate();
   const { pathname } = useLocation();

--- a/services/ui-src/src/components/reports/ReportProvider.test.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 // components
 import { ReportContext, ReportProvider } from "./ReportProvider";
+// utils
 import {
   mockReportKeys,
   mockMcparReport,

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -14,19 +14,13 @@ import {
   sortReportsOldestToNewest,
   useStore,
 } from "utils";
-import {
-  ReportKeys,
-  ReportContextShape,
-  ReportShape,
-  ReportMetadataShape,
-} from "types";
+import { ReportKeys, ReportContextShape, ReportShape } from "types";
 import { reportErrors } from "verbiage/errors";
 
 // CONTEXT DECLARATION
 
 export const ReportContext = createContext<ReportContextShape>({
   // report
-  report: undefined as ReportShape | undefined,
   contextIsLoaded: false as boolean,
   archiveReport: Function,
   releaseReport: Function,
@@ -35,8 +29,6 @@ export const ReportContext = createContext<ReportContextShape>({
   updateReport: Function,
   submitReport: Function,
   // reports by state
-  reportsByState: undefined as ReportMetadataShape[] | undefined,
-  copyEligibleReportsByState: undefined as ReportMetadataShape[] | undefined,
   fetchReportsByState: Function,
   // selected report
   clearReportSelection: Function,
@@ -44,27 +36,27 @@ export const ReportContext = createContext<ReportContextShape>({
   setReportSelection: Function,
   isReportPage: false as boolean,
   errorMessage: undefined as string | undefined,
-  lastSavedTime: undefined as string | undefined,
 });
 
 export const ReportProvider = ({ children }: Props) => {
   const { pathname } = useLocation();
-  const { state: userState } = useStore().user ?? {};
-  const [lastSavedTime, setLastSavedTime] = useState<string>();
   const [error, setError] = useState<string>();
   const [contextIsLoaded, setContextIsLoaded] = useState<boolean>(false);
   const [isReportPage, setIsReportPage] = useState<boolean>(false);
 
-  // REPORT
-
-  const [report, setReport] = useState<ReportShape | undefined>();
-  const [reportsByState, setReportsByState] = useState<
-    ReportShape[] | undefined
-  >();
-
-  const [copyEligibleReportsByState, setCopyEligibleReportsByState] = useState<
-    ReportShape[] | undefined
-  >();
+  // state management
+  const {
+    report,
+    reportsByState,
+    copyEligibleReportsByState,
+    lastSavedTime,
+    setReport,
+    setReportsByState,
+    clearReportsByState,
+    setCopyEligibleReportsByState,
+    setLastSavedTime,
+  } = useStore();
+  const { state: userState } = useStore().user ?? {};
 
   const hydrateAndSetReport = (report: ReportShape | undefined) => {
     if (report) {
@@ -160,10 +152,6 @@ export const ReportProvider = ({ children }: Props) => {
     localStorage.setItem("selectedReport", "");
   };
 
-  const clearReportsByState = () => {
-    setReportsByState(undefined);
-  };
-
   const setReportSelection = async (report: ReportShape) => {
     hydrateAndSetReport(report);
     localStorage.setItem("selectedReportType", report.reportType);
@@ -204,9 +192,10 @@ export const ReportProvider = ({ children }: Props) => {
 
   const providerValue = useMemo(
     () => ({
+      // context
+      contextIsLoaded,
       // report
       report,
-      contextIsLoaded,
       archiveReport,
       releaseReport,
       fetchReport,
@@ -221,6 +210,7 @@ export const ReportProvider = ({ children }: Props) => {
       clearReportSelection,
       clearReportsByState,
       setReportSelection,
+      // other
       isReportPage,
       errorMessage: error,
       lastSavedTime,

--- a/services/ui-src/src/components/reports/StandardReportPage.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.tsx
@@ -10,6 +10,7 @@ import {
 } from "components";
 // utils
 import { filterFormData, useFindRoute, useStore } from "utils";
+// types
 import {
   AnyObject,
   isFieldElement,
@@ -19,8 +20,11 @@ import {
 
 export const StandardReportPage = ({ route, validateOnRender }: Props) => {
   const [submitting, setSubmitting] = useState<boolean>(false);
-  const { report, updateReport } = useContext(ReportContext);
+  const { updateReport } = useContext(ReportContext);
+  // state management
   const { full_name, state } = useStore().user ?? {};
+  const { report } = useStore();
+
   const navigate = useNavigate();
   const { nextRoute } = useFindRoute(
     report!.formTemplate.flatRoutes!,

--- a/services/ui-src/src/components/statusing/StatusTable.tsx
+++ b/services/ui-src/src/components/statusing/StatusTable.tsx
@@ -1,22 +1,26 @@
-import { Fragment, useContext } from "react";
+import { Fragment } from "react";
 import { useNavigate } from "react-router-dom";
 // components
 import { Box, Button, Flex, Image, Td, Text, Tr } from "@chakra-ui/react";
-import { ReportContext, Table } from "components";
+import { Table } from "components";
 // types
 import { ReportPageProgress, ReportType } from "types";
 // utils
-import { getRouteStatus, useBreakpoint } from "utils";
+import {
+  assertExhaustive,
+  getRouteStatus,
+  useBreakpoint,
+  useStore,
+} from "utils";
 // verbiage
 import verbiage from "verbiage/pages/mcpar/mcpar-review-and-submit";
 // assets
 import editIcon from "assets/icons/icon_edit.png";
 import errorIcon from "assets/icons/icon_error_circle_bright.png";
 import successIcon from "assets/icons/icon_check_circle.png";
-import { assertExhaustive } from "utils/other/typing";
 
 export const StatusTable = () => {
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   const { review } = verbiage;
   const rowDepth = 1;
   return report ? (
@@ -97,7 +101,7 @@ const TableRow = ({ page, depth }: RowProps) => {
   const { isMobile } = useBreakpoint();
   const { name, path, children, status } = page;
   const buttonAriaLabel = `Edit  ${name}`;
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   return (
     <Tr>
       {depth == 1 ? (

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -1,15 +1,13 @@
+import { useMemo } from "react";
 // components
 import { Button, Flex, Image, Spinner, Td, Text, Tr } from "@chakra-ui/react";
 import { EntityStatusIcon } from "components";
 // types
 import { AnyObject, EntityShape } from "types";
 // utils
-import { eligibilityGroup, useStore } from "utils";
+import { eligibilityGroup, getMlrEntityStatus, useStore } from "utils";
 // assets
 import deleteIcon from "assets/icons/icon_cancel_x_circle.png";
-import { useContext, useMemo } from "react";
-import { ReportContext } from "components/reports/ReportProvider";
-import { getMlrEntityStatus } from "utils/tables/getMlrEntityStatus";
 
 export const EntityRow = ({
   entity,
@@ -21,7 +19,7 @@ export const EntityRow = ({
   openEntityDetailsOverlay,
 }: Props) => {
   const { report_programName, report_planName } = entity;
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   const { userIsEndUser } = useStore().user ?? {};
   const reportingPeriod = `${entity.report_reportingPeriodStartDate} to ${entity.report_reportingPeriodEndDate}`;
 

--- a/services/ui-src/src/components/tables/EntityStatusIcon.tsx
+++ b/services/ui-src/src/components/tables/EntityStatusIcon.tsx
@@ -1,18 +1,18 @@
+import { useMemo } from "react";
 // components
 import { Box, Image, Text } from "@chakra-ui/react";
-// utils
+// types
 import { EntityShape } from "types";
 // assets
 import unfinishedIcon from "assets/icons/icon_error_circle_bright.png";
 import unfinishedIconDark from "assets/icons/icon_error_circle.png";
 import successIcon from "assets/icons/icon_check_circle.png";
 import successIconDark from "assets/icons/icon_check_circle_dark.png";
-import { useContext, useMemo } from "react";
-import { ReportContext } from "components/reports/ReportProvider";
-import { getMlrEntityStatus } from "utils/tables/getMlrEntityStatus";
+// utils
+import { getMlrEntityStatus, useStore } from "utils";
 
 export const EntityStatusIcon = ({ entity, isPdf }: Props) => {
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
 
   const entityComplete = useMemo(() => {
     return report ? getMlrEntityStatus(report, entity) : false;

--- a/services/ui-src/src/components/tables/MobileEntityRow.tsx
+++ b/services/ui-src/src/components/tables/MobileEntityRow.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 // components
 import {
   Box,
@@ -13,12 +14,14 @@ import { EntityStatusIcon } from "components";
 // types
 import { AnyObject, EntityShape } from "types";
 // utils
-import { eligibilityGroup, parseCustomHtml, useStore } from "utils";
+import {
+  eligibilityGroup,
+  getMlrEntityStatus,
+  parseCustomHtml,
+  useStore,
+} from "utils";
 // assets
 import deleteIcon from "assets/icons/icon_cancel_x_circle.png";
-import { useContext, useMemo } from "react";
-import { ReportContext } from "components/reports/ReportProvider";
-import { getMlrEntityStatus } from "utils/tables/getMlrEntityStatus";
 
 export const MobileEntityRow = ({
   entity,
@@ -30,7 +33,7 @@ export const MobileEntityRow = ({
   openEntityDetailsOverlay,
 }: Props) => {
   const { editEntityButtonText, enterReportText, tableHeader } = verbiage;
-  const { report } = useContext(ReportContext);
+  const { report } = useStore();
   const reportingPeriod = `${entity.report_reportingPeriodStartDate} to ${entity.report_reportingPeriodEndDate}`;
 
   const { report_programName, report_planName } = entity;

--- a/services/ui-src/src/types/reportContext.ts
+++ b/services/ui-src/src/types/reportContext.ts
@@ -57,12 +57,8 @@ export interface ReportContextMethods {
 }
 
 export interface ReportContextShape extends ReportContextMethods {
-  report: ReportShape | undefined;
   contextIsLoaded: boolean;
-  reportsByState: ReportMetadataShape[] | undefined;
-  copyEligibleReportsByState: ReportMetadataShape[] | undefined;
   errorMessage?: string | undefined;
-  lastSavedTime?: string | undefined;
   isReportPage: boolean;
 }
 

--- a/services/ui-src/src/types/states.ts
+++ b/services/ui-src/src/types/states.ts
@@ -1,4 +1,9 @@
-import { AdminBannerData, MCRUser } from "types";
+import {
+  AdminBannerData,
+  MCRUser,
+  ReportMetadataShape,
+  ReportShape,
+} from "types";
 
 // initial user state
 export interface McrUserState {
@@ -25,4 +30,23 @@ export interface AdminBannerState {
   setBannerLoading: (bannerLoading: boolean) => void;
   setBannerErrorMessage: (bannerErrorMessage: string) => void;
   setBannerDeleting: (bannerDeleting: boolean) => void;
+}
+
+// initial report state
+export interface McrReportState {
+  // INITIAL STATE
+  report: ReportShape | undefined;
+  reportsByState: ReportMetadataShape[] | undefined;
+  copyEligibleReportsByState: ReportMetadataShape[] | undefined;
+  lastSavedTime: string | undefined;
+  // ACTIONS
+  setReport: (newReport: ReportShape | undefined) => void;
+  setReportsByState: (
+    newReportsByState: ReportMetadataShape[] | undefined
+  ) => void;
+  clearReportsByState: () => void;
+  setCopyEligibleReportsByState: (
+    newCopyEligibleReportsByState: ReportMetadataShape[] | undefined
+  ) => void;
+  setLastSavedTime: (lastSavedTime: string | undefined) => void;
 }

--- a/services/ui-src/src/utils/index.ts
+++ b/services/ui-src/src/utils/index.ts
@@ -17,6 +17,8 @@ export * from "./reports/reports";
 export * from "./reports/routing";
 // statusing
 export * from "./statusing/getRouteStatus";
+// tables
+export * from "./tables/getMlrEntityStatus";
 // tracking
 export * from "./tracking/tealium";
 // validation

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -4,8 +4,11 @@ import { devtools, persist } from "zustand/middleware";
 import {
   AdminBannerData,
   AdminBannerState,
+  McrReportState,
   MCRUser,
   McrUserState,
+  ReportMetadataShape,
+  ReportShape,
 } from "types";
 
 // USER STORE
@@ -53,12 +56,45 @@ const bannerStore = (set: Function) => ({
     }),
 });
 
+// REPORT STORE
+const reportStore = (set: Function) => ({
+  // initial state
+  report: undefined,
+  reportsByState: undefined,
+  copyEligibleReportsByState: undefined,
+  lastSavedTime: undefined,
+  // actions
+  setReport: (newReport: ReportShape | undefined) =>
+    set(() => ({ report: newReport }), false, { type: "setReport" }),
+  setReportsByState: (newReportsByState: ReportMetadataShape[] | undefined) =>
+    set(() => ({ reportsByState: newReportsByState }), false, {
+      type: "setReportsByState",
+    }),
+  clearReportsByState: () =>
+    set(() => ({ reportsByState: undefined }), false, {
+      type: "clearReportsByState",
+    }),
+  setCopyEligibleReportsByState: (
+    newCopyEligibleReportsByState: ReportMetadataShape[] | undefined
+  ) =>
+    set(
+      () => ({ copyEligibleReportsByState: newCopyEligibleReportsByState }),
+      false,
+      { type: "setCopyEligibleReportsByState" }
+    ),
+  setLastSavedTime: (lastSavedTime: string | undefined) =>
+    set(() => ({ lastSavedTime: lastSavedTime }), false, {
+      type: "setLastSavedTime",
+    }),
+});
+
 export const useStore = create(
   // persist and devtools are being used for debugging state
   persist(
-    devtools<McrUserState & AdminBannerState>((set) => ({
+    devtools<McrUserState & AdminBannerState & McrReportState>((set) => ({
       ...userStore(set),
       ...bannerStore(set),
+      ...reportStore(set),
     })),
     {
       name: "mcr-store",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Converting the `ReportProvider` from `useContext` to `useStore`

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3173

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
All of the report-related actions should work as expected. If you've got Redux DevTools installed, you can verify that the states are updating correctly.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
