### PR TITLE
adding slack alert for failed destroy action

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -61,3 +61,17 @@ jobs:
         run: |
           ./run destroy --stage $STAGE_PREFIX$branch_name --verify false --service app-api
           ./run destroy --stage $STAGE_PREFIX$branch_name --verify false
+
+  # Notify the integrations channel when a destroy action fails
+  notify_on_destroy_failure:
+    runs-on: ubuntu-latest
+    needs: 
+      - destroy
+    if: ${{ failure() }}
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_TITLE: ":boom: A destroy action has failed on ${{ github.repository }}."
+          MSG_MINIMAL: true
+          SLACK_WEBHOOK: ${{ secrets.INTEGRATIONS_SLACK_WEBHOOK }}


### PR DESCRIPTION
### Description
currently when the destroy action fails, it fails silently. this is to surface the destroy action failing so that when it happens we dont leave leaking infra behind and go look at why it failed .

### Related ticket(s)
https://jiraent.cms.gov/browse/CMDCT-3659

---
### How to test
when destroy fails it should alert the integrations channel


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
