### PR TITLE
ILOS Redirect Bug

### DIFF
--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -3953,7 +3953,7 @@
                     "type": "internalLink",
                     "content": "Add ILOS",
                     "props": {
-                      "to": "/mcpar/program-information/add-in-lieu-of-services"
+                      "to": "/mcpar/program-information/add-in-lieu-of-services-and-settings"
                     }
                   },
                   {

--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -4009,7 +4009,7 @@
                             "type": "internalLink",
                             "content": "Add ILOS",
                             "props": {
-                              "to": "/mcpar/program-information/add-in-lieu-of-services"
+                              "to": "/mcpar/program-information/add-in-lieu-of-services-and-settings"
                             }
                           },
                           {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Updating the redirect ILOS path for whenever a plan is missing added ILOS's.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Set [this variable](https://github.com/Enterprise-CMCS/macpro-mdct-mcr/blob/f8d041892dd7c94760e0d5ad76db498065ebb848/services/ui-src/src/components/modals/AddEditReportModal.tsx#L44) to `true`
- Log in as a state user
- Create a MCPAR
- Navigate to `/mcpar/plan-level-indicators/ilos`

The **Add ILOS** button should redirect you to `/mcpar/program-information/add-in-lieu-of-services-and-settings`

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
