### PR TITLE
Change to lastSynced to avoid conflict with user-relevant field

### DIFF
--- a/services/database/scripts/sync-kafka-2024.js
+++ b/services/database/scripts/sync-kafka-2024.js
@@ -77,7 +77,7 @@ function filterData(items) {
 async function transform(items) {
   // Touch sync field only
   const transformed = items.map((item) => {
-    const corrected = { ...item, ...{ lastAltered: dbSyncTime } };
+    const corrected = { ...item, ...{ lastSynced: dbSyncTime } };
     return corrected;
   });
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Following #11728 change the db field from `lastAltered` which is updated when a user saves a report to `lastSynced` which is only used for a one-off script like this. That way when we update the value in prod it does not impact a field that is supposed to reflect user interaction.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3695
