### PR TITLE
Some tweaks to make cypress run better

### DIFF
--- a/tests/cypress/e2e/mcpar/dashboard.cy.js
+++ b/tests/cypress/e2e/mcpar/dashboard.cy.js
@@ -14,6 +14,10 @@ const newReportInputArray = [
   { name: "programIsPCCM", type: "radio", value: "No" },
 ];
 
+before(() => {
+  cy.archiveExistingMcparReports();
+});
+
 describe("MCPAR Dashboard Page - Program Creation/Editing/Archiving", () => {
   it("State users can create and edit reports", () => {
     cy.authenticate("stateUser");

--- a/tests/cypress/e2e/mcpar/form.cy.js
+++ b/tests/cypress/e2e/mcpar/form.cy.js
@@ -2,6 +2,10 @@ import mcparTemplate from "../../../../services/app-api/forms/mcpar.json";
 
 const templateMap = { MCPAR: mcparTemplate };
 
+before(() => {
+  cy.archiveExistingMcparReports();
+});
+
 describe("MCPAR E2E Form Submission", () => {
   it("A state user can fully create a form and submit it", () => {
     cy.authenticate("stateUser");

--- a/tests/cypress/e2e/mlr/form.cy.js
+++ b/tests/cypress/e2e/mlr/form.cy.js
@@ -1,5 +1,9 @@
 import template from "../../../../services/app-api/forms/mlr.json";
 
+before(() => {
+  cy.archiveExistingMlrReports();
+});
+
 describe("MLR E2E Form Submission", () => {
   const programName = `automated test - ${new Date().toISOString()}`;
   beforeEach(() => {

--- a/tests/cypress/e2e/sidebar.cy.js
+++ b/tests/cypress/e2e/sidebar.cy.js
@@ -5,6 +5,10 @@ const expandCollapseSidebar = "Open/Close sidebar menu";
 const subsectionText = ".chakra-link .level-2";
 const sectionLink = ".chakra-link .level-1";
 
+before(() => {
+  cy.archiveExistingMcparReports();
+});
+
 describe("Sidebar integration tests", () => {
   it("The sidebar can be navigated at multiple depths, references the selected items, and can be", () => {
     // Sign in as a state user
@@ -14,17 +18,24 @@ describe("Sidebar integration tests", () => {
     cy.get('button:contains("Enter MCPAR online")').click();
 
     // Create Report & nav to it
+    const programName = `automated test - ${new Date().toISOString()}`;
     cy.get('button:contains("Add / copy a MCPAR")').click();
-    cy.get('input[name="programName"]').type(
-      "automated test - " + new Date().toISOString()
-    );
+    cy.get('input[name="programName"]').type(programName);
     cy.get('input[name="reportingPeriodStartDate"]').type("07142023");
     cy.get('input[name="reportingPeriodEndDate"]').type("07142026");
     cy.get('[name="combinedData"]').focused().click();
     cy.get('input[name="programIsPCCM"').check("No");
     cy.get("button[type=submit]").contains("Save").click();
     cy.wait(2000);
-    cy.get('button:contains("Edit")').first().click();
+    //Find our new program and open it
+    cy.get("table").within(() => {
+      cy.get("td")
+        .contains(programName)
+        .parent()
+        .find('button:contains("Edit")')
+        .focus()
+        .click();
+    });
     cy.wait(2000);
 
     // Expand next section, collapse first, nav to new page.

--- a/tests/cypress/support/authentication.js
+++ b/tests/cypress/support/authentication.js
@@ -38,6 +38,7 @@ Cypress.Commands.add("navigateToHomePage", () => {
 Cypress.Commands.add("authenticate", (userType, userCredentials) => {
   //Defeats the purpose of sessions, but does improve performance when switching between users
   Cypress.session.clearAllSavedSessions();
+  cy.wait(2000);
   cy.session([userType, userCredentials], () => {
     cy.visit("/");
     cy.wait(2000);

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -1,0 +1,67 @@
+const { fillFormField } = require("./form/formInputs");
+
+const adminMcparSelectorArray = [
+  { name: "state", type: "dropdown", value: "District of Columbia" },
+  {
+    name: "report",
+    type: "radio",
+    value: "Managed Care Program Annual Report (MCPAR)",
+  },
+];
+
+const adminMlrSelectorArray = [
+  { name: "state", type: "dropdown", value: "District of Columbia" },
+  {
+    name: "report",
+    type: "radio",
+    value: "Medicaid Medical Loss Ratio (MLR)",
+  },
+];
+
+Cypress.Commands.add("archiveExistingMcparReports", () => {
+  // login as admin
+  cy.authenticate("adminUser");
+  cy.navigateToHomePage();
+
+  // go to mcpar dashboard
+  fillFormField(adminMcparSelectorArray);
+  cy.contains("Go to Report Dashboard").click();
+  cy.wait(3000);
+
+  /*
+   * Check if there is already a MCPAR report, if so, archive
+   * is to ensure a clean test bed
+   */
+  cy.get("table").then(($table) => {
+    if ($table.find('button:contains("Archive")').length > 0) {
+      $table.find('button:contains("Archive")').each(() => {
+        cy.get('button:contains("Archive")').first().click();
+        cy.wait(500);
+      });
+    }
+  });
+});
+
+Cypress.Commands.add("archiveExistingMlrReports", () => {
+  // login as admin
+  cy.authenticate("adminUser");
+  cy.navigateToHomePage();
+
+  // go to mlr dashboard
+  fillFormField(adminMlrSelectorArray);
+  cy.contains("Go to Report Dashboard").click();
+  cy.wait(3000);
+
+  /*
+   * Check if there is already a SAR report, if so, archive
+   * is to ensure a clean test bed
+   */
+  cy.get("table").then(($table) => {
+    if ($table.find('button:contains("Archive")').length > 0) {
+      $table.find('button:contains("Archive")').each(() => {
+        cy.get('button:contains("Archive")').first().click();
+        cy.wait(500);
+      });
+    }
+  });
+});

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -6,5 +6,6 @@
 import "cypress-axe";
 import "./accessibility";
 import "./authentication";
+import "./commands";
 
 export { fillFormField, verifyElementsArePrefilled } from "./form/formInputs";


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Borrow the "archive reports before running tests" idea from MFP
- Add wait after clearing auth sessions
  - This seemed to reduce retries that happen as a result of the old session still being active
- Rewrite sidebar commands to ensure it's entering the correct report


I ran these against local and against MCR dev. Especially in the dev env I saw fewer retries and more reliable outcomes.

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Run tests
- Tests pass in this branch

Only one retry happened in the tests
https://github.com/Enterprise-CMCS/macpro-mdct-mcr/actions/runs/9177706206/job/25236861227?pr=11704
