### PR TITLE
make app-api destroy first

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -54,4 +54,6 @@ jobs:
           role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Destroy
-        run: ./run destroy --stage $STAGE_PREFIX$branch_name --verify false
+        run: |
+          ./run destroy --stage $STAGE_PREFIX$branch_name --verify false --service app-api
+          ./run destroy --stage $STAGE_PREFIX$branch_name --verify false

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -54,6 +54,7 @@ jobs:
           role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Destroy
+        # destroy app-api first due to a dependency between it and database
         run: |
           ./run destroy --stage $STAGE_PREFIX$branch_name --verify false --service app-api
           ./run destroy --stage $STAGE_PREFIX$branch_name --verify false


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The order of delete is different every time. If `database` gets deleted before `app-api` the `app-api` stack fails to delete because of a dependency on S3 buckets from the `database` stack.

With this change our delete ensures app-api completes before deleting the database stack

Note: `--verify false` is necessary for CI because the `true` case is interactive. It still waits for the entire stack to delete before proceeding due to the `wait` parameter which defaults to true

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Verify the order of events in [this destroy run](https://github.com/Enterprise-CMCS/macpro-mdct-mcr/actions/runs/9996781953/job/27631884527) against a test branch

Verify there are no stacks with the name `test-delete-me` in Cloudformation

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment