### PR TITLE
fix scss deprecation warning

### DIFF
--- a/services/ui-src/src/styles/index.scss
+++ b/services/ui-src/src/styles/index.scss
@@ -36,13 +36,13 @@ li::marker {
 
 a {
   color: var(--chakra-colors-palette-white);
+  transition: all 0.3s ease !important;
   &:hover {
     color: var(--chakra-colors-palette-gray_light);
   }
   &:visited {
     color: inherit;
   }
-  transition: all 0.3s ease !important;
 }
 
 // USA BANNER STYLES


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Running MCR locally we get this deprecation warning
```
           ui| DEPRECATION WARNING: Sass's behavior for declarations that appear after nested
           ui| rules will be changing to match the behavior specified by CSS in an upcoming
           ui| version. To keep the existing behavior, move the declaration above the nested
           ui| rule. To opt into the new behavior, wrap the declaration in `& {}`.
           ui|
           ui| More info: https://sass-lang.com/d/mixed-decls
           ui|
           ui|    ╷
           ui| 42 │ ┌   &:visited {
           ui| 43 │ │     color: inherit;
           ui| 44 │ │   }
           ui|    │ └─── nested rule
           ui| 45 │     transition: all 0.3s ease !important;
           ui|    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
           ui|    ╵
           ui|     src/styles/index.scss 45:3  root stylesheet
```

As per the warning I moved the transition styling above the nested rules and the warning is gone

Fix first [applied in MFP](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/765)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-none

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Run locally
- Verify this warning does not show up (it's usually the last thing from the `ui` logs)
- Verify that when you hover links they transition to the darker color in the same time
  - If you want you can play around with the time value and verify it affects the link color transition time

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment
