### PR TITLE
CMDCT-3792: delete 'as' prop in createElementWithChildren

### DIFF
--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -81,6 +81,9 @@ export function createElementWithChildren(
       element.children.map((x) => createElementWithChildren(x))
     );
   }
+  if (type === "html") {
+    delete elementProps.as;
+  }
   const santizedContent = sanitizeAndParseHtml(content);
   return React.createElement(elementType, elementProps, santizedContent);
 }


### PR DESCRIPTION

### Description
<!-- Detailed description of changes and related context -->
The 'as' prop was not being deleted before an element was created with `createElementWithChildren()`.
Hence, a warning was being thrown. 
This PR prevents the warning by removing 'as' from the props before the element is created.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3792 [MCR] Console Cleanup (StandardReportPage + DrawerReportPage)

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Run MCR locally
2. Open console
3. Navigate to "Add Plans"
4. Click continue
5. The reported error should not appear.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
