### PR TITLE
Remove unnecessary step which breaks job

### DIFF
--- a/.github/workflows/snyk-auto-merge.yml
+++ b/.github/workflows/snyk-auto-merge.yml
@@ -13,10 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'mdct-github-service-account' }}
     steps:
-      - name: Snyk Gather Metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v1
-      - name: Approve a PR
+      - name: Auto-approve Snyk PR
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
### Description
[Fixes an existing problem related to this work
](https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/11626)


<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
