### PR TITLE
MDCT-3297 Selected States Dropdown BugFix

### DIFF
--- a/services/ui-src/src/utils/auth/UserProvider.tsx
+++ b/services/ui-src/src/utils/auth/UserProvider.tsx
@@ -36,14 +36,21 @@ export const UserProvider = ({ children }: Props) => {
   // state management
   const { user, showLocalLogins, setUser, setShowLocalLogins } = useStore();
 
+  // Clear selectedReport from localStorage when logging out of report.
+  const clearSelectedReportCache = () => {
+    const selectReportCacheExists = localStorage.getItem("selectedReportType");
+    selectReportCacheExists && localStorage.removeItem("selectedReportType");
+  };
+
   // initialize the authentication manager that oversees timeouts
   initAuthManager();
 
   const logout = useCallback(async () => {
     try {
       setUser(undefined);
-      localStorage.clear();
+      clearSelectedReportCache();
       await Auth.signOut();
+      localStorage.clear();
     } catch (error) {
       console.log(error); // eslint-disable-line no-console
     }

--- a/services/ui-src/src/utils/auth/UserProvider.tsx
+++ b/services/ui-src/src/utils/auth/UserProvider.tsx
@@ -42,8 +42,8 @@ export const UserProvider = ({ children }: Props) => {
   const logout = useCallback(async () => {
     try {
       setUser(undefined);
-      await Auth.signOut();
       localStorage.clear();
+      await Auth.signOut();
     } catch (error) {
       console.log(error); // eslint-disable-line no-console
     }


### PR DESCRIPTION
### Description

For admin and internal users - the landing page "Select states" dropdown is greyed out in certain conditions. This issue seems to only occur in Prod.

If you enter a report there's a `selectedReport` value stored in localStorage. When you logout without leaving the report that value seems to still be there when the user logs back in. The dropdown seems to work when removing that value. 

I added a method to just remove the `selectedReport` value to try and avoid regression conflicts. 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-https://jiraent.cms.gov/browse/CMDCT-3297

---
### How to test
This issue has only been found on Prod as a admin or internal user.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
