### PR TITLE
CMDCT-3543: ILOS (Section A. Program Information)

### DIFF
--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -215,7 +215,7 @@
           }
         },
         {
-          "name": "Add In Lieu of Services (optional)",
+          "name": "Add In Lieu of Services",
           "path": "/mcpar/program-information/add-in-lieu-of-services",
           "pageType": "standard",
           "verbiage": {
@@ -224,12 +224,8 @@
               "subsection": "In Lieu of Services and Settings Offered",
               "info": [
                 {
-                  "type": "html",
-                  "content": "<b>If In Lieu of Services and Settings (ILOS) are available in this managed care program, enter the name of each ILOS offered under the managed care program, as approved in the managed care plan contract(s).</b> <br/>"
-                },
-                {
-                  "type": "span",
-                  "content": "<br/>Do not include short-term IMD stays. Access "
+                  "type": "p",
+                  "content": "If In Lieu of Services and Settings (ILOS) are available in this managed care program, enter the name of each ILOS offered, as approved in the managed care plan contract(s). Do not include short-term IMD stays. <b>You are required to complete this section if ILOS are available.</b> Do not include short-term IMD stays. Access "
                 },
                 {
                   "type": "externalLink",
@@ -3590,59 +3586,6 @@
                     {
                       "id": "2gx74mMf7Ou0BRI5Kyp2Ih",
                       "label": "Promptly when plan receives information about the change"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        },
-        {
-          "name": "XI: ILOS",
-          "path": "/mcpar/plan-level-indicators/ilos",
-          "pageType": "drawer",
-          "entityType": "ilos",
-          "verbiage": {
-            "intro": {
-              "section": "Section D: Plan-Level Indicators",
-              "subsection": "Topic XI. ILOS",
-              "spreadsheet": "D4_Plan_ILOS"
-            },
-            "dashboardTitle": "Report ILOS utilization for each managed care plan during the contract rating period",
-            "info": "If In Lieu of Services and Settings (ILOS) are available in this managed care program, report ILOS utilization for each plan during the contract rating period. Select \"Enter\" for each plan listed below to indicate whether or not ILOS was offered by the plan, select which ILOS the plan offered, and enter data on utilization for each ILOS offered.",
-            "drawerTitle": "",
-            "missingEntityMessage": [
-              {
-                "type": "span",
-                "content": "This program is missing ILOS. You won’t be able to complete this section until you’ve added all the ILOS offered under the program. "
-              },
-              {
-                "type": "internalLink",
-                "content": "Add In Lieu of Services",
-                "props": {
-                  "to": "/mcpar/program-information/add-in-lieu-of-services"
-                }
-              }
-            ]
-          },
-          "drawerForm": {
-            "id": "dilos",
-            "fields": [
-              {
-                "id": "plan_ilosOfferedByPlan",
-                "type": "radio",
-                "validation": "radio",
-                "props": {
-                  "label": "D4.XI.1 ILOS offered by plan",
-                  "hint": "Indicate whether this plan offered ILOS to their enrollees.",
-                  "choices": [
-                    {
-                      "id": "FlryiigyFX6WzoXGO44i9I4X",
-                      "label": "No"
-                    },
-                    {
-                      "id": "wQOpexgX5QHj0xssJSqtzKF4",
-                      "label": "Yes, at least 1 ILOS is offered by this plan"
                     }
                   ]
                 }

--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -8,7 +8,8 @@
     "accessMeasures": { "required": true },
     "qualityMeasures": { "required": true },
     "plans": { "required": true },
-    "bssEntities": { "required": true }
+    "bssEntities": { "required": true },
+    "ilos": { "required": false }
   },
   "routes": [
     {
@@ -208,6 +209,54 @@
                 "validation": "dynamic",
                 "props": {
                   "label": "BSS entity name"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "Add In Lieu of Services (optional)",
+          "path": "/mcpar/program-information/add-in-lieu-of-services",
+          "pageType": "standard",
+          "verbiage": {
+            "intro": {
+              "section": "Section A: Program Information",
+              "subsection": "In Lieu of Services and Settings Offered",
+              "info": [
+                {
+                  "type": "html",
+                  "content": "<b>If In Lieu of Services and Settings (ILOS) are available in this managed care program, enter the name of each ILOS offered under the managed care program, as approved in the managed care plan contract(s).</b> <br/><br/>"
+                },
+                {
+                  "type": "span",
+                  "content": "Do not include short-term IMD stays. Access "
+                },
+                {
+                  "type": "externalLink",
+                  "content": "guidance on In Lieu of Services on Medicaid.gov",
+                  "props": {
+                    "href": "https://www.medicaid.gov/medicaid/managed-care/guidance/lieu-of-services-and-settings/index.html",
+                    "target": "_blank",
+                    "aria-label": "guidance on In Lieu of Services on Medicaid.gov (link opens in new tab)."
+                  }
+                },
+                {
+                  "type": "span",
+                  "content": "."
+                }
+              ],
+              "spreadsheet": "A_Program_Info"
+            }
+          },
+          "form": {
+            "id": "aailos",
+            "fields": [
+              {
+                "id": "ilos",
+                "type": "dynamic",
+                "validation": "dynamicOptional",
+                "props": {
+                  "label": "ILOS name"
                 }
               }
             ]

--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -9,7 +9,7 @@
     "qualityMeasures": { "required": true },
     "plans": { "required": true },
     "bssEntities": { "required": true },
-    "ilos": { "required": false }
+    "ilos": { " required": false }
   },
   "routes": [
     {
@@ -390,227 +390,6 @@
                       ]
                     }
                   ]
-                }
-              }
-            ]
-          }
-        },
-        {
-          "name": "X: Program Integrity",
-          "path": "/mcpar/state-level-indicators/program-integrity",
-          "pageType": "standard",
-          "verbiage": {
-            "intro": {
-              "section": "Section B: State-Level Indicators",
-              "subsection": "Topic X: Program Integrity",
-              "spreadsheet": "B_State"
-            }
-          },
-          "form": {
-            "id": "bpi",
-            "fields": [
-              {
-                "id": "state_focusedProgramIntegrityActivitiesConducted",
-                "type": "textarea",
-                "validation": "text",
-                "props": {
-                  "label": "B.X.1 Payment risks between the state and plans",
-                  "hint": "Describe service-specific or other focused PI activities that the state conducted during the past year in this managed care program.</br>Examples include analyses focused on use of long-term services and supports (LTSS) or prescription drugs or activities that focused on specific payment issues to identify, address, and prevent fraud, waste or abuse. Consider data analytics, reviews of under/overutilization, and other activities. If no PI activities were performed, enter 'No PI activities were performed during the reporting period' as your response. 'N/A' is not an acceptable response."
-                }
-              },
-              {
-                "id": "state_overpaymentStandard",
-                "type": "radio",
-                "validation": "radio",
-                "props": {
-                  "label": "B.X.2 Contract standard for overpayments",
-                  "hint": "Does the state allow plans to retain overpayments, require the return of overpayments, or has established a hybrid system? Select one.",
-                  "choices": [
-                    {
-                      "id": "UG7uunqq5UCtUq1is3iyiw",
-                      "label": "Allow plans to retain overpayments"
-                    },
-                    {
-                      "id": "3DGAqqnOBE2kwKVFMxUt3A",
-                      "label": "State requires the return of overpayments"
-                    },
-                    {
-                      "id": "jlIZKSPaf0GSVGmJbRUBzg",
-                      "label": "State has established a hybrid system"
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "state_overpaymentStandardContractLanguageLocation",
-                "type": "textarea",
-                "validation": "text",
-                "props": {
-                  "label": "B.X.3 Location of contract provision stating overpayment standard",
-                  "hint": "Describe where the overpayment standard in the previous indicator is located in plan contracts, as required by 42 CFR 438.608(d)(1)(i)."
-                }
-              },
-              {
-                "id": "state_overpaymentStandardDescription",
-                "type": "textarea",
-                "validation": "text",
-                "props": {
-                  "label": "B.X.4 Description of overpayment contract standard",
-                  "hint": "Briefly describe the overpayment standard (for example, details on whether the state allows plans to retain overpayments, requires the plans to return overpayments, or administers a hybrid system) selected in indicator B.X.2."
-                }
-              },
-              {
-                "id": "state_overpaymentReportingMonitoringEfforts",
-                "type": "textarea",
-                "validation": "text",
-                "props": {
-                  "label": "B.X.5 State overpayment reporting monitoring",
-                  "hint": "Describe how the state monitors plan performance in reporting overpayments to the state, e.g. does the state track compliance with this requirement and/or timeliness of reporting?</br>The regulations at 438.604(a)(7), 608(a)(2) and 608(a)(3) require plan reporting to the state on various overpayment topics (whether annually or promptly). This indicator is asking the state how it monitors that reporting."
-                }
-              },
-              {
-                "id": "state_beneficiaryCircumstanceChangeReconciliationEfforts",
-                "type": "textarea",
-                "validation": "text",
-                "props": {
-                  "label": "B.X.6 Changes in beneficiary circumstances",
-                  "hint": "Describe how the state ensures timely and accurate reconciliation of enrollment files between the state and plans to ensure appropriate payments for enrollees experiencing a change in status (e.g., incarcerated, deceased, switching plans)."
-                }
-              },
-              {
-                "id": "state_providerTerminationReportingMonitoringEfforts",
-                "type": "radio",
-                "validation": "radio",
-                "props": {
-                  "label": "B.X.7a Changes in provider circumstances: Monitoring plans",
-                  "hint": "Does the state monitor whether plans report provider “for cause” terminations in a timely manner under 42 CFR 438.608(a)(4)? Select one.",
-                  "choices": [
-                    {
-                      "id": "WFrdLUutmEujEZkS7rWVqQ",
-                      "label": "Yes",
-                      "children": [
-                        {
-                          "id": "state_providerTerminationReportingMonitoringMetrics",
-                          "type": "radio",
-                          "validation": {
-                            "type": "radio",
-                            "nested": true,
-                            "parentFieldName": "state_providerTerminationReportingMonitoringEfforts"
-                          },
-                          "props": {
-                            "label": "B.X.7b Changes in provider circumstances: Metrics",
-                            "hint": "Does the state use a metric or indicator to assess plan reporting performance? Select one.",
-                            "choices": [
-                              {
-                                "id": "SPqyExyg8UioX6Od1IWvlg",
-                                "label": "Yes",
-                                "children": [
-                                  {
-                                    "id": "state_providerTerminationReportingMonitoringMetricsDescription",
-                                    "type": "textarea",
-                                    "validation": {
-                                      "type": "text",
-                                      "nested": true,
-                                      "parentFieldName": "state_providerTerminationReportingMonitoringMetrics"
-                                    },
-                                    "props": {
-                                      "label": "B.X.7c Changes in provider circumstances: Describe metric",
-                                      "hint": "Describe the metric or indicator that the state uses."
-                                    }
-                                  }
-                                ]
-                              },
-                              {
-                                "id": "XPflE27BV0G3RJFYxuw8QA",
-                                "label": "No"
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "id": "3tIhiqQxhEiSIhM7UW1DKQ",
-                      "label": "No"
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "state_excludedEntityIdentifiedInFederalDatabaseCheck",
-                "type": "radio",
-                "validation": "radio",
-                "props": {
-                  "label": "B.X.8a Federal database checks: Excluded person or entities",
-                  "hint": "During the state's federal database checks, did the state find any person or entity excluded? Select one.</br>Consistent with the requirements at 42 CFR 455.436 and 438.602, the State must confirm the identity and determine the exclusion status of the MCO, PIHP, PAHP, PCCM or PCCM entity, any subcontractor, as well as any person with an ownership or control interest, or who is an agent or managing employee of the MCO, PIHP, PAHP, PCCM or PCCM entity through routine checks of Federal databases.",
-                  "choices": [
-                    {
-                      "id": "zrrv4vmXRkGhSkaS2V2d3A",
-                      "label": "Yes",
-                      "children": [
-                        {
-                          "id": "state_excludedEntityIdentificationInstancesSummary",
-                          "type": "textarea",
-                          "validation": {
-                            "type": "text",
-                            "nested": true,
-                            "parentFieldName": "state_excludedEntityIdentifiedInFederalDatabaseCheck"
-                          },
-                          "props": {
-                            "label": "B.X.8b Federal database checks: Summarize instances of exclusion",
-                            "hint": "Summarize the instances and whether the entity was notified as required in 438.602(d). Report actions taken, such as plan-level sanctions and corrective actions."
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "id": "ed1vyv6qB0a4aDLSeHOGPQ",
-                      "label": "No"
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "state_ownershipControlDisclosureWebsite",
-                "type": "radio",
-                "validation": "radio",
-                "props": {
-                  "label": "B.X.9a Website posting of 5 percent or more ownership control",
-                  "hint": "Does the state post on its website the names of individuals and entities with 5% or more ownership or control interest in MCOs, PIHPs, PAHPs, PCCMs and PCCM entities and subcontractors? Refer to §455.104 and required by 42 CFR 438.602(g)(3).",
-                  "choices": [
-                    {
-                      "id": "fNiPtEub20Soo1W5FcdU3A",
-                      "label": "Yes",
-                      "children": [
-                        {
-                          "id": "state_ownershipControlDisclosureWebsiteLink",
-                          "type": "text",
-                          "validation": {
-                            "type": "url",
-                            "nested": true,
-                            "parentFieldName": "state_ownershipControlDisclosureWebsite"
-                          },
-                          "props": {
-                            "label": "B.X.9b Website posting of 5 percent or more ownership control: Link",
-                            "hint": "What is the link to the website? Refer to 42 CFR 602(g)(3)."
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "id": "qhyidi0w4UiiBvCsoTgFOg",
-                      "label": "No"
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "state_submittedDataAuditResults",
-                "type": "textarea",
-                "validation": "text",
-                "props": {
-                  "label": "B.X.10 Periodic audits",
-                  "hint": "If the state conducted any audits during the contract year to determine the accuracy, truthfulness, and completeness of the encounter and financial data submitted by the plans, provide the link(s) to the audit results. Refer to 42 CFR 438.602(e). If no audits were conducted, please enter 'No such audits were conducted during the reporting year' as your response. 'N/A' is not an acceptable response."
                 }
               }
             ]
@@ -1686,6 +1465,42 @@
                 "props": {
                   "label": "C1.IX.4 State evaluation of BSS entity performance",
                   "hint": "What are steps taken by the state to evaluate the quality, effectiveness, and efficiency of the BSS entities' performance?"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "X: Program Integrity",
+          "path": "/mcpar/program-level-indicators/program-integrity",
+          "pageType": "standard",
+          "verbiage": {
+            "intro": {
+              "section": "Section C: Program-Level Indicators",
+              "subsection": "Topic X: Program Integrity",
+              "spreadsheet": "C1_Program_Set"
+            }
+          },
+          "form": {
+            "id": "cpi",
+            "fields": [
+              {
+                "id": "program_prohibitedAffiliationDisclosure",
+                "type": "radio",
+                "validation": "radio",
+                "props": {
+                  "label": "C1.X.3 Prohibited affiliation disclosure",
+                  "hint": "Did any plans disclose prohibited affiliations? If the state took action, enter those actions under D: Plan-level Indicators, Section VIII - Sanctions (Corresponds with Tab D3 in the Excel Workbook). Refer to 42 CFR 438.610(d).",
+                  "choices": [
+                    {
+                      "id": "7emiYPcs60GzXxKS5Pc9bg",
+                      "label": "Yes"
+                    },
+                    {
+                      "id": "SCGdBlpSQU6OVWAf3mDlMQ",
+                      "label": "No"
+                    }
+                  ]
                 }
               }
             ]

--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -9,7 +9,7 @@
     "qualityMeasures": { "required": true },
     "plans": { "required": true },
     "bssEntities": { "required": true },
-    "ilos": { " required": false }
+    "ilos": { "required": false }
   },
   "routes": [
     {

--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -3642,33 +3642,7 @@
                     },
                     {
                       "id": "wQOpexgX5QHj0xssJSqtzKF4",
-                      "label": "Yes, at least 1 ILOS is offered by this plan",
-                      "children": [
-                        {
-                          "id": "BZX2jt2OG0Y9SZCtWDbTJvB9",
-                          "type": "checkbox",
-                          "validation": {
-                            "type": "checkbox",
-                            "nested": true,
-                            "parentFieldName": "wQOpexgX5QHj0xssJSqtzKF4"
-                          },
-                          "props": {
-                            "label": "D4.XI.2 ILOS utilization by plan",
-                            "hint": "Select all the ILOS that were offered by this plan during the contract rating period. For each ILOS offered by the plan, enter the deduplicated number of enrollees that utilized the ILOS during the contract rating period. If the plan offered an ILOS during the contract rating period, but there was no utilization, select the ILOS and enter \"0\"."
-                          },
-                          "children": [
-                            {
-                              "id": "plan_ilosUtilization",
-                              "type": "text",
-                              "repeat": "ilos",
-                              "validation": {
-                                "type": "text",
-                                "nested": true
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                      "label": "Yes, at least 1 ILOS is offered by this plan"
                     }
                   ]
                 }

--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -224,7 +224,7 @@
               "subsection": "In Lieu of Services and Settings Offered",
               "info": [
                 {
-                  "type": "p",
+                  "type": "span",
                   "content": "If In Lieu of Services and Settings (ILOS) are available in this managed care program, enter the name of each ILOS offered, as approved in the managed care plan contract(s). Do not include short-term IMD stays. <b>You are required to complete this section if ILOS are available.</b> Do not include short-term IMD stays. Access "
                 },
                 {

--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -619,6 +619,227 @@
               }
             ]
           }
+        },
+        {
+          "name": "X: Program Integrity",
+          "path": "/mcpar/state-level-indicators/program-integrity",
+          "pageType": "standard",
+          "verbiage": {
+            "intro": {
+              "section": "Section B: State-Level Indicators",
+              "subsection": "Topic X: Program Integrity",
+              "spreadsheet": "B_State"
+            }
+          },
+          "form": {
+            "id": "bpi",
+            "fields": [
+              {
+                "id": "state_focusedProgramIntegrityActivitiesConducted",
+                "type": "textarea",
+                "validation": "text",
+                "props": {
+                  "label": "B.X.1 Payment risks between the state and plans",
+                  "hint": "Describe service-specific or other focused PI activities that the state conducted during the past year in this managed care program.</br>Examples include analyses focused on use of long-term services and supports (LTSS) or prescription drugs or activities that focused on specific payment issues to identify, address, and prevent fraud, waste or abuse. Consider data analytics, reviews of under/overutilization, and other activities. If no PI activities were performed, enter 'No PI activities were performed during the reporting period' as your response. 'N/A' is not an acceptable response."
+                }
+              },
+              {
+                "id": "state_overpaymentStandard",
+                "type": "radio",
+                "validation": "radio",
+                "props": {
+                  "label": "B.X.2 Contract standard for overpayments",
+                  "hint": "Does the state allow plans to retain overpayments, require the return of overpayments, or has established a hybrid system? Select one.",
+                  "choices": [
+                    {
+                      "id": "UG7uunqq5UCtUq1is3iyiw",
+                      "label": "Allow plans to retain overpayments"
+                    },
+                    {
+                      "id": "3DGAqqnOBE2kwKVFMxUt3A",
+                      "label": "State requires the return of overpayments"
+                    },
+                    {
+                      "id": "jlIZKSPaf0GSVGmJbRUBzg",
+                      "label": "State has established a hybrid system"
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "state_overpaymentStandardContractLanguageLocation",
+                "type": "textarea",
+                "validation": "text",
+                "props": {
+                  "label": "B.X.3 Location of contract provision stating overpayment standard",
+                  "hint": "Describe where the overpayment standard in the previous indicator is located in plan contracts, as required by 42 CFR 438.608(d)(1)(i)."
+                }
+              },
+              {
+                "id": "state_overpaymentStandardDescription",
+                "type": "textarea",
+                "validation": "text",
+                "props": {
+                  "label": "B.X.4 Description of overpayment contract standard",
+                  "hint": "Briefly describe the overpayment standard (for example, details on whether the state allows plans to retain overpayments, requires the plans to return overpayments, or administers a hybrid system) selected in indicator B.X.2."
+                }
+              },
+              {
+                "id": "state_overpaymentReportingMonitoringEfforts",
+                "type": "textarea",
+                "validation": "text",
+                "props": {
+                  "label": "B.X.5 State overpayment reporting monitoring",
+                  "hint": "Describe how the state monitors plan performance in reporting overpayments to the state, e.g. does the state track compliance with this requirement and/or timeliness of reporting?</br>The regulations at 438.604(a)(7), 608(a)(2) and 608(a)(3) require plan reporting to the state on various overpayment topics (whether annually or promptly). This indicator is asking the state how it monitors that reporting."
+                }
+              },
+              {
+                "id": "state_beneficiaryCircumstanceChangeReconciliationEfforts",
+                "type": "textarea",
+                "validation": "text",
+                "props": {
+                  "label": "B.X.6 Changes in beneficiary circumstances",
+                  "hint": "Describe how the state ensures timely and accurate reconciliation of enrollment files between the state and plans to ensure appropriate payments for enrollees experiencing a change in status (e.g., incarcerated, deceased, switching plans)."
+                }
+              },
+              {
+                "id": "state_providerTerminationReportingMonitoringEfforts",
+                "type": "radio",
+                "validation": "radio",
+                "props": {
+                  "label": "B.X.7a Changes in provider circumstances: Monitoring plans",
+                  "hint": "Does the state monitor whether plans report provider “for cause” terminations in a timely manner under 42 CFR 438.608(a)(4)? Select one.",
+                  "choices": [
+                    {
+                      "id": "WFrdLUutmEujEZkS7rWVqQ",
+                      "label": "Yes",
+                      "children": [
+                        {
+                          "id": "state_providerTerminationReportingMonitoringMetrics",
+                          "type": "radio",
+                          "validation": {
+                            "type": "radio",
+                            "nested": true,
+                            "parentFieldName": "state_providerTerminationReportingMonitoringEfforts"
+                          },
+                          "props": {
+                            "label": "B.X.7b Changes in provider circumstances: Metrics",
+                            "hint": "Does the state use a metric or indicator to assess plan reporting performance? Select one.",
+                            "choices": [
+                              {
+                                "id": "SPqyExyg8UioX6Od1IWvlg",
+                                "label": "Yes",
+                                "children": [
+                                  {
+                                    "id": "state_providerTerminationReportingMonitoringMetricsDescription",
+                                    "type": "textarea",
+                                    "validation": {
+                                      "type": "text",
+                                      "nested": true,
+                                      "parentFieldName": "state_providerTerminationReportingMonitoringMetrics"
+                                    },
+                                    "props": {
+                                      "label": "B.X.7c Changes in provider circumstances: Describe metric",
+                                      "hint": "Describe the metric or indicator that the state uses."
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "id": "XPflE27BV0G3RJFYxuw8QA",
+                                "label": "No"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "id": "3tIhiqQxhEiSIhM7UW1DKQ",
+                      "label": "No"
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "state_excludedEntityIdentifiedInFederalDatabaseCheck",
+                "type": "radio",
+                "validation": "radio",
+                "props": {
+                  "label": "B.X.8a Federal database checks: Excluded person or entities",
+                  "hint": "During the state's federal database checks, did the state find any person or entity excluded? Select one.</br>Consistent with the requirements at 42 CFR 455.436 and 438.602, the State must confirm the identity and determine the exclusion status of the MCO, PIHP, PAHP, PCCM or PCCM entity, any subcontractor, as well as any person with an ownership or control interest, or who is an agent or managing employee of the MCO, PIHP, PAHP, PCCM or PCCM entity through routine checks of Federal databases.",
+                  "choices": [
+                    {
+                      "id": "zrrv4vmXRkGhSkaS2V2d3A",
+                      "label": "Yes",
+                      "children": [
+                        {
+                          "id": "state_excludedEntityIdentificationInstancesSummary",
+                          "type": "textarea",
+                          "validation": {
+                            "type": "text",
+                            "nested": true,
+                            "parentFieldName": "state_excludedEntityIdentifiedInFederalDatabaseCheck"
+                          },
+                          "props": {
+                            "label": "B.X.8b Federal database checks: Summarize instances of exclusion",
+                            "hint": "Summarize the instances and whether the entity was notified as required in 438.602(d). Report actions taken, such as plan-level sanctions and corrective actions."
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "id": "ed1vyv6qB0a4aDLSeHOGPQ",
+                      "label": "No"
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "state_ownershipControlDisclosureWebsite",
+                "type": "radio",
+                "validation": "radio",
+                "props": {
+                  "label": "B.X.9a Website posting of 5 percent or more ownership control",
+                  "hint": "Does the state post on its website the names of individuals and entities with 5% or more ownership or control interest in MCOs, PIHPs, PAHPs, PCCMs and PCCM entities and subcontractors? Refer to §455.104 and required by 42 CFR 438.602(g)(3).",
+                  "choices": [
+                    {
+                      "id": "fNiPtEub20Soo1W5FcdU3A",
+                      "label": "Yes",
+                      "children": [
+                        {
+                          "id": "state_ownershipControlDisclosureWebsiteLink",
+                          "type": "text",
+                          "validation": {
+                            "type": "url",
+                            "nested": true,
+                            "parentFieldName": "state_ownershipControlDisclosureWebsite"
+                          },
+                          "props": {
+                            "label": "B.X.9b Website posting of 5 percent or more ownership control: Link",
+                            "hint": "What is the link to the website? Refer to 42 CFR 602(g)(3)."
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "id": "qhyidi0w4UiiBvCsoTgFOg",
+                      "label": "No"
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "state_submittedDataAuditResults",
+                "type": "textarea",
+                "validation": "text",
+                "props": {
+                  "label": "B.X.10 Periodic audits",
+                  "hint": "If the state conducted any audits during the contract year to determine the accuracy, truthfulness, and completeness of the encounter and financial data submitted by the plans, provide the link(s) to the audit results. Refer to 42 CFR 438.602(e). If no audits were conducted, please enter 'No such audits were conducted during the reporting year' as your response. 'N/A' is not an acceptable response."
+                }
+              }
+            ]
+          }
         }
       ]
     },
@@ -1469,42 +1690,6 @@
                 "props": {
                   "label": "C1.IX.4 State evaluation of BSS entity performance",
                   "hint": "What are steps taken by the state to evaluate the quality, effectiveness, and efficiency of the BSS entities' performance?"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "name": "X: Program Integrity",
-          "path": "/mcpar/program-level-indicators/program-integrity",
-          "pageType": "standard",
-          "verbiage": {
-            "intro": {
-              "section": "Section C: Program-Level Indicators",
-              "subsection": "Topic X: Program Integrity",
-              "spreadsheet": "C1_Program_Set"
-            }
-          },
-          "form": {
-            "id": "cpi",
-            "fields": [
-              {
-                "id": "program_prohibitedAffiliationDisclosure",
-                "type": "radio",
-                "validation": "radio",
-                "props": {
-                  "label": "C1.X.3 Prohibited affiliation disclosure",
-                  "hint": "Did any plans disclose prohibited affiliations? If the state took action, enter those actions under D: Plan-level Indicators, Section VIII - Sanctions (Corresponds with Tab D3 in the Excel Workbook). Refer to 42 CFR 438.610(d).",
-                  "choices": [
-                    {
-                      "id": "7emiYPcs60GzXxKS5Pc9bg",
-                      "label": "Yes"
-                    },
-                    {
-                      "id": "SCGdBlpSQU6OVWAf3mDlMQ",
-                      "label": "No"
-                    }
-                  ]
                 }
               }
             ]
@@ -3405,6 +3590,85 @@
                     {
                       "id": "2gx74mMf7Ou0BRI5Kyp2Ih",
                       "label": "Promptly when plan receives information about the change"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "XI: ILOS",
+          "path": "/mcpar/plan-level-indicators/ilos",
+          "pageType": "drawer",
+          "entityType": "ilos",
+          "verbiage": {
+            "intro": {
+              "section": "Section D: Plan-Level Indicators",
+              "subsection": "Topic XI. ILOS",
+              "spreadsheet": "D4_Plan_ILOS"
+            },
+            "dashboardTitle": "Report ILOS utilization for each managed care plan during the contract rating period",
+            "info": "If In Lieu of Services and Settings (ILOS) are available in this managed care program, report ILOS utilization for each plan during the contract rating period. Select \"Enter\" for each plan listed below to indicate whether or not ILOS was offered by the plan, select which ILOS the plan offered, and enter data on utilization for each ILOS offered.",
+            "drawerTitle": "",
+            "missingEntityMessage": [
+              {
+                "type": "span",
+                "content": "This program is missing ILOS. You won’t be able to complete this section until you’ve added all the ILOS offered under the program. "
+              },
+              {
+                "type": "internalLink",
+                "content": "Add In Lieu of Services",
+                "props": {
+                  "to": "/mcpar/program-information/add-in-lieu-of-services"
+                }
+              }
+            ]
+          },
+          "drawerForm": {
+            "id": "dilos",
+            "fields": [
+              {
+                "id": "plan_ilosOfferedByPlan",
+                "type": "radio",
+                "validation": "radio",
+                "props": {
+                  "label": "D4.XI.1 ILOS offered by plan",
+                  "hint": "Indicate whether this plan offered ILOS to their enrollees.",
+                  "choices": [
+                    {
+                      "id": "FlryiigyFX6WzoXGO44i9I4X",
+                      "label": "No"
+                    },
+                    {
+                      "id": "wQOpexgX5QHj0xssJSqtzKF4",
+                      "label": "Yes, at least 1 ILOS is offered by this plan",
+                      "children": [
+                        {
+                          "id": "BZX2jt2OG0Y9SZCtWDbTJvB9",
+                          "type": "checkbox",
+                          "validation": {
+                            "type": "checkbox",
+                            "nested": true,
+                            "parentFieldName": "wQOpexgX5QHj0xssJSqtzKF4"
+                          },
+                          "props": {
+                            "label": "D4.XI.2 ILOS utilization by plan",
+                            "hint": "Select all the ILOS that were offered by this plan during the contract rating period. For each ILOS offered by the plan, enter the deduplicated number of enrollees that utilized the ILOS during the contract rating period. If the plan offered an ILOS during the contract rating period, but there was no utilization, select the ILOS and enter \"0\"."
+                          },
+                          "children": [
+                            {
+                              "id": "plan_ilosUtilization",
+                              "type": "text",
+                              "repeat": "ilos",
+                              "validation": {
+                                "type": "text",
+                                "nested": true
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 }

--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -225,11 +225,11 @@
               "info": [
                 {
                   "type": "html",
-                  "content": "<b>If In Lieu of Services and Settings (ILOS) are available in this managed care program, enter the name of each ILOS offered under the managed care program, as approved in the managed care plan contract(s).</b> <br/><br/>"
+                  "content": "<b>If In Lieu of Services and Settings (ILOS) are available in this managed care program, enter the name of each ILOS offered under the managed care program, as approved in the managed care plan contract(s).</b> <br/>"
                 },
                 {
                   "type": "span",
-                  "content": "Do not include short-term IMD stays. Access "
+                  "content": "<br/>Do not include short-term IMD stays. Access "
                 },
                 {
                   "type": "externalLink",

--- a/services/app-api/utils/validation/completionSchemas.ts
+++ b/services/app-api/utils/validation/completionSchemas.ts
@@ -238,7 +238,7 @@ export const dynamic = () =>
       })
     )
     .required(error.REQUIRED_GENERIC);
-export const dynamicOptional = () => dynamic().notRequired();
+export const dynamicOptional = () => array().notRequired().nullable();
 
 // NESTED
 export const nested = (

--- a/services/app-api/utils/validation/schemaMap.ts
+++ b/services/app-api/utils/validation/schemaMap.ts
@@ -196,7 +196,7 @@ export const radioOptional = () => radio();
 
 // DYNAMIC
 export const dynamic = () => array().min(0).of(mixed());
-export const dynamicOptional = () => dynamic();
+export const dynamicOptional = () => dynamic().notRequired();
 
 // NESTED
 export const nested = (

--- a/services/app-api/utils/validation/schemaMap.ts
+++ b/services/app-api/utils/validation/schemaMap.ts
@@ -196,7 +196,7 @@ export const radioOptional = () => radio();
 
 // DYNAMIC
 export const dynamic = () => array().min(0).of(mixed());
-export const dynamicOptional = () => dynamic().notRequired();
+export const dynamicOptional = () => array().notRequired().nullable();
 
 // NESTED
 export const nested = (

--- a/services/ui-src/src/components/modals/DeleteDynamicFieldRecordModal.tsx
+++ b/services/ui-src/src/components/modals/DeleteDynamicFieldRecordModal.tsx
@@ -15,6 +15,7 @@ export const DeleteDynamicFieldRecordModal = ({
   const fieldTypeMap: any = {
     plans: "plan",
     bssEntities: "BSS entity",
+    ilos: "ILOS",
   };
 
   const entityName = fieldTypeMap[entityType];

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -183,6 +183,7 @@ export const dynamic = () =>
       })
     )
     .required(error.REQUIRED_GENERIC);
+
 export const dynamicOptional = () => dynamic().notRequired();
 
 // NESTED

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -184,7 +184,7 @@ export const dynamic = () =>
     )
     .required(error.REQUIRED_GENERIC);
 
-export const dynamicOptional = () => dynamic().notRequired();
+export const dynamicOptional = () => array().notRequired().nullable();
 
 // NESTED
 export const nested = (

--- a/services/ui-src/src/verbiage/pages/mcpar/mcpar-get-started.ts
+++ b/services/ui-src/src/verbiage/pages/mcpar/mcpar-get-started.ts
@@ -39,6 +39,7 @@ export default {
             ["D1_Plan_Set", "D: Plan-Level Indicators"],
             ["D2_Plan_Measures", "D: Plan-Level Indicators"],
             ["D3_Plan_Sanctions", "D: Plan-Level Indicators"],
+            ["D4_Plan_ILOS", "D: Plan-Level Indicators"],
             ["E_BSS_Entities", "E: BSS Entity Indicators"],
           ],
         },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR adds a new subsection of `Section A. Program Information` of the MCPAR report, which includes a new form which is a dynamic field (similar to `Add plans`) for ILOS entities.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3544

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a new MCPAR report
- Navigate to `/mcpar/program-information/add-in-lieu-of-services`
- Verify the functionality stated above (as well as the correct completion status in `Review & submit`).

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
`mcpar.json` is updated to include a new section under `Section A. Program Information` titled `Add In Lieu of Services`

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
