### PR TITLE
cmdct-3737 - remove Button from within Link

### DIFF
--- a/services/ui-src/src/components/layout/Header.tsx
+++ b/services/ui-src/src/components/layout/Header.tsx
@@ -2,15 +2,7 @@ import { useContext } from "react";
 import { Link as RouterLink } from "react-router-dom";
 // components
 import { UsaBanner } from "@cmsgov/design-system";
-import {
-  Box,
-  Button,
-  Container,
-  Flex,
-  Image,
-  Link,
-  Text,
-} from "@chakra-ui/react";
+import { Box, Container, Flex, Image, Link, Text } from "@chakra-ui/react";
 import { Menu, MenuOption, ReportContext } from "components";
 // utils
 import { useBreakpoint, useStore } from "utils";
@@ -95,7 +87,7 @@ export const Header = ({ handleLogout }: Props) => {
                   tabIndex={-1}
                 >
                   {!isMobile ? (
-                    <Button variant="outline">Leave form</Button>
+                    <Text sx={sx.leaveFormText}>Leave form</Text>
                   ) : (
                     <Image src={closeIcon} alt="Close" sx={sx.closeIcon} />
                   )}
@@ -194,5 +186,12 @@ const sx = {
   },
   closeIcon: {
     width: "2rem",
+  },
+  leaveFormText: {
+    border: "1px solid",
+    padding: ".5rem 1rem",
+    borderRadius: "5px",
+    color: "palette.primary",
+    fontWeight: "bold",
   },
 };

--- a/tests/cypress/e2e/mcpar/form.cy.js
+++ b/tests/cypress/e2e/mcpar/form.cy.js
@@ -21,6 +21,8 @@ describe("MCPAR E2E Form Submission", () => {
     cy.get('[data-testid="modal-submit-button"]').focus().click();
 
     cy.contains("Successfully Submitted").should("be.visible");
+    cy.get("a:contains('Leave form')").focus().click();
+    cy.url().should("include", "/mcpar");
   });
 
   it("A state user cannot submit an incomplete form", () => {


### PR DESCRIPTION
### Description
The "Leave form" call to action should be marked up as a link and there should be no element inside.
The "Leave form" call to action should be styled as an outline button


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3737

---
### How to test
Login, create WP, enter WP and see that 'Leave form' still looks the same but is no longer a button.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
