### PR TITLE
CMDCT-3436: Render Links as Plain Text in MCPAR PDF

### DIFF
--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -1,4 +1,4 @@
-import { Box, Link, Text } from "@chakra-ui/react";
+import { Box, Text } from "@chakra-ui/react";
 // types
 import { AnyObject, Choice, EntityShape, FieldChoice, FormField } from "types";
 // utils
@@ -150,9 +150,6 @@ export const renderResponseData = (
       entityIndex!
     );
   }
-  // check for and handle link fields (email, url)
-  const { isLink, isEmail } = checkLinkTypes(formField);
-  if (isLink) return renderLinkFieldResponse(fieldResponseData, isEmail);
   // handle all other field types
   return renderDefaultFieldResponse(formField, fieldResponseData);
 };
@@ -191,15 +188,6 @@ export const renderChoiceListFieldResponse = (
   });
   return choicesToDisplay;
 };
-
-export const renderLinkFieldResponse = (
-  fieldResponseData: AnyObject,
-  isEmail: boolean
-) => (
-  <Link href={(isEmail ? "mailto:" : "") + fieldResponseData} target="_blank">
-    {fieldResponseData}
-  </Link>
-);
 
 export const renderDefaultFieldResponse = (
   formField: FormField,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Links rendered in the MCPAR and MLR PDFs are causing accessibility issues as they're showing up untagged, so it has been decided to remove the links themselves and simply render them as plain text.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3436

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Verify that links are rendering as text on export.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
