### PR TITLE
fix page width 360 on get started page

### DIFF
--- a/services/ui-src/src/components/pages/GetStarted/ReportGetStartedPage.tsx
+++ b/services/ui-src/src/components/pages/GetStarted/ReportGetStartedPage.tsx
@@ -190,7 +190,7 @@ const sx = {
     fontWeight: "bold",
   },
   image: {
-    maxWidth: "20rem",
+    maxWidth: "18rem",
   },
   additionalInfo: {
     marginTop: "1rem",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-2385

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Navigate to `/mcpar/get-started` by clicking the "Enter MCPAR online" button
- Shrink the page width to 360px (you can verify the size by using browser tools for mobile views)
- Verify that everything fits within the page and there is no left-right scrolling to see content
- Compare to the same page in https://mdctmcrdev.cms.gov


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment