### PR TITLE
remove implementations of momentjs

### DIFF
--- a/services/ui-src/src/components/layout/Timeout.tsx
+++ b/services/ui-src/src/components/layout/Timeout.tsx
@@ -17,7 +17,7 @@ import {
   UserContext,
 } from "utils";
 import { PROMPT_AT, IDLE_WINDOW } from "../../constants";
-import moment from "moment";
+import { add } from "date-fns";
 
 export const Timeout = () => {
   const context = useContext(UserContext);
@@ -43,7 +43,7 @@ export const Timeout = () => {
   }, [location]);
 
   const setTimer = () => {
-    const expiration = moment().add(IDLE_WINDOW, "milliseconds");
+    const expiration = add(Date.now(), { seconds: IDLE_WINDOW / 1000 });
     if (timeoutPromptId) {
       clearTimers();
     }

--- a/services/ui-src/src/utils/auth/authLifecycle.test.tsx
+++ b/services/ui-src/src/utils/auth/authLifecycle.test.tsx
@@ -44,7 +44,7 @@ describe("Test AuthManager", () => {
     // Check that the new timestamp is updated
     const storedExpiration = getExpiration();
     expect(storedExpiration).not.toEqual(initialExpiration);
-    expect(new Date(storedExpiration!).valueOf()).toBeGreaterThanOrEqual(
+    expect(new Date(storedExpiration!).valueOf()).toBeGreaterThan(
       new Date(initialExpiration).valueOf()
     );
   });

--- a/services/ui-src/src/utils/auth/authLifecycle.tsx
+++ b/services/ui-src/src/utils/auth/authLifecycle.tsx
@@ -15,7 +15,7 @@ class AuthManager {
     // Force users with stale tokens greater than the timeout to log in for a fresh session
     const expiration = localStorage.getItem("mdctmcr_session_exp");
     const isExpired =
-      expiration && new Date(expiration).valueOf() <= Date.now().valueOf();
+      expiration && new Date(expiration).valueOf() < Date.now().valueOf();
     if (isExpired) {
       localStorage.removeItem("mdctmcr_session_exp");
       Auth.signOut().then(() => {

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -1,6 +1,5 @@
 import { utcToZonedTime, zonedTimeToUtc } from "date-fns-tz";
 import { DateShape, TimeShape } from "types";
-import moment from "moment";
 
 export const midnight: TimeShape = { hour: 0, minute: 0, second: 0 };
 export const oneSecondToMidnight: TimeShape = {
@@ -161,5 +160,5 @@ export const calculateDueDate = (date: string) => {
  */
 export const calculateRemainingSeconds = (expiresAt?: any) => {
   if (!expiresAt) return 0;
-  return moment(expiresAt).diff(moment()) / 1000;
+  return (new Date(expiresAt).valueOf() - Date.now()) / 1000;
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
see title

date-fns is a package we already had installed, and is a recommended swap for momentjs.

the moment package is a sub-dependency of `serverless-bundle`. we cannot remove it from yarn.lock, but hopefully this still resolves the issue.

References:
[Security issue](https://www.invicti.com/web-vulnerability-scanner/vulnerabilities/version-disclosure-momentjs/)
[MomentJS recommends using alternatives](https://momentjs.com/docs/#/-project-status/)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3909

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Tests pass

- Modify the values for `IDLE_WINDOW` and `PROMPT_AT` in the src/constants.ts file to be shorter (change leading values to 1 and 0.5 or something)
- Run locally
- Let the app sit until the timeout hits
  - Ensure the prompt shows up as expected
  - Ensure the prompt still does the correct actions when you click on them
  - Ensure if you don't do anything it logs you out

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
