### PR TITLE
CMDCT-3803: Convert EntityProvider from ContextAPI to Zustand Store

### DIFF
--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -42,13 +42,12 @@ export const ChoiceListField = ({
   const [displayValue, setDisplayValue] = useState<Choice[]>(defaultValue);
 
   const { updateReport } = useContext(ReportContext);
-  const { entities, entityType, updateEntities, selectedEntity } =
-    useContext(EntityContext);
+  const { updateEntities } = useContext(EntityContext);
 
   // state management
   const { full_name, state, userIsAdmin, userIsReadOnly } =
     useStore().user ?? {};
-  const { report } = useStore();
+  const { report, entities, entityType, selectedEntity } = useStore();
 
   // get form context and register field
   const form = useFormContext();

--- a/services/ui-src/src/components/fields/DateField.tsx
+++ b/services/ui-src/src/components/fields/DateField.tsx
@@ -33,11 +33,10 @@ export const DateField = ({
 
   // state management
   const { full_name, state } = useStore().user ?? {};
-  const { report } = useStore();
+  const { report, entities, entityType, selectedEntity } = useStore();
 
   const { updateReport } = useContext(ReportContext);
-  const { entities, entityType, updateEntities, selectedEntity } =
-    useContext(EntityContext);
+  const { updateEntities } = useContext(EntityContext);
 
   // get form context and register form field
   const form = useFormContext();

--- a/services/ui-src/src/components/fields/DropdownField.tsx
+++ b/services/ui-src/src/components/fields/DropdownField.tsx
@@ -40,12 +40,17 @@ export const DropdownField = ({
   ...props
 }: Props) => {
   const { updateReport } = useContext(ReportContext);
-  const { entities, entityType, updateEntities, selectedEntity } =
-    useContext(EntityContext);
+  const { updateEntities } = useContext(EntityContext);
 
   // state management
   const { full_name, state } = useStore().user ?? {};
-  const { report, copyEligibleReportsByState } = useStore();
+  const {
+    report,
+    copyEligibleReportsByState,
+    entities,
+    entityType,
+    selectedEntity,
+  } = useStore();
 
   // fetch the option values and format them if necessary
   const formatOptions = (options: DropdownOptions[] | string) => {

--- a/services/ui-src/src/components/fields/DynamicField.tsx
+++ b/services/ui-src/src/components/fields/DynamicField.tsx
@@ -26,11 +26,10 @@ import cancelIcon from "assets/icons/icon_cancel_x_circle.png";
 export const DynamicField = ({ name, label, ...props }: Props) => {
   // state management
   const { full_name, state, userIsEndUser } = useStore().user ?? {};
-  const { report } = useStore();
+  const { report, entities, entityType, selectedEntity } = useStore();
 
   const { updateReport } = useContext(ReportContext);
-  const { entities, entityType, updateEntities, selectedEntity } =
-    useContext(EntityContext);
+  const { updateEntities } = useContext(EntityContext);
   const [displayValues, setDisplayValues] = useState<EntityShape[]>([]);
   const [selectedRecord, setSelectedRecord] = useState<EntityShape | undefined>(
     undefined

--- a/services/ui-src/src/components/fields/NumberField.tsx
+++ b/services/ui-src/src/components/fields/NumberField.tsx
@@ -37,11 +37,10 @@ export const NumberField = ({
   const [displayValue, setDisplayValue] = useState(defaultValue);
   // state management
   const { full_name, state } = useStore().user ?? {};
-  const { report } = useStore();
+  const { report, entities, entityType, selectedEntity } = useStore();
 
   const { updateReport } = useContext(ReportContext);
-  const { entities, entityType, updateEntities, selectedEntity } =
-    useContext(EntityContext);
+  const { updateEntities } = useContext(EntityContext);
 
   // get form context and register field
   const form = useFormContext();

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -33,11 +33,10 @@ export const TextField = ({
 
   // state management
   const { full_name, state } = useStore().user ?? {};
-  const { report } = useStore();
+  const { report, entities, entityType, selectedEntity } = useStore();
 
   const { updateReport } = useContext(ReportContext);
-  const { entities, entityType, selectedEntity, updateEntities } =
-    useContext(EntityContext);
+  const { updateEntities } = useContext(EntityContext);
 
   // get form context and register field
   const form = useFormContext();

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlay.test.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlay.test.tsx
@@ -4,9 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { EntityDetailsOverlay } from "./EntityDetailsOverlay";
 // utils
 import {
-  mockAdminUserStore,
-  mockEntityDetailsContext,
-  mockMLRReportEntityStartedFieldData,
+  mockEntityStore,
   mockModalOverlayForm,
   mockStateUserStore,
   RouterWrappedComponent,
@@ -15,60 +13,42 @@ import { useStore } from "utils";
 // verbiage
 import accordionVerbiage from "../../verbiage/pages/accordion";
 import overlayVerbiage from "../../verbiage/pages/overlays";
-import { EntityContext } from "components";
 
 const mockCloseEntityDetailsOverlay = jest.fn();
 const mockOnSubmit = jest.fn();
 
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+mockedUseStore.mockReturnValue({
+  ...mockStateUserStore,
+  ...mockEntityStore,
+});
 
-const entityDetailsOverlayComponentStateUser = (
+const entityDetailsOverlayComponent = (
   <RouterWrappedComponent>
-    <EntityContext.Provider value={mockEntityDetailsContext}>
-      <EntityDetailsOverlay
-        closeEntityDetailsOverlay={mockCloseEntityDetailsOverlay}
-        entityType={"program"}
-        entities={[mockMLRReportEntityStartedFieldData.program[0]]}
-        form={mockModalOverlayForm}
-        onSubmit={mockOnSubmit}
-        disabled={false}
-        setEntering={jest.fn()}
-        selectedEntity={mockMLRReportEntityStartedFieldData.program[0]}
-      />
-    </EntityContext.Provider>
-  </RouterWrappedComponent>
-);
-
-const entityDetailsOverlayComponentAdminUser = (
-  <RouterWrappedComponent>
-    <EntityContext.Provider value={mockEntityDetailsContext}>
-      <EntityDetailsOverlay
-        closeEntityDetailsOverlay={mockCloseEntityDetailsOverlay}
-        entityType={"program"}
-        entities={[mockMLRReportEntityStartedFieldData.program[0]]}
-        form={mockModalOverlayForm}
-        onSubmit={mockOnSubmit}
-        disabled={true}
-        setEntering={jest.fn()}
-        selectedEntity={mockMLRReportEntityStartedFieldData.program[0]}
-      />
-    </EntityContext.Provider>
+    <EntityDetailsOverlay
+      closeEntityDetailsOverlay={mockCloseEntityDetailsOverlay}
+      entityType={mockEntityStore.entityType!}
+      entities={mockEntityStore.entities}
+      form={mockModalOverlayForm}
+      onSubmit={mockOnSubmit}
+      disabled={false}
+      setEntering={jest.fn()}
+      selectedEntity={mockEntityStore.selectedEntity!}
+    />
   </RouterWrappedComponent>
 );
 
 describe("Test EntityDetailsOverlayV2 (empty state)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    render(entityDetailsOverlayComponent);
   });
 
   const user = userEvent.setup();
-  const selectedEntity = mockMLRReportEntityStartedFieldData.program[0];
+  const selectedEntity = mockEntityStore.selectedEntity;
 
   it("should render the initial view for a state user", async () => {
-    mockedUseStore.mockReturnValue(mockStateUserStore);
-    render(entityDetailsOverlayComponentStateUser);
-
     // Close out of the Overlay it opened
     const closeButton = screen.getByText("Return to MLR Reporting");
     expect(closeButton).toBeVisible();
@@ -83,10 +63,12 @@ describe("Test EntityDetailsOverlayV2 (empty state)", () => {
     expect(screen.getByText(accordionHeader)).toBeVisible();
 
     // Check if MLR Report For is showing the correct Entity Data
-    const reportPlanName = selectedEntity.report_planName;
-    const reportProgramName = selectedEntity.report_programName;
-    const eligibilityGroup = selectedEntity.report_eligibilityGroup[0].value;
-    const reportingPeriod = `${selectedEntity.report_reportingPeriodStartDate} to ${selectedEntity.report_reportingPeriodEndDate}`;
+    const reportPlanName = selectedEntity!.report_planName;
+    const reportProgramName = selectedEntity!.report_programName;
+    const eligibilityGroup = selectedEntity!.report_eligibilityGroup[0].value;
+    const reportingPeriod = `${
+      selectedEntity!.report_reportingPeriodStartDate
+    } to ${selectedEntity!.report_reportingPeriodEndDate}`;
 
     expect(screen.getByText(reportPlanName)).toBeVisible();
     expect(screen.getByText(reportProgramName)).toBeVisible();
@@ -98,55 +80,7 @@ describe("Test EntityDetailsOverlayV2 (empty state)", () => {
     expect(saveAndReturn).toBeVisible();
   });
 
-  it("should render the initial view for an admin", async () => {
-    mockedUseStore.mockReturnValue(mockAdminUserStore);
-    render(entityDetailsOverlayComponentAdminUser);
-
-    // Close out of the Overlay it opened
-    const closeButton = screen.getByText("Return to MLR Reporting");
-    expect(closeButton).toBeVisible();
-
-    // Check if header is visible on load - H2
-    expect(
-      screen.getByText(overlayVerbiage.MLR.intro.subsection)
-    ).toBeVisible();
-
-    // Check if accordion is showing
-    const accordionHeader = accordionVerbiage.MLR.formIntro.buttonLabel;
-    expect(screen.getByText(accordionHeader)).toBeVisible();
-
-    // Check if MLR Report For is showing the correct Entity Data
-    const reportPlanName = selectedEntity.report_planName;
-    const reportProgramName = selectedEntity.report_programName;
-    const eligibilityGroup = selectedEntity.report_eligibilityGroup[0].value;
-    const reportingPeriod = `${selectedEntity.report_reportingPeriodStartDate} to ${selectedEntity.report_reportingPeriodEndDate}`;
-
-    expect(screen.getByText(reportPlanName)).toBeVisible();
-    expect(screen.getByText(reportProgramName)).toBeVisible();
-    expect(screen.getByText(eligibilityGroup)).toBeVisible();
-    expect(screen.getByText(reportingPeriod)).toBeVisible();
-
-    // Make sure footer button appears correctly for admins
-    const returnButton = screen.getByText("Return");
-    expect(returnButton).toBeVisible();
-  });
-
   it("should call the close overlay function when clicking Return to MLR", async () => {
-    // Set as State User
-    mockedUseStore.mockReturnValue(mockStateUserStore);
-    render(entityDetailsOverlayComponentStateUser);
-
-    // Close out of the Overlay it opened
-    const closeButton = screen.getByText("Return to MLR Reporting");
-    await user.click(closeButton);
-    expect(mockCloseEntityDetailsOverlay).toBeCalled();
-  });
-
-  it("should call the close overlay function when clicking Return to MLR as an Admin", async () => {
-    // Set as State User
-    mockedUseStore.mockReturnValue(mockAdminUserStore);
-    render(entityDetailsOverlayComponentAdminUser);
-
     // Close out of the Overlay it opened
     const closeButton = screen.getByText("Return to MLR Reporting");
     await user.click(closeButton);

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlay.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlay.tsx
@@ -1,17 +1,16 @@
-import React, { MouseEventHandler, useContext, useEffect } from "react";
+import React, { MouseEventHandler, useEffect } from "react";
 // components
 import { Box, Button, Flex, Image, Spinner, Text } from "@chakra-ui/react";
 import { Form, ReportPageIntro } from "components";
 // types
 import { EntityShape, EntityType, FormJson } from "types";
 // utils
-
+import { useStore } from "utils";
 // assets
 import arrowLeftBlue from "assets/icons/icon_arrow_left_blue.png";
 // verbiage
 import accordionVerbiage from "../../verbiage/pages/accordion";
 import overlayVerbiage from "../../verbiage/pages/overlays";
-import { EntityContext } from "components/reports/EntityProvider";
 
 export const EntityDetailsOverlay = ({
   closeEntityDetailsOverlay,
@@ -26,8 +25,7 @@ export const EntityDetailsOverlay = ({
   validateOnRender,
 }: Props) => {
   // Entity Provider Setup
-  const { setEntities, setSelectedEntity, setEntityType } =
-    useContext(EntityContext);
+  const { setEntities, setSelectedEntity, setEntityType } = useStore();
 
   useEffect(() => {
     setSelectedEntity(selectedEntity);

--- a/services/ui-src/src/components/reports/EntityProvider.test.tsx
+++ b/services/ui-src/src/components/reports/EntityProvider.test.tsx
@@ -27,7 +27,7 @@ interface Props {
 }
 
 const TestComponent = (props: Props) => {
-  const { entities, setEntities, updateEntities, setSelectedEntity } =
+  const { setEntities, updateEntities, setSelectedEntity } =
     useContext(EntityContext);
 
   useEffect(() => {
@@ -42,8 +42,8 @@ const TestComponent = (props: Props) => {
       <button onClick={() => updateEntities({ test: "update" })}>
         Update Entities
       </button>
-      <p id="entities">{JSON.stringify(entities)}</p>
-      <p>{entities.length}</p>
+      <p id="entities">{JSON.stringify(testEntities)}</p>
+      <p>{testEntities.length}</p>
     </div>
   );
 };

--- a/services/ui-src/src/components/reports/EntityProvider.tsx
+++ b/services/ui-src/src/components/reports/EntityProvider.tsx
@@ -1,15 +1,16 @@
-import { ReactNode, useMemo, useState, createContext } from "react";
-import { EntityType, EntityShape } from "types";
+import { ReactNode, useMemo, createContext } from "react";
+// types
+import { EntityShape } from "types";
+// utils
+import { useStore } from "utils";
+
+// CONTEXT DECLARATION
 
 interface EntityContextShape {
   updateEntities: Function;
   setEntities: Function;
   setSelectedEntity: Function;
   setEntityType: Function;
-  entityType?: EntityType;
-  entityId?: string;
-  entities: EntityShape[];
-  selectedEntity?: EntityShape;
 }
 
 export const EntityContext = createContext<EntityContextShape>({
@@ -17,10 +18,6 @@ export const EntityContext = createContext<EntityContextShape>({
   setEntities: Function,
   setSelectedEntity: Function,
   setEntityType: Function,
-  entityType: undefined,
-  entityId: undefined,
-  entities: [],
-  selectedEntity: undefined,
 });
 
 /**
@@ -33,9 +30,15 @@ export const EntityContext = createContext<EntityContextShape>({
  * @param children - React nodes
  */
 export const EntityProvider = ({ children }: EntityProviderProps) => {
-  const [selectedEntity, setSelectedEntity] = useState<EntityShape>();
-  const [entityType, setEntityType] = useState<EntityType>();
-  const [entities, setEntities] = useState<EntityShape[]>([]);
+  // state management
+  const {
+    selectedEntity,
+    entityType,
+    entities,
+    setSelectedEntity,
+    setEntityType,
+    setEntities,
+  } = useStore();
 
   /**
    * updateEntities updates the user's selected entity with their changes, and
@@ -48,9 +51,8 @@ export const EntityProvider = ({ children }: EntityProviderProps) => {
    */
   const updateEntities = (updateData: EntityShape) => {
     const currentEntities = entities;
-    const selectedEntityIndex = currentEntities?.findIndex(
-      (x) => x.id === selectedEntity?.id
-    );
+    const selectedEntityIndex =
+      currentEntities?.findIndex((x) => x.id === selectedEntity?.id) ?? -1;
     if (currentEntities && selectedEntityIndex > -1) {
       const newEntity = {
         ...currentEntities[selectedEntityIndex],
@@ -58,19 +60,23 @@ export const EntityProvider = ({ children }: EntityProviderProps) => {
       };
       currentEntities[selectedEntityIndex] = newEntity;
     }
+
     return currentEntities;
   };
 
   const providerValue = useMemo(
     () => ({
-      updateEntities,
-      setSelectedEntity,
-      setEntities,
-      selectedEntity,
+      // entities
       entities,
+      setEntities,
+      updateEntities,
+      // selected entity
+      selectedEntity,
+      entityId: selectedEntity?.id,
+      setSelectedEntity,
+      // entity type
       setEntityType,
       entityType,
-      entityId: selectedEntity?.id,
     }),
     [entities, selectedEntity]
   );

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.test.tsx
@@ -2,11 +2,7 @@ import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 // components
-import {
-  EntityProvider,
-  ModalOverlayReportPage,
-  ReportProvider,
-} from "components";
+import { ModalOverlayReportPage, ReportProvider } from "components";
 // utils
 import {
   RouterWrappedComponent,
@@ -17,6 +13,7 @@ import {
   mockMlrReportStore,
   mockMLRReportEntityStartedFieldData,
   mockEmptyReportStore,
+  mockEntityStore,
 } from "utils/testing/setupJest";
 import { UserProvider, useStore } from "utils";
 // verbiage
@@ -25,6 +22,7 @@ import accordionVerbiage from "../../verbiage/pages/accordion";
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 const mockMlrEntityStartedStore = {
+  ...mockEntityStore,
   ...mockMlrReportStore,
   report: {
     ...mockMlrReportStore.report,
@@ -34,7 +32,7 @@ const mockMlrEntityStartedStore = {
 
 const mockSetSidebarHidden = jest.fn();
 
-const modalOverlayReportPageInitialComponent = (
+const modalOverlayReportPageComponent = (
   <RouterWrappedComponent>
     <UserProvider>
       <ReportProvider>
@@ -42,21 +40,6 @@ const modalOverlayReportPageInitialComponent = (
           route={mockModalOverlayReportPageWithOverlayJson}
           setSidebarHidden={mockSetSidebarHidden}
         />
-      </ReportProvider>
-    </UserProvider>
-  </RouterWrappedComponent>
-);
-
-const modalOverlayReportPageEntityAddedComponent = (
-  <RouterWrappedComponent>
-    <UserProvider>
-      <ReportProvider>
-        <EntityProvider>
-          <ModalOverlayReportPage
-            route={mockModalOverlayReportPageWithOverlayJson}
-            setSidebarHidden={mockSetSidebarHidden}
-          />
-        </EntityProvider>
       </ReportProvider>
     </UserProvider>
   </RouterWrappedComponent>
@@ -74,7 +57,7 @@ describe("Test ModalOverlayReportPage (empty state)", () => {
       ...mockStateUserStore,
       ...mockEmptyReportStore,
     });
-    render(modalOverlayReportPageInitialComponent);
+    render(modalOverlayReportPageComponent);
 
     // Check if header is visible on load - H1
     expect(screen.getByText(verbiage.intro.section)).toBeVisible();
@@ -109,7 +92,7 @@ describe("Test ModalOverlayReportPage (empty state)", () => {
     });
 
     await act(async () => {
-      render(modalOverlayReportPageInitialComponent);
+      render(modalOverlayReportPageComponent);
     });
 
     const user = userEvent.setup();
@@ -132,7 +115,7 @@ describe("Test ModalOverlayReportPage (empty state)", () => {
     });
 
     await act(async () => {
-      render(modalOverlayReportPageInitialComponent);
+      render(modalOverlayReportPageComponent);
     });
 
     // Check if header is visible on load - H1
@@ -172,6 +155,7 @@ describe("Test ModalOverlayReportPage (Entities Added State)", () => {
     mockedUseStore.mockReturnValue({
       ...mockStateUserStore,
       ...mockMlrEntityStartedStore,
+      ...mockEntityStore,
     });
   });
 
@@ -179,7 +163,7 @@ describe("Test ModalOverlayReportPage (Entities Added State)", () => {
 
   it("should render the initial view for a State user", async () => {
     await act(async () => {
-      render(modalOverlayReportPageEntityAddedComponent);
+      render(modalOverlayReportPageComponent);
     });
     // Check if header is visible on load - H1
     expect(screen.getByText(verbiage.intro.section)).toBeVisible();
@@ -215,7 +199,7 @@ describe("Test ModalOverlayReportPage (Entities Added State)", () => {
 
   it("should open the edit modal", async () => {
     await act(async () => {
-      render(modalOverlayReportPageEntityAddedComponent);
+      render(modalOverlayReportPageComponent);
     });
 
     const user = userEvent.setup();
@@ -236,7 +220,7 @@ describe("Test ModalOverlayReportPage (Entities Added State)", () => {
 
   it("should open and close the delete modal as a State user", async () => {
     await act(async () => {
-      render(modalOverlayReportPageEntityAddedComponent);
+      render(modalOverlayReportPageComponent);
     });
 
     const user = userEvent.setup();
@@ -280,7 +264,7 @@ describe("Test ModalOverlayReportPage (Entities Added State)", () => {
     });
 
     await act(async () => {
-      render(modalOverlayReportPageEntityAddedComponent);
+      render(modalOverlayReportPageComponent);
     });
 
     // Verify the entity exists
@@ -299,7 +283,7 @@ describe("Test ModalOverlayReportPage (Entities Added State)", () => {
 
   it("should open and close the overlay page as a State user", async () => {
     await act(async () => {
-      render(modalOverlayReportPageEntityAddedComponent);
+      render(modalOverlayReportPageComponent);
     });
 
     const user = userEvent.setup();
@@ -331,7 +315,7 @@ describe("Test ModalOverlayReportPage (Entities Added State)", () => {
     });
 
     await act(async () => {
-      render(modalOverlayReportPageEntityAddedComponent);
+      render(modalOverlayReportPageComponent);
     });
 
     const user = userEvent.setup();
@@ -371,7 +355,7 @@ describe("Test ModalOverlayReportPage (Entities Added State)", () => {
     });
 
     await act(async () => {
-      render(modalOverlayReportPageEntityAddedComponent);
+      render(modalOverlayReportPageComponent);
     });
 
     const user = userEvent.setup();
@@ -401,7 +385,7 @@ describe("Test ModalOverlayReportPage (Entities Added State)", () => {
 describe("Test ModalOverlayReportPage accessibility", () => {
   it("Should not have basic accessibility issues", async () => {
     await act(async () => {
-      const { container } = render(modalOverlayReportPageInitialComponent);
+      const { container } = render(modalOverlayReportPageComponent);
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });
@@ -409,7 +393,7 @@ describe("Test ModalOverlayReportPage accessibility", () => {
 
   it("Should not have basic accessibility issues", async () => {
     await act(async () => {
-      const { container } = render(modalOverlayReportPageEntityAddedComponent);
+      const { container } = render(modalOverlayReportPageComponent);
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });

--- a/services/ui-src/src/types/states.ts
+++ b/services/ui-src/src/types/states.ts
@@ -1,5 +1,7 @@
 import {
   AdminBannerData,
+  EntityShape,
+  EntityType,
   ErrorVerbiage,
   MCRUser,
   ReportMetadataShape,
@@ -52,4 +54,16 @@ export interface McrReportState {
     newCopyEligibleReportsByState: ReportMetadataShape[] | undefined
   ) => void;
   setLastSavedTime: (lastSavedTime: string | undefined) => void;
+}
+
+// initial entity state
+export interface McrEntityState {
+  // INITIAL STATE
+  selectedEntity: EntityShape | undefined;
+  entityType: EntityType | undefined;
+  entities: EntityShape[] | undefined;
+  // ACTIONS
+  setSelectedEntity: (newSelectedEntity: EntityShape | undefined) => void;
+  setEntityType: (newEntityType: EntityType | undefined) => void;
+  setEntities: (newEntities: EntityShape[] | undefined) => void;
 }

--- a/services/ui-src/src/utils/autosave/autosave.ts
+++ b/services/ui-src/src/utils/autosave/autosave.ts
@@ -41,7 +41,7 @@ export interface GetAutosaveFieldsProps extends AutosaveField {
  */
 export interface EntityContextShape {
   selectedEntity?: EntityShape;
-  entities: EntityShape[];
+  entities?: EntityShape[];
   entityType?: EntityType;
   updateEntities: Function;
 }

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -4,7 +4,10 @@ import { devtools, persist } from "zustand/middleware";
 import {
   AdminBannerData,
   AdminBannerState,
+  EntityShape,
+  EntityType,
   ErrorVerbiage,
+  McrEntityState,
   McrReportState,
   MCRUser,
   McrUserState,
@@ -89,14 +92,38 @@ const reportStore = (set: Function) => ({
     }),
 });
 
+// ENTITY STORE
+const entityStore = (set: Function) => ({
+  // initial state
+  selectedEntity: undefined,
+  entityType: undefined,
+  entities: undefined,
+  // actions
+  setSelectedEntity: (newSelectedEntity: EntityShape | undefined) =>
+    set(() => ({ selectedEntity: newSelectedEntity }), false, {
+      type: "setSelectedEntity",
+    }),
+  setEntityType: (newEntityType: EntityType | undefined) =>
+    set(() => ({ entityType: newEntityType }), false, {
+      type: "setEntityType",
+    }),
+  setEntities: (newEntities: EntityShape[] | undefined) =>
+    set(() => ({ entities: newEntities }), false, {
+      type: "setEntities",
+    }),
+});
+
 export const useStore = create(
   // persist and devtools are being used for debugging state
   persist(
-    devtools<McrUserState & AdminBannerState & McrReportState>((set) => ({
-      ...userStore(set),
-      ...bannerStore(set),
-      ...reportStore(set),
-    })),
+    devtools<McrUserState & AdminBannerState & McrReportState & McrEntityState>(
+      (set) => ({
+        ...userStore(set),
+        ...bannerStore(set),
+        ...reportStore(set),
+        ...entityStore(set),
+      })
+    ),
     {
       name: "mcr-store",
       partialize: (state) => ({ report: state.report }),

--- a/services/ui-src/src/utils/testing/mockReport.tsx
+++ b/services/ui-src/src/utils/testing/mockReport.tsx
@@ -593,6 +593,13 @@ export const mockReportMethods = {
   contextIsLoaded: true,
 };
 
+export const mockEntityMethods = {
+  updateEntities: jest.fn(),
+  setEntities: jest.fn(),
+  setSelectedEntity: jest.fn(),
+  setEntityType: jest.fn(),
+};
+
 export const mockMcparReportContext = {
   ...mockReportMethods,
   report: mockMcparReport,
@@ -628,13 +635,10 @@ export const mockMLREntityStartedReportContext = {
 };
 
 export const mockEntityDetailsContext = {
+  ...mockEntityMethods,
   selectedEntity: undefined,
   entities: [],
   entityType: "program" as EntityType,
-  updateEntities: jest.fn(),
-  setEntities: jest.fn(),
-  setSelectedEntity: jest.fn(),
-  setEntityType: jest.fn(),
 };
 
 export const mockMLRLockedReportContext = {

--- a/services/ui-src/src/utils/testing/mockZustand.tsx
+++ b/services/ui-src/src/utils/testing/mockZustand.tsx
@@ -9,6 +9,8 @@ import {
 // types
 import {
   AdminBannerState,
+  entityTypes,
+  McrEntityState,
   McrReportState,
   McrUserState,
   UserRoles,
@@ -163,6 +165,36 @@ export const mockEmptyReportStore: McrReportState = {
   setLastSavedTime: () => {},
 };
 
+// ENTITY STATES / STORE
+export const mockEntityStore: McrEntityState = {
+  entities: [],
+  entityType: entityTypes[0],
+  selectedEntity: {
+    id: "mock-plan-id-1",
+    type: entityTypes[0],
+    report_planName: "mock-plan",
+    report_programName: "mock-programName",
+    report_programType: [
+      {
+        key: "report-programType-mock",
+        value: "mock value",
+      },
+    ],
+    report_eligibilityGroup: [
+      {
+        key: "report-eligibilityGroup-mock",
+        value: "mock value",
+      },
+    ],
+    report_reportingPeriodStartDate: "11/11/2011",
+    report_reportingPeriodEndDate: "11/11/2011",
+  },
+  // ACTIONS
+  setSelectedEntity: () => {},
+  setEntityType: () => {},
+  setEntities: () => {},
+};
+
 // BOUND STORE
 
 export const mockUseStore: McrUserState & AdminBannerState & McrReportState = {
@@ -171,4 +203,5 @@ export const mockUseStore: McrUserState & AdminBannerState & McrReportState = {
   ...mockMcparReportStore,
   ...mockMlrReport,
   ...mockEmptyReportStore,
+  ...mockEntityStore,
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This covers the final state management updates for MCR, updating the `EntityProvider` to use the Zustand store instead of `ContextAPI`

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3803

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
This will be easier for you if you've got the [redux-devtools](https://github.com/reduxjs/redux-devtools) plugin installed, _but_ if you do not you can still look at the data locally. I'll fill you in 💯 

- Log in as a state user
- Create an MLR report
- Fill in that report

To verify that the `fieldData` is being saved correctly for entities (in this case the entity type is `program`), you'll need to either open up Redux DevTools:

<img width="427" alt="Screenshot 2024-09-10 at 3 37 36 PM" src="https://github.com/user-attachments/assets/90ef956a-605b-4ae1-8614-5434d3af661b">

...or you can also check the field data locally:

<img width="201" alt="Screenshot 2024-09-10 at 3 34 39 PM" src="https://github.com/user-attachments/assets/cd9f9b47-8265-4d2b-ae89-a060a5019fe8">

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
