### PR TITLE
Cmdct 3793 - added spinner to pdf banner button is the report is not displayed

### DIFF
--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -1075,7 +1075,11 @@
                     },
                     {
                       "type": "p",
-                      "content": "Revisions to the Medicaid managed care regulations in 2016 and 2020 built on existing requirements that managed care plans maintain provider networks sufficient to ensure adequate access to covered services by: (1) requiring states to develop quantitative network adequacy standards for at least eight specified provider types if covered under the contract, and to make these standards available online; (2) strengthening network adequacy monitoring requirements; and (3) addressing the needs of people with long-term care service needs (42 CFR 438.66; 42 CFR 438.68).</p><p>42 CFR 438.66(e) specifies that the MCPAR must provide information on and an assessment of the availability and accessibility of covered services within the MCO, PHIP, or PAHP contracts, including network adequacy standards for each managed care program."
+                      "content": "Revisions to the Medicaid managed care regulations in 2016 and 2020 built on existing requirements that managed care plans maintain provider networks sufficient to ensure adequate access to covered services by: (1) requiring states to develop quantitative network adequacy standards for at least eight specified provider types if covered under the contract, and to make these standards available online; (2) strengthening network adequacy monitoring requirements; and (3) addressing the needs of people with long-term care service needs (42 CFR 438.66; 42 CFR 438.68)."
+                    },
+                    {
+                      "type": "p",
+                      "content": "42 CFR 438.66(e) specifies that the MCPAR must provide information on and an assessment of the availability and accessibility of covered services within the MCO, PHIP, or PAHP contracts, including network adequacy standards for each managed care program."
                     }
                   ]
                 },
@@ -3382,7 +3386,11 @@
               "info": [
                 {
                   "type": "p",
-                  "content": "Describe sanctions that the state has issued for each plan. Report all known actions across the following domains: sanctions, administrative penalties, corrective action plans, other. Include any pending or unresolved actions.</p><p>42 CFR 438.66(e)(2)(viii) specifies that the MCPAR include the results of any sanctions or corrective action plans imposed by the State or other formal or informal intervention with a contracted MCO, PIHP, PAHP, or PCCM entity to improve performance."
+                  "content": "Describe sanctions that the state has issued for each plan. Report all known actions across the following domains: sanctions, administrative penalties, corrective action plans, other. Include any pending or unresolved actions."
+                },
+                {
+                  "type": "p",
+                  "content": "42 CFR 438.66(e)(2)(viii) specifies that the MCPAR include the results of any sanctions or corrective action plans imposed by the State or other formal or informal intervention with a contracted MCO, PIHP, PAHP, or PCCM entity to improve performance."
                 }
               ]
             },

