### PR TITLE
Fix optional text on PDF

### DIFF
--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -67,6 +67,7 @@ export const renderOverlayEntityDataCell = (
   const notApplicable =
     parentFieldCheckedChoiceIds &&
     !parentFieldCheckedChoiceIds?.includes(entity.id);
+
   return (
     <Box>
       <Text>
@@ -136,7 +137,7 @@ export const renderResponseData = (
     : fieldResponseData;
   const missingEntryVerbiage = notApplicable
     ? verbiage.missingEntry.notApplicable
-    : verbiage.missingEntry.noResponse;
+    : `${verbiage.missingEntry.noResponse}, optional`;
   const missingEntryStyle = notApplicable ? sx.notApplicable : sx.noResponse;
   if (!hasResponse)
     return <Text sx={missingEntryStyle}>{missingEntryVerbiage}</Text>;
@@ -282,7 +283,7 @@ const sx = {
     fontWeight: "bold",
   },
   noResponse: {
-    color: "palette.error_darker",
+    color: "palette.base",
   },
   notApplicable: {
     color: "palette.gray_medium",

--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -67,7 +67,6 @@ export const renderOverlayEntityDataCell = (
   const notApplicable =
     parentFieldCheckedChoiceIds &&
     !parentFieldCheckedChoiceIds?.includes(entity.id);
-
   return (
     <Box>
       <Text>
@@ -137,12 +136,23 @@ export const renderResponseData = (
     : fieldResponseData;
   const missingEntryVerbiage = notApplicable
     ? verbiage.missingEntry.notApplicable
-    : `${verbiage.missingEntry.noResponse}, optional`;
-  const missingEntryStyle = notApplicable
-    ? sx.notApplicable
-    : sx.noResponseOptional;
-  if (!hasResponse)
+    : verbiage.missingEntry.noResponse;
+
+  const missingEntryStyle = notApplicable ? sx.notApplicable : sx.noResponse;
+
+  if (!hasResponse && !isChoiceListField) {
     return <Text sx={missingEntryStyle}>{missingEntryVerbiage}</Text>;
+    // need to explicitly make this else if conditional so
+  }
+
+  if (!hasResponse && isChoiceListField) {
+    return (
+      <Text
+        sx={sx.noResponseOptional}
+      >{`${verbiage.missingEntry.noResponse}, optional`}</Text>
+    );
+  }
+
   // chandle choice list fields (checkbox, radio)
   if (isChoiceListField) {
     return renderChoiceListFieldResponse(
@@ -287,10 +297,10 @@ const sx = {
   noResponse: {
     color: "palette.error_darker",
   },
-  notApplicable: {
-    color: "palette.gray_medium",
-  },
   noResponseOptional: {
     color: "palette.base",
+  },
+  notApplicable: {
+    color: "palette.gray_medium",
   },
 };

--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -138,7 +138,9 @@ export const renderResponseData = (
   const missingEntryVerbiage = notApplicable
     ? verbiage.missingEntry.notApplicable
     : `${verbiage.missingEntry.noResponse}, optional`;
-  const missingEntryStyle = notApplicable ? sx.notApplicable : sx.noResponse;
+  const missingEntryStyle = notApplicable
+    ? sx.notApplicable
+    : sx.noResponseOptional;
   if (!hasResponse)
     return <Text sx={missingEntryStyle}>{missingEntryVerbiage}</Text>;
   // chandle choice list fields (checkbox, radio)
@@ -283,9 +285,12 @@ const sx = {
     fontWeight: "bold",
   },
   noResponse: {
-    color: "palette.base",
+    color: "palette.error_darker",
   },
   notApplicable: {
     color: "palette.gray_medium",
+  },
+  noResponseOptional: {
+    color: "palette.base",
   },
 };


### PR DESCRIPTION
### Description
Fixed optional checkbox and radio btn questions to display "Not answered, optional" instead of the required messaging

![Screenshot 2024-04-15 at 12 12 06 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/14514294/beaf9577-c362-47c3-ade6-78bc77dc24d0)

<img width="651" alt="Screenshot 2024-05-01 at 3 58 04 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mcr/assets/14514294/6cd3c78b-5dc4-40f2-8653-4913bdb8e2b7">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-[https://jiraent.cms.gov/browse/CMDCT-3547]

---
### How to test
1. Fill out MLR Report and leave optional checkbox fields and radio fields unselected.
2. Go to Review PDF and see the 'no response' verbiage 


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
