### PR TITLE
Remove spreadsheet widget from PDF

### DIFF
--- a/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
@@ -38,14 +38,12 @@ export const ExportedEntityDetailsOverlaySection = ({
     <Box sx={sx.sectionHeading} {...props}>
       <ExportedSectionHeading
         heading={exportVerbiageMap[report?.reportType as ReportType]}
-        reportType={report?.reportType}
         verbiage={{
           ...section.verbiage,
           intro: {
             ...section.verbiage.intro,
             info: undefined,
             exportSectionHeader: undefined,
-            spreadsheet: "MLR Reporting",
           },
         }}
       />

--- a/services/ui-src/src/components/export/ExportedSectionHeading.test.tsx
+++ b/services/ui-src/src/components/export/ExportedSectionHeading.test.tsx
@@ -1,12 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 // components
-import { ReportContext, ExportedSectionHeading } from "components";
+import { ExportedSectionHeading } from "components";
 // utils
-import {
-  mockMcparReportContext,
-  mockVerbiageIntro,
-} from "utils/testing/setupJest";
+import { mockVerbiageIntro } from "utils/testing/setupJest";
 
 const mockSectionHeading = {
   heading: "mock-heading",
@@ -17,9 +14,7 @@ const mockSectionHeading = {
 const { heading, verbiage } = mockSectionHeading;
 
 const exportedReportSectionHeadingComponent = (
-  <ReportContext.Provider value={mockMcparReportContext}>
-    <ExportedSectionHeading heading={heading} verbiage={verbiage} />
-  </ReportContext.Provider>
+  <ExportedSectionHeading heading={heading} verbiage={verbiage} />
 );
 
 describe("ExportedSectionHeading renders", () => {

--- a/services/ui-src/src/components/export/ExportedSectionHeading.tsx
+++ b/services/ui-src/src/components/export/ExportedSectionHeading.tsx
@@ -1,21 +1,15 @@
 // components
 import { Box, Heading, Text } from "@chakra-ui/react";
-import { SpreadsheetWidget } from "components";
 // types
 import { ReportPageVerbiage } from "types";
 // utils
 import { parseCustomHtml } from "utils";
 
-export const ExportedSectionHeading = ({
-  heading,
-  reportType,
-  verbiage,
-}: Props) => {
+export const ExportedSectionHeading = ({ heading, verbiage }: Props) => {
   const sectionSubHeader = verbiage?.intro?.subsection || heading;
   const sectionInfo = verbiage?.intro?.exportSectionHeader
     ? null
     : verbiage?.intro?.info;
-  const sectionSpreadsheet = verbiage?.intro?.spreadsheet;
 
   const introHeaderRender = () => {
     const infoHeader: any = verbiage?.intro?.info && verbiage?.intro?.info[0];
@@ -47,15 +41,6 @@ export const ExportedSectionHeading = ({
             </Text>
           </Box>
         )}
-        {sectionSpreadsheet && (
-          <Box sx={sx.spreadsheet}>
-            <SpreadsheetWidget
-              description={sectionSpreadsheet}
-              isPdf={true}
-              reportType={reportType}
-            />
-          </Box>
-        )}
       </Box>
     </>
   );
@@ -63,7 +48,6 @@ export const ExportedSectionHeading = ({
 
 export interface Props {
   heading: string;
-  reportType?: string;
   verbiage?: ReportPageVerbiage;
 }
 
@@ -96,12 +80,6 @@ const sx = {
     },
     h4: {
       fontSize: "lg",
-    },
-  },
-  spreadsheet: {
-    margin: "1.5rem 0",
-    "@media print": {
-      pageBreakAfter: "avoid",
     },
   },
 };

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -82,7 +82,7 @@ export const ExportedReportPage = () => {
             </Table>
           )}
           {/* report sections */}
-          {renderReportSections(report.formTemplate.routes, report.reportType)}
+          {renderReportSections(report.formTemplate.routes)}
         </Box>
       )) || (
         <Center>
@@ -112,10 +112,7 @@ export const reportTitle = (
   }
 };
 
-export const renderReportSections = (
-  reportRoutes: ReportRoute[],
-  reportType: string
-) => {
+export const renderReportSections = (reportRoutes: ReportRoute[]) => {
   // recursively render sections
   const renderSection = (section: ReportRoute) => {
     const childSections = section?.children;
@@ -128,7 +125,6 @@ export const renderReportSections = (
           <Box>
             <ExportedSectionHeading
               heading={section.verbiage?.intro?.subsection || section.name}
-              reportType={reportType}
               verbiage={section.verbiage || undefined}
             />
             <ExportedReportWrapper section={section as ReportRouteWithForm} />


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Remove the excel spreadsheet widget from the PDF view.

These widgets weren't showing up in the accessibility tag tree so screen readers didn't announce them. We decided to remove them entirely from the PDFs.

Feedback: I think I cleaned up all the relevant code but let me know if you see something hanging! We still need the spreadsheet widget logic elsewhere for regular report pages.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3434

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deployed url: https://d2j9bh3ozajjoy.cloudfront.net/

- Log in as a state user
- Create a MCPAR report
- Go to "Review and Submit" and view the PDF
- Verify that the excel widget does not show up
- Compare to main or to the regular report, where it appears at the top of every page.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---