### PR TITLE
Fix audit failing when there are no orphaned topics

### DIFF
--- a/.github/audit-account.sh
+++ b/.github/audit-account.sh
@@ -85,7 +85,7 @@ get_topics () {
     TOPICS+=($(echo '{"TOPIC":"'${T}'","STAGE":"'${STAGE}'"}'))
   done
 
-  jq -s '{TOPICS:.}' <<< ${TOPICS[*]}
+  jq -s '{TOPICS:.}' <<< ${TOPICS[*]-}
 }
 
 #Produce a report with all topics and associated resource tags

--- a/.github/workflows/audit-account.yml
+++ b/.github/workflows/audit-account.yml
@@ -64,19 +64,19 @@ jobs:
           echo "Reports with no entries will be omitted"
           CI_ACTIVE="$(./audit-account.sh ci_active resources.json)"
           [[ $(jq -r 'length' <<< "${CI_ACTIVE}") -gt 0 ]] && jq -r '(.[0] 
-            | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "${CI_ACTIVE}" > reports/ci_active.csv
+            | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "${CI_ACTIVE}" > reports/ci_active.csv || :
           CI_INACTIVE="$(./audit-account.sh ci_inactive resources.json)"
           [[ $(jq -r 'length' <<< "${CI_INACTIVE}") -gt 0 ]] && jq -r '(.[0] 
-            | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "${CI_INACTIVE}" > reports/ci_inactive.csv
+            | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "${CI_INACTIVE}" > reports/ci_inactive.csv || :
           CF_OTHER="$(./audit-account.sh cf_other resources.json)"
           [[ $(jq -r 'length' <<< "${CF_OTHER}") -gt 0 ]] && jq -r '(.[0] 
-            | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "${CF_OTHER}" > reports/cf_other.csv
+            | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "${CF_OTHER}" > reports/cf_other.csv || :
           UNTAGGED="$(./audit-account.sh untagged resources.json)"
           [[ $(jq -r 'length' <<< "${UNTAGGED}") -gt 0 ]] && jq -r '(.[0] 
-            | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "${UNTAGGED}" > reports/untagged.csv
+            | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "${UNTAGGED}" > reports/untagged.csv || :
           TOPICS="$(./audit-account.sh orphaned_topics)"
           [[ $(jq -r 'length' <<< "${TOPICS}") -gt 0 ]] && jq -r '(.[0] 
-            | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "${TOPICS}" > reports/orphaned_topics.csv          
+            | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "${TOPICS}" > reports/orphaned_topics.csv || :         
       - name: Upload reports
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
### Description
This is a super simple change to keep the orphaned_topics job from causing a build failure when there are no orhpaned topics.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
No ticket, just a fix

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
See this [workflow run](https://github.com/Enterprise-CMCS/macpro-mdct-mcr/actions/runs/10165468854) for reference.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