--- a/services/ui-src/src/components/app/App.tsx
+++ b/services/ui-src/src/components/app/App.tsx
@@ -54,12 +54,15 @@ export const App = () => {
             <Timeout />
             <MainSkipNav />
             {!isExportPage && <Header handleLogout={logout} />}
-            {isExportPage && <ExportedReportBanner />}
-            <Container sx={sx.appContainer} data-testid="app-container">
-              <ErrorBoundary FallbackComponent={Error}>
+            <ErrorBoundary FallbackComponent={Error}>
+              {isExportPage && (
+                <ExportedReportBanner data-testid="pdf-banner" />
+              )}
+              <Container sx={sx.appContainer} data-testid="app-container">
                 <AppRoutes />
-              </ErrorBoundary>
-            </Container>
+              </Container>
+            </ErrorBoundary>
+
             <Footer />
           </ReportProvider>
         </Flex>

--- a/services/ui-src/src/components/app/Error.tsx
+++ b/services/ui-src/src/components/app/Error.tsx
@@ -1,35 +1,43 @@
 // components
 import { Flex, Heading, Image, Link, Text } from "@chakra-ui/react";
-import { PageTemplate } from "components";
+import { ExportedReportBanner, PageTemplate } from "components";
 // utils
 import { createEmailLink } from "utils/other/email";
 // assets
 import warningIcon from "assets/icons/icon_warning.png";
 import verbiage from "verbiage/pages/error";
+import { useLocation } from "react-router-dom";
 
 export const Error = () => {
   const { header, subHeading, emailText } = verbiage;
   const { preLinkText, helpDeskEmail, postLinkText } = emailText;
+  const { pathname } = useLocation();
+  const isExportPage = pathname.includes("/export");
 
   return (
-    <PageTemplate sxOverride={sx.layout}>
-      <Flex sx={sx.heading}>
-        <Image src={warningIcon} alt="warning icon" sx={sx.warningIcon} />
-        <Heading as="h1" sx={sx.headerText}>
-          {header}
+    <>
+      {isExportPage && (
+        <ExportedReportBanner error={true} data-testid="pdf-banner-error" />
+      )}
+      <PageTemplate sxOverride={sx.layout}>
+        <Flex sx={sx.heading}>
+          <Image src={warningIcon} alt="warning icon" sx={sx.warningIcon} />
+          <Heading as="h1" sx={sx.headerText}>
+            {header}
+          </Heading>
+        </Flex>
+        <Heading as="h2" sx={sx.subHeadingText}>
+          {subHeading}
         </Heading>
-      </Flex>
-      <Heading as="h2" sx={sx.subHeadingText}>
-        {subHeading}
-      </Heading>
-      <Text sx={sx.descriptionText}>
-        {preLinkText}
-        <Link href={createEmailLink({ address: helpDeskEmail })} isExternal>
-          {helpDeskEmail}
-        </Link>
-        {postLinkText}
-      </Text>
-    </PageTemplate>
+        <Text sx={sx.descriptionText}>
+          {preLinkText}
+          <Link href={createEmailLink({ address: helpDeskEmail })} isExternal>
+            {helpDeskEmail}
+          </Link>
+          {postLinkText}
+        </Text>
+      </PageTemplate>
+    </>
   );
 };
 

--- a/services/ui-src/src/components/export/ExportedReportBanner.tsx
+++ b/services/ui-src/src/components/export/ExportedReportBanner.tsx
@@ -1,19 +1,22 @@
 // assets
 import pdfIcon from "assets/icons/icon_pdf_white.png";
 // components
-import { Box, Button, Image, Text } from "@chakra-ui/react";
+import { Box, Button, Image, Spinner, Text } from "@chakra-ui/react";
 // verbiage
 import mcparVerbiage from "verbiage/pages/mcpar/mcpar-export";
 import mlrVerbiage from "verbiage/pages/mlr/mlr-export";
 // utils
 import { useStore } from "utils";
 // types
-import { ReportType } from "types";
+import { ReportRoute, ReportType } from "types";
 
-export const ExportedReportBanner = () => {
+export const ExportedReportBanner = ({ error }: Props) => {
   const { report } = useStore();
   const reportType = (report?.reportType ||
     localStorage.getItem("selectedReportType")) as ReportType;
+  const routesToRender = report?.formTemplate.routes.filter(
+    (route: ReportRoute) => route
+  );
 
   const verbiageMap: { [key in ReportType]: any } = {
     MCPAR: mcparVerbiage,
@@ -31,13 +34,21 @@ export const ExportedReportBanner = () => {
   return (
     <Box data-testid="exportedReportBanner" sx={sx.container}>
       <Text>{reportBanner.intro}</Text>
-      <Button sx={sx.pdfButton} onClick={onClickHandler}>
-        <Image src={pdfIcon} w={5} alt="PDF Icon" />
-        {reportBanner.pdfButton}
-      </Button>
+      {!error && report && routesToRender ? (
+        <Button sx={sx.pdfButton} onClick={onClickHandler}>
+          <Image src={pdfIcon} w={5} alt="PDF Icon" />
+          {reportBanner.pdfButton}
+        </Button>
+      ) : (
+        <Spinner />
+      )}
     </Box>
   );
 };
+
+export interface Props {
+  error?: boolean;
+}
 
 const sx = {
   container: {

--- a/services/ui-src/src/components/export/ExportedSectionHeading.tsx
+++ b/services/ui-src/src/components/export/ExportedSectionHeading.tsx
@@ -1,5 +1,5 @@
 // components
-import { Box, Heading, Text } from "@chakra-ui/react";
+import { Box, Heading } from "@chakra-ui/react";
 // types
 import { ReportPageVerbiage } from "types";
 // utils
@@ -34,11 +34,9 @@ export const ExportedSectionHeading = ({ heading, verbiage }: Props) => {
       <Box data-testid="exportedSectionHeading" sx={sx.container}>
         {sectionInfo && (
           <Box sx={sx.info}>
-            <Text>
-              {typeof sectionInfo === "string"
-                ? sectionInfo
-                : parseCustomHtml(sectionInfo)}
-            </Text>
+            {typeof sectionInfo === "string"
+              ? sectionInfo
+              : parseCustomHtml(sectionInfo)}
           </Box>
         )}
       </Box>


### PR DESCRIPTION
### Description
The user always sees an active button to download the PDF version of the report, regardless of if the PDF has been generated. This PR addresses this issue by adding a spinner if the report has not generated, or if there is an error message.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3793

---
### How to test
Create a program, go to the review and submit, go to pdf, see that the button is a spinner if the PDF isn't generated. To see the header during an error: 

In `<ExportedSectionHeading />`, change

` <Box sx={sx.info}>
            {typeof sectionInfo === "string"
              ? sectionInfo
              : parseCustomHtml(sectionInfo)}
          </Box>
`
to 
`{sectionInfo}`

And see that the pdf banner button is now a spinner.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
