### PR TITLE
E2E Test: Skip ILOS in Route Traversal

### DIFF
--- a/tests/cypress/e2e/mcpar/form.cy.js
+++ b/tests/cypress/e2e/mcpar/form.cy.js
@@ -112,8 +112,8 @@ const traverseRoutes = (routes) => {
   routes.forEach((route) => {
     // skip over the ILOS routes as they are behind an LD flag
     if (
-      !route.pathname.contains("add-in-lieu-of-services") ||
-      !route.pathname.contains("ilos")
+      !route.path.includes("add-in-lieu-of-services") ||
+      !route.path.includes("ilos")
     ) {
       traverseRoute(route);
     }

--- a/tests/cypress/e2e/mcpar/form.cy.js
+++ b/tests/cypress/e2e/mcpar/form.cy.js
@@ -112,8 +112,8 @@ const traverseRoutes = (routes) => {
   routes.forEach((route) => {
     // skip over the ILOS routes as they are behind an LD flag
     if (
-      !route.path.contains("add-in-lieu-of-services") ||
-      !route.path.contains("ilos")
+      !route.pathname.contains("add-in-lieu-of-services") ||
+      !route.pathname.contains("ilos")
     ) {
       traverseRoute(route);
     }

--- a/tests/cypress/e2e/mcpar/form.cy.js
+++ b/tests/cypress/e2e/mcpar/form.cy.js
@@ -110,7 +110,13 @@ function fillOutPartialMCPAR() {
 const traverseRoutes = (routes) => {
   //iterate over each route
   routes.forEach((route) => {
-    traverseRoute(route);
+    // skip over the ILOS routes as they are behind an LD flag
+    if (
+      !route.path.contains("add-in-lieu-of-services") ||
+      !route.path.contains("ilos")
+    ) {
+      traverseRoute(route);
+    }
   });
 };
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Currently, the ILOS routes are available in the `mcpar.json` template, but won't be accessible in higher environment, causing the E2E test to fail when trying to traverse those routes. This skips them until they're released.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Cypress / E2E actions should pass on deploy.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
