### PR TITLE
refactor api response pattern

### DIFF
--- a/services/app-api/handlers/banners/create.test.ts
+++ b/services/app-api/handlers/banners/create.test.ts
@@ -2,16 +2,18 @@ import { createBanner } from "./create";
 import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
 import { mockClient } from "aws-sdk-client-mock";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
 // utils
 import { error } from "../../utils/constants/constants";
 import { proxyEvent } from "../../utils/testing/proxyEvent";
+import { StatusCodes } from "../../utils/responses/response-lib";
+import { hasPermissions } from "../../utils/auth/authorization";
 
 const dynamoClientMock = mockClient(DynamoDBDocumentClient);
 
 jest.mock("../../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
-  hasPermissions: jest.fn().mockReturnValueOnce(false).mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
+  hasPermissions: jest.fn().mockReturnValue(true),
 }));
 
 const testEvent: APIGatewayProxyEvent = {
@@ -38,9 +40,10 @@ const consoleSpy: {
 
 describe("Test createBanner API method", () => {
   test("Test unauthorized banner creation throws 403 error", async () => {
+    (hasPermissions as jest.Mock).mockReturnValueOnce(false);
     const res = await createBanner(testEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(StatusCodes.Forbidden);
     expect(res.body).toContain(error.UNAUTHORIZED);
   });
 
@@ -49,7 +52,7 @@ describe("Test createBanner API method", () => {
     dynamoClientMock.on(PutCommand).callsFake(mockPut);
     const res = await createBanner(testEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.CREATED);
+    expect(res.statusCode).toBe(StatusCodes.Created);
     expect(res.body).toContain("test banner");
     expect(res.body).toContain("test description");
     expect(mockPut).toHaveBeenCalled();
@@ -57,29 +60,26 @@ describe("Test createBanner API method", () => {
 
   test("Test invalid data causes failure", async () => {
     const res = await createBanner(testEventWithInvalidData, null);
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SERVER_ERROR);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
   });
 
-  test("Test bannerKey not provided throws 500 error", async () => {
+  test("Test bannerKey not provided throws 400 error", async () => {
     const noKeyEvent: APIGatewayProxyEvent = {
       ...testEvent,
       pathParameters: {},
     };
     const res = await createBanner(noKeyEvent, null);
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 
-  test("Test bannerKey empty throws 500 error", async () => {
+  test("Test bannerKey empty throws 400 error", async () => {
     const noKeyEvent: APIGatewayProxyEvent = {
       ...testEvent,
       pathParameters: { bannerId: "" },
     };
     const res = await createBanner(noKeyEvent, null);
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 });

--- a/services/app-api/handlers/banners/create.test.ts
+++ b/services/app-api/handlers/banners/create.test.ts
@@ -39,6 +39,9 @@ const consoleSpy: {
 };
 
 describe("Test createBanner API method", () => {
+  beforeEach(() => {
+    dynamoClientMock.reset();
+  });
   test("Test unauthorized banner creation throws 403 error", async () => {
     (hasPermissions as jest.Mock).mockReturnValueOnce(false);
     const res = await createBanner(testEvent, null);
@@ -56,6 +59,13 @@ describe("Test createBanner API method", () => {
     expect(res.body).toContain("test banner");
     expect(res.body).toContain("test description");
     expect(mockPut).toHaveBeenCalled();
+  });
+
+  test("Test dynamo issue throws error", async () => {
+    dynamoClientMock.on(PutCommand).rejectsOnce("error with dynamo");
+    const res = await createBanner(testEvent, null);
+    expect(res.statusCode).toBe(StatusCodes.InternalServerError);
+    expect(res.body).toContain(error.DYNAMO_CREATION_ERROR);
   });
 
   test("Test invalid data causes failure", async () => {

--- a/services/app-api/handlers/banners/create.ts
+++ b/services/app-api/handlers/banners/create.ts
@@ -5,51 +5,61 @@ import dynamoDb from "../../utils/dynamo/dynamodb-lib";
 import { hasPermissions } from "../../utils/auth/authorization";
 import { validateData } from "../../utils/validation/validation";
 import { error } from "../../utils/constants/constants";
+import {
+  badRequest,
+  created,
+  forbidden,
+  internalServerError,
+} from "../../utils/responses/response-lib";
 // types
-import { StatusCodes, UserRoles } from "../../utils/types";
+import { UserRoles } from "../../utils/types";
+
+const validationSchema = yup.object().shape({
+  key: yup.string().required(),
+  title: yup.string().required(),
+  description: yup.string().required(),
+  link: yup.string().url().notRequired(),
+  startDate: yup.number().required(),
+  endDate: yup.number().required(),
+});
 
 export const createBanner = handler(async (event, _context) => {
   if (!hasPermissions(event, [UserRoles.ADMIN])) {
-    return {
-      status: StatusCodes.UNAUTHORIZED,
-      body: error.UNAUTHORIZED,
-    };
-  } else if (!event?.pathParameters?.bannerId!) {
-    throw new Error(error.NO_KEY);
-  } else {
-    const unvalidatedPayload = JSON.parse(event!.body!);
-
-    const validationSchema = yup.object().shape({
-      key: yup.string().required(),
-      title: yup.string().required(),
-      description: yup.string().required(),
-      link: yup.string().url().notRequired(),
-      startDate: yup.number().required(),
-      endDate: yup.number().required(),
-    });
-
-    const validatedPayload = await validateData(
-      validationSchema,
-      unvalidatedPayload
-    );
-
-    if (validatedPayload) {
-      const params = {
-        TableName: process.env.BANNER_TABLE_NAME!,
-        Item: {
-          key: event.pathParameters.bannerId,
-          createdAt: Date.now(),
-          lastAltered: Date.now(),
-          lastAlteredBy: event?.headers["cognito-identity-id"],
-          title: validatedPayload.title,
-          description: validatedPayload.description,
-          link: validatedPayload.link,
-          startDate: validatedPayload.startDate,
-          endDate: validatedPayload.endDate,
-        },
-      };
-      await dynamoDb.put(params);
-      return { status: StatusCodes.CREATED, body: params };
-    }
+    return forbidden(error.UNAUTHORIZED);
   }
+  if (!event?.pathParameters?.bannerId!) {
+    return badRequest(error.NO_KEY);
+  }
+  const unvalidatedPayload = JSON.parse(event.body!);
+
+  let validatedPayload;
+  try {
+    validatedPayload = await validateData(validationSchema, unvalidatedPayload);
+  } catch {
+    return badRequest(error.INVALID_DATA);
+  }
+
+  const { title, description, link, startDate, endDate } = validatedPayload;
+  const currentTime = Date.now();
+
+  const params = {
+    TableName: process.env.BANNER_TABLE_NAME!,
+    Item: {
+      key: event.pathParameters.bannerId,
+      createdAt: currentTime,
+      lastAltered: currentTime,
+      lastAlteredBy: event?.headers["cognito-identity-id"],
+      title,
+      description,
+      link,
+      startDate,
+      endDate,
+    },
+  };
+  try {
+    await dynamoDb.put(params);
+  } catch {
+    return internalServerError(error.DYNAMO_CREATION_ERROR);
+  }
+  return created(params);
 });

--- a/services/app-api/handlers/banners/delete.test.ts
+++ b/services/app-api/handlers/banners/delete.test.ts
@@ -4,14 +4,16 @@ import { mockClient } from "aws-sdk-client-mock";
 // utils
 import { proxyEvent } from "../../utils/testing/proxyEvent";
 import { error } from "../../utils/constants/constants";
+import { hasPermissions } from "../../utils/auth/authorization";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
+import { StatusCodes } from "../../utils/responses/response-lib";
 
 const dynamoClientMock = mockClient(DynamoDBDocumentClient);
 
 jest.mock("../../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
-  hasPermissions: jest.fn().mockReturnValueOnce(false).mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
+  hasPermissions: jest.fn().mockReturnValue(true),
 }));
 
 const testEvent: APIGatewayProxyEvent = {
@@ -30,10 +32,11 @@ const consoleSpy: {
 
 describe("Test deleteBanner API method", () => {
   test("Test not authorized to delete banner throws 403 error", async () => {
+    (hasPermissions as jest.Mock).mockReturnValueOnce(false);
     const res = await deleteBanner(testEvent, null);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(StatusCodes.Forbidden);
     expect(res.body).toContain(error.UNAUTHORIZED);
   });
 
@@ -43,32 +46,29 @@ describe("Test deleteBanner API method", () => {
     const res = await deleteBanner(testEvent, null);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
-    expect(res.body).toContain("testKey");
+    expect(res.statusCode).toBe(StatusCodes.Ok);
     expect(mockDelete).toHaveBeenCalled();
   });
 
-  test("Test bannerKey not provided throws 500 error", async () => {
+  test("Test bannerKey not provided throws 400 error", async () => {
     const noKeyEvent: APIGatewayProxyEvent = {
       ...testEvent,
       pathParameters: {},
     };
     const res = await deleteBanner(noKeyEvent, null);
 
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 
-  test("Test bannerKey empty throws 500 error", async () => {
+  test("Test bannerKey empty throws 400 error", async () => {
     const noKeyEvent: APIGatewayProxyEvent = {
       ...testEvent,
       pathParameters: { bannerId: "" },
     };
     const res = await deleteBanner(noKeyEvent, null);
 
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 });

--- a/services/app-api/handlers/banners/delete.ts
+++ b/services/app-api/handlers/banners/delete.ts
@@ -3,25 +3,23 @@ import handler from "../handler-lib";
 import dynamoDb from "../../utils/dynamo/dynamodb-lib";
 import { hasPermissions } from "../../utils/auth/authorization";
 import { error } from "../../utils/constants/constants";
+import { badRequest, forbidden, ok } from "../../utils/responses/response-lib";
 // types
-import { StatusCodes, UserRoles } from "../../utils/types";
+import { UserRoles } from "../../utils/types";
 
 export const deleteBanner = handler(async (event, _context) => {
   if (!hasPermissions(event, [UserRoles.ADMIN])) {
-    return {
-      status: StatusCodes.UNAUTHORIZED,
-      body: error.UNAUTHORIZED,
-    };
-  } else if (!event?.pathParameters?.bannerId!) {
-    throw new Error(error.NO_KEY);
-  } else {
-    const params = {
-      TableName: process.env.BANNER_TABLE_NAME!,
-      Key: {
-        key: event?.pathParameters?.bannerId!,
-      },
-    };
-    await dynamoDb.delete(params);
-    return { status: StatusCodes.SUCCESS, body: params };
+    return forbidden(error.UNAUTHORIZED);
   }
+  if (!event?.pathParameters?.bannerId!) {
+    return badRequest(error.NO_KEY);
+  }
+  const params = {
+    TableName: process.env.BANNER_TABLE_NAME!,
+    Key: {
+      key: event.pathParameters.bannerId,
+    },
+  };
+  await dynamoDb.delete(params);
+  return ok();
 });

--- a/services/app-api/handlers/banners/fetch.test.ts
+++ b/services/app-api/handlers/banners/fetch.test.ts
@@ -6,12 +6,13 @@ import { proxyEvent } from "../../utils/testing/proxyEvent";
 import { error } from "../../utils/constants/constants";
 import { mockBannerResponse } from "../../utils/testing/setupJest";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
+import { StatusCodes } from "../../utils/responses/response-lib";
 
 const dynamoClientMock = mockClient(DynamoDBDocumentClient);
 
 jest.mock("../../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   hasPermissions: jest.fn().mockReturnValue(true),
 }));
 
@@ -43,7 +44,7 @@ describe("Test fetchBanner API method", () => {
     });
     const res = await fetchBanner(testEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
   });
 
   test("Test Successful Banner Fetch", async () => {
@@ -53,32 +54,30 @@ describe("Test fetchBanner API method", () => {
     const res = await fetchBanner(testEvent, null);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
     expect(res.body).toContain("testDesc");
     expect(res.body).toContain("testTitle");
   });
 
-  test("Test bannerKey not provided throws 500 error", async () => {
+  test("Test bannerKey not provided throws 400 error", async () => {
     const noKeyEvent: APIGatewayProxyEvent = {
       ...testEvent,
       pathParameters: {},
     };
     const res = await fetchBanner(noKeyEvent, null);
 
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SERVER_ERROR);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 
-  test("Test bannerKey empty throws 500 error", async () => {
+  test("Test bannerKey empty throws 400 error", async () => {
     const noKeyEvent: APIGatewayProxyEvent = {
       ...testEvent,
       pathParameters: { bannerId: "" },
     };
     const res = await fetchBanner(noKeyEvent, null);
 
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SERVER_ERROR);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 });

--- a/services/app-api/handlers/banners/fetch.ts
+++ b/services/app-api/handlers/banners/fetch.ts
@@ -1,22 +1,20 @@
 import handler from "../handler-lib";
 import dynamoDb from "../../utils/dynamo/dynamodb-lib";
-// types
-import { StatusCodes } from "../../utils/types";
 // utils
 import { error } from "../../utils/constants/constants";
+import { badRequest, ok } from "../../utils/responses/response-lib";
 
 export const fetchBanner = handler(async (event, _context) => {
   if (!event?.pathParameters?.bannerId!) {
-    throw new Error(error.NO_KEY);
+    return badRequest(error.NO_KEY);
   }
   const params = {
     TableName: process.env.BANNER_TABLE_NAME!,
     Key: {
-      key: event?.pathParameters?.bannerId!,
+      key: event.pathParameters.bannerId,
     },
   };
   const response = await dynamoDb.get(params);
 
-  const status = StatusCodes.SUCCESS;
-  return { status: status, body: response };
+  return ok(response);
 });

--- a/services/app-api/handlers/reports/archive.test.ts
+++ b/services/app-api/handlers/reports/archive.test.ts
@@ -115,4 +115,21 @@ describe("Test archiveReport method", () => {
     expect(res.statusCode).toBe(StatusCodes.Forbidden);
     expect(res.body).toContain(error.UNAUTHORIZED);
   });
+
+  test("Test dynamo put issue throws error", async () => {
+    mockAuthUtil.hasPermissions.mockReturnValue(true);
+    mockedFetchReport.mockResolvedValue({
+      statusCode: 200,
+      headers: {
+        "Access-Control-Allow-Origin": "string",
+        "Access-Control-Allow-Credentials": true,
+      },
+      body: JSON.stringify(mockMcparReport),
+    });
+    const dynamoPutSpy = jest.spyOn(dynamodbLib, "put");
+    dynamoPutSpy.mockRejectedValueOnce("error");
+    const res: any = await archiveReport(archiveEvent, null);
+    expect(res.statusCode).toBe(StatusCodes.InternalServerError);
+    expect(res.body).toContain(error.DYNAMO_UPDATE_ERROR);
+  });
 });

--- a/services/app-api/handlers/reports/archive.test.ts
+++ b/services/app-api/handlers/reports/archive.test.ts
@@ -8,11 +8,12 @@ import {
 } from "../../utils/testing/setupJest";
 import { error } from "../../utils/constants/constants";
 import dynamodbLib from "../../utils/dynamo/dynamodb-lib";
+import { StatusCodes } from "../../utils/responses/response-lib";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
 
 jest.mock("../../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn().mockResolvedValue(true),
+  isAuthenticated: jest.fn().mockResolvedValue(true),
   hasPermissions: jest.fn(() => {}),
 }));
 
@@ -65,8 +66,22 @@ describe("Test archiveReport method", () => {
     const body = JSON.parse(res.body);
     expect(consoleSpy.debug).toHaveBeenCalled();
     expect(dynamoPutSpy).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
     expect(body.archived).toBe(true);
+  });
+
+  test("Test archive report with missing parameters returns 400", async () => {
+    const event = {
+      ...archiveEvent,
+      pathParameters: {
+        ...archiveEvent.pathParameters,
+        state: undefined,
+      },
+    };
+    const res = await archiveReport(event, null);
+    expect(consoleSpy.debug).toHaveBeenCalled();
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
+    expect(res.body).toContain(error.NO_KEY);
   });
 
   test("Test archive report with no existing record throws 404", async () => {
@@ -81,7 +96,7 @@ describe("Test archiveReport method", () => {
     });
     const res = await archiveReport(archiveEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+    expect(res.statusCode).toBe(StatusCodes.NotFound);
     expect(res.body).toContain(error.NO_MATCHING_RECORD);
   });
 
@@ -97,7 +112,7 @@ describe("Test archiveReport method", () => {
     });
     const res = await archiveReport(archiveEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    expect(res.statusCode).toBe(StatusCodes.Forbidden);
     expect(res.body).toContain(error.UNAUTHORIZED);
   });
 });

--- a/services/app-api/handlers/reports/archive.ts
+++ b/services/app-api/handlers/reports/archive.ts
@@ -4,62 +4,64 @@ import { fetchReport } from "./fetch";
 import dynamoDb from "../../utils/dynamo/dynamodb-lib";
 import { error, reportTables } from "../../utils/constants/constants";
 import { hasPermissions } from "../../utils/auth/authorization";
+import {
+  badRequest,
+  forbidden,
+  internalServerError,
+  notFound,
+  ok,
+} from "../../utils/responses/response-lib";
+import { hasReportPathParams } from "../../utils/dynamo/hasReportPathParams";
 // types
-import { StatusCodes, UserRoles } from "../../utils/types";
+import { UserRoles } from "../../utils/types";
 
 export const archiveReport = handler(async (event, context) => {
+  const requiredParams = ["reportType", "state", "id"];
+  // Return bad request if missing required parameters
+  if (
+    !event.pathParameters ||
+    !hasReportPathParams(event.pathParameters, requiredParams)
+  ) {
+    return badRequest(error.NO_KEY);
+  }
   // Return a 403 status if the user is not an admin.
   if (!hasPermissions(event, [UserRoles.ADMIN, UserRoles.APPROVER])) {
-    return {
-      status: StatusCodes.UNAUTHORIZED,
-      body: error.UNAUTHORIZED,
-    };
+    return forbidden(error.UNAUTHORIZED);
   }
 
   // Get current report
   const reportEvent = { ...event, body: "" };
   const getCurrentReport = await fetchReport(reportEvent, context);
 
-  if (!getCurrentReport.body) {
-    return {
-      status: StatusCodes.NOT_FOUND,
-      body: error.NO_MATCHING_RECORD,
-    };
+  if (!getCurrentReport?.body) {
+    return notFound(error.NO_MATCHING_RECORD);
   }
 
-  // if current report exists, parse for archived status
-  if (getCurrentReport?.body) {
-    const currentReport = JSON.parse(getCurrentReport.body);
-    const currentArchivedStatus = currentReport?.archived;
-    const reportType = currentReport?.reportType;
+  // parse for archived status
+  const currentReport = JSON.parse(getCurrentReport.body);
+  const currentArchivedStatus = currentReport?.archived;
+  const reportType = currentReport?.reportType;
 
-    const reportTable = reportTables[reportType as keyof typeof reportTables];
+  const reportTable = reportTables[reportType as keyof typeof reportTables];
 
-    // Delete raw data prior to updating
-    delete currentReport.fieldData;
-    delete currentReport.formTemplate;
+  // Delete raw data prior to updating
+  delete currentReport.fieldData;
+  delete currentReport.formTemplate;
 
-    // toggle archived status in report metadata table
-    const reportMetadataParams = {
-      TableName: reportTable,
-      Item: {
-        ...currentReport,
-        archived: !currentArchivedStatus,
-      },
-    };
+  // toggle archived status in report metadata table
+  const reportMetadataParams = {
+    TableName: reportTable,
+    Item: {
+      ...currentReport,
+      archived: !currentArchivedStatus,
+    },
+  };
 
-    try {
-      await dynamoDb.put(reportMetadataParams);
-    } catch {
-      return {
-        status: StatusCodes.SERVER_ERROR,
-        body: error.DYNAMO_UPDATE_ERROR,
-      };
-    }
-
-    return {
-      status: StatusCodes.SUCCESS,
-      body: reportMetadataParams.Item,
-    };
+  try {
+    await dynamoDb.put(reportMetadataParams);
+  } catch {
+    return internalServerError(error.DYNAMO_UPDATE_ERROR);
   }
+
+  return ok(reportMetadataParams.Item);
 });

--- a/services/app-api/handlers/reports/create.test.ts
+++ b/services/app-api/handlers/reports/create.test.ts
@@ -11,13 +11,14 @@ import {
 import { error } from "../../utils/constants/constants";
 import * as authFunctions from "../../utils/auth/authorization";
 import s3Lib from "../../utils/s3/s3-lib";
+import { StatusCodes } from "../../utils/responses/response-lib";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
 
 const dynamoClientMock = mockClient(DynamoDBDocumentClient);
 
 jest.mock("../../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn().mockResolvedValue(true),
+  isAuthenticated: jest.fn().mockResolvedValue(true),
   hasPermissions: jest.fn().mockReturnValue(true),
 }));
 
@@ -199,10 +200,10 @@ describe("Test createReport API method", () => {
     consoleSpy.debug = jest.spyOn(console, "debug").mockImplementation();
   });
 
-  test("Test unauthorized report creation throws 403 error", async () => {
-    jest.spyOn(authFunctions, "isAuthorized").mockResolvedValueOnce(false);
+  test("Test unauthorized report creation throws 401 error", async () => {
+    jest.spyOn(authFunctions, "isAuthenticated").mockResolvedValueOnce(false);
     const res = await createReport(creationEvent, null);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(StatusCodes.Unauthenticated);
     expect(res.body).toContain(error.UNAUTHORIZED);
   });
 
@@ -210,7 +211,7 @@ describe("Test createReport API method", () => {
     jest.spyOn(authFunctions, "hasPermissions").mockReturnValueOnce(false);
     const res = await createReport(creationEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(StatusCodes.Forbidden);
     expect(res.body).toContain(error.UNAUTHORIZED);
   });
 
@@ -222,9 +223,9 @@ describe("Test createReport API method", () => {
     s3PutSpy.mockResolvedValue(mockS3PutObjectCommandOutput);
     const res = await createReport(creationEvent, null);
 
-    const body = JSON.parse(res.body);
+    const body = JSON.parse(res.body!);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.CREATED);
+    expect(res.statusCode).toBe(StatusCodes.Created);
     expect(body.status).toContain("Not started");
     expect(body.fieldDataId).toBeDefined;
     expect(body.formTemplateId).toBeDefined;
@@ -255,9 +256,9 @@ describe("Test createReport API method", () => {
     s3PutSpy.mockResolvedValue(mockS3PutObjectCommandOutput);
     const res = await createReport(createPccmEvent, null);
 
-    const body = JSON.parse(res.body);
+    const body = JSON.parse(res.body!);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.CREATED);
+    expect(res.statusCode).toBe(StatusCodes.Created);
     expect(body.status).toContain("Not started");
     expect(body.fieldDataId).toBeDefined;
     expect(body.formTemplateId).toBeDefined;
@@ -293,7 +294,7 @@ describe("Test createReport API method", () => {
     s3PutSpy.mockResolvedValue(mockS3PutObjectCommandOutput);
     const res = await createReport(creationEventWithInvalidData, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SERVER_ERROR);
+    expect(res.statusCode).toBe(StatusCodes.InternalServerError);
     expect(res.body).toContain(error.INVALID_DATA);
     expect(s3PutSpy).toHaveBeenCalled();
   });
@@ -306,7 +307,7 @@ describe("Test createReport API method", () => {
     s3PutSpy.mockResolvedValue(mockS3PutObjectCommandOutput);
     const res = await createReport(creationEventWithNoFieldData, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.MISSING_DATA);
     expect(s3PutSpy).toHaveBeenCalled();
   });
@@ -319,7 +320,7 @@ describe("Test createReport API method", () => {
     const res = await createReport(noKeyEvent, null);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 
@@ -331,7 +332,7 @@ describe("Test createReport API method", () => {
     const res = await createReport(noKeyEvent, null);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 
@@ -349,9 +350,9 @@ describe("Test createReport API method", () => {
     });
     const copyFieldDataSpy = jest.spyOn(reportUtils, "copyFieldDataFromSource");
     const res = await createReport(creationEventWithCopySource, null);
-    const body = JSON.parse(res.body);
+    const body = JSON.parse(res.body!);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.CREATED);
+    expect(res.statusCode).toBe(StatusCodes.Created);
     expect(copyFieldDataSpy).toBeCalled();
     expect(body.fieldDataId).not.toEqual("mockReportFieldData");
     expect(body.fieldData.plans).toBeDefined();
@@ -369,7 +370,7 @@ describe("Test createReport API method", () => {
     const copyFieldDataSpy = jest.spyOn(reportUtils, "copyFieldDataFromSource");
     const res = await createReport(creationEventInvalidState, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(copyFieldDataSpy).not.toBeCalled();
   });
 
@@ -377,7 +378,7 @@ describe("Test createReport API method", () => {
     const copyFieldDataSpy = jest.spyOn(reportUtils, "copyFieldDataFromSource");
     const res = await createReport(creationEventMlrReport, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(copyFieldDataSpy).not.toBeCalled();
   });
 
@@ -393,9 +394,9 @@ describe("Test createReport API method", () => {
     });
     const copyFieldDataSpy = jest.spyOn(reportUtils, "copyFieldDataFromSource");
     const res = await createReport(creationEventWithCopySource, null);
-    const body = JSON.parse(res.body);
+    const body = JSON.parse(res.body!);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.CREATED);
+    expect(res.statusCode).toBe(StatusCodes.Created);
     expect(copyFieldDataSpy).toBeCalled();
     expect(body.fieldDataId).not.toEqual("mockReportFieldData");
     expect(body.fieldData).toMatchObject({ stateName: "Alabama" });
@@ -420,9 +421,9 @@ describe("Test createReport API method", () => {
     });
     const copyFieldDataSpy = jest.spyOn(reportUtils, "copyFieldDataFromSource");
     const res = await createReport(creationEventWithCopySource, null);
-    const body = JSON.parse(res.body);
+    const body = JSON.parse(res.body!);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.CREATED);
+    expect(res.statusCode).toBe(StatusCodes.Created);
     expect(copyFieldDataSpy).toBeCalled();
     expect(body.fieldDataId).not.toEqual("mockReportFieldData");
     expect(body.fieldData).toMatchObject({ stateName: "Alabama" });

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -22,13 +22,14 @@ import {
   copyFieldDataFromSource,
   makePCCMModifications,
 } from "../../utils/reports/reports";
-// types
 import {
-  isReportType,
-  isState,
-  StatusCodes,
-  UserRoles,
-} from "../../utils/types";
+  badRequest,
+  created,
+  forbidden,
+  internalServerError,
+} from "../../utils/responses/response-lib";
+// types
+import { isReportType, isState, UserRoles } from "../../utils/types";
 
 export const createReport = handler(async (event, _context) => {
   const requiredParams = ["reportType", "state"];
@@ -37,34 +38,22 @@ export const createReport = handler(async (event, _context) => {
     !event.pathParameters ||
     !hasReportPathParams(event.pathParameters, requiredParams)
   ) {
-    return {
-      status: StatusCodes.BAD_REQUEST,
-      body: error.NO_KEY,
-    };
+    return badRequest(error.NO_KEY);
   }
 
   const { state, reportType } = event.pathParameters;
   if (!isState(state)) {
-    return {
-      status: StatusCodes.BAD_REQUEST,
-      body: error.NO_KEY,
-    };
+    return badRequest(error.NO_KEY);
   }
   if (!hasPermissions(event, [UserRoles.STATE_USER], state)) {
-    return {
-      status: StatusCodes.UNAUTHORIZED,
-      body: error.UNAUTHORIZED,
-    };
+    return forbidden(error.UNAUTHORIZED);
   }
   const unvalidatedPayload = JSON.parse(event.body!);
   const { metadata: unvalidatedMetadata, fieldData: unvalidatedFieldData } =
     unvalidatedPayload;
 
   if (!isReportType(reportType)) {
-    return {
-      status: StatusCodes.BAD_REQUEST,
-      body: error.NO_KEY,
-    };
+    return badRequest(error.NO_KEY);
   }
 
   const reportBucket = reportBuckets[reportType];
@@ -88,10 +77,7 @@ export const createReport = handler(async (event, _context) => {
 
   // Return MISSING_DATA error if missing unvalidated data or validators.
   if (!unvalidatedFieldData || !formTemplate.validationJson) {
-    return {
-      status: StatusCodes.BAD_REQUEST,
-      body: error.MISSING_DATA,
-    };
+    return badRequest(error.MISSING_DATA);
   }
 
   // Create report and field ids.
@@ -100,17 +86,19 @@ export const createReport = handler(async (event, _context) => {
   const formTemplateId: string = formTemplateVersion?.id;
 
   // Validate field data
-  const validatedFieldData = await validateFieldData(
-    formTemplate.validationJson,
-    unvalidatedFieldData
-  );
+  let validatedFieldData;
+  try {
+    validatedFieldData = await validateFieldData(
+      formTemplate.validationJson,
+      unvalidatedFieldData
+    );
+  } catch {
+    return badRequest(error.INVALID_DATA);
+  }
 
-  // Return INVALID_DATA error if field data is not valid.
-  if (!validatedFieldData || Object.keys(validatedFieldData).length === 0) {
-    return {
-      status: StatusCodes.SERVER_ERROR,
-      body: error.INVALID_DATA,
-    };
+  // Return INVALID_DATA error field data has no valid entries
+  if (validatedFieldData && Object.keys(validatedFieldData).length === 0) {
+    return internalServerError(error.INVALID_DATA);
   }
 
   // If the `copyFieldDataSourceId` parameter is passed, merge the validated field data with the source ids data.
@@ -123,7 +111,7 @@ export const createReport = handler(async (event, _context) => {
       state,
       unvalidatedMetadata.copyFieldDataSourceId,
       formTemplate,
-      validatedFieldData,
+      validatedFieldData!,
       reportType
     );
   } else {
@@ -145,25 +133,20 @@ export const createReport = handler(async (event, _context) => {
   try {
     await s3Lib.put(fieldDataParams);
   } catch {
-    return {
-      status: StatusCodes.SERVER_ERROR,
-      body: error.S3_OBJECT_CREATION_ERROR,
-    };
+    return internalServerError(error.S3_OBJECT_CREATION_ERROR);
   }
 
-  const validatedMetadata = await validateData(metadataValidationSchema, {
-    ...unvalidatedMetadata,
-  });
-
-  // Return INVALID_DATA error if metadata is not valid.
-  if (!validatedMetadata) {
-    return {
-      status: StatusCodes.BAD_REQUEST,
-      body: error.INVALID_DATA,
-    };
+  let validatedMetadata;
+  try {
+    validatedMetadata = await validateData(metadataValidationSchema, {
+      ...unvalidatedMetadata,
+    });
+  } catch {
+    // Return INVALID_DATA error if metadata is not valid.
+    return badRequest(error.INVALID_DATA);
   }
 
-  // Create DyanmoDB record.
+  // Create DynamoDB record.
   const reportMetadataParams: PutCommandInput = {
     TableName: reportTable,
     Item: {
@@ -182,19 +165,13 @@ export const createReport = handler(async (event, _context) => {
   try {
     await dynamoDb.put(reportMetadataParams);
   } catch {
-    return {
-      status: StatusCodes.SERVER_ERROR,
-      body: error.DYNAMO_CREATION_ERROR,
-    };
+    return internalServerError(error.DYNAMO_CREATION_ERROR);
   }
 
-  return {
-    status: StatusCodes.CREATED,
-    body: {
-      ...reportMetadataParams.Item,
-      fieldData: validatedFieldData,
-      formTemplate,
-      formTemplateVersion: formTemplateVersion?.versionNumber,
-    },
-  };
+  return created({
+    ...reportMetadataParams.Item,
+    fieldData: validatedFieldData,
+    formTemplate,
+    formTemplateVersion: formTemplateVersion?.versionNumber,
+  });
 });

--- a/services/app-api/handlers/reports/submit.test.ts
+++ b/services/app-api/handlers/reports/submit.test.ts
@@ -15,12 +15,13 @@ import {
 } from "../../utils/testing/setupJest";
 import s3Lib from "../../utils/s3/s3-lib";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
+import { StatusCodes } from "../../utils/responses/response-lib";
 
 const dynamoClientMock = mockClient(DynamoDBDocumentClient);
 
 jest.mock("../../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   hasPermissions: jest.fn().mockReturnValue(true),
 }));
 
@@ -53,7 +54,7 @@ describe("Test submitReport API method", () => {
     });
     const res = await submitReport(testSubmitEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+    expect(res.statusCode).toBe(StatusCodes.NotFound);
   });
 
   test("Test Successful Report Submittal", async () => {
@@ -71,8 +72,8 @@ describe("Test submitReport API method", () => {
 
     const res = await submitReport(testSubmitEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
-    const body = JSON.parse(res.body);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
+    const body = JSON.parse(res.body!);
     expect(body.lastAlteredBy).toContain("Thelonious States");
     expect(body.programName).toContain("testProgram");
     expect(body.isComplete).toStrictEqual(true);
@@ -102,8 +103,8 @@ describe("Test submitReport API method", () => {
 
     const res = await submitReport(testSubmitEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
-    const body = JSON.parse(res.body);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
+    const body = JSON.parse(res.body!);
     expect(body.lastAlteredBy).toContain("Thelonious States");
     expect(body.submissionName).toContain("testProgram");
     expect(body.isComplete).toStrictEqual(true);
@@ -120,8 +121,8 @@ describe("Test submitReport API method", () => {
     });
     const res = await submitReport(testSubmitEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SERVER_ERROR);
-    const body = JSON.parse(res.body);
+    expect(res.statusCode).toBe(StatusCodes.Conflict);
+    const body = JSON.parse(res.body!);
     expect(body).toStrictEqual(error.REPORT_INCOMPLETE);
   });
 
@@ -132,7 +133,7 @@ describe("Test submitReport API method", () => {
     };
     const res = await submitReport(noKeyEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 
@@ -143,7 +144,7 @@ describe("Test submitReport API method", () => {
     };
     const res = await submitReport(noKeyEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 });

--- a/services/app-api/handlers/reports/submit.ts
+++ b/services/app-api/handlers/reports/submit.ts
@@ -116,7 +116,7 @@ export const submitReport = handler(async (event, _context) => {
       any
     >;
   } catch {
-    return internalServerError(error.NOT_IN_DATABASE);
+    return internalServerError(error.S3_OBJECT_GET_ERROR);
   }
 
   const fieldData = {
@@ -146,7 +146,7 @@ export const submitReport = handler(async (event, _context) => {
       any
     >;
   } catch {
-    return internalServerError(error.NOT_IN_DATABASE);
+    return internalServerError(error.S3_OBJECT_GET_ERROR);
   }
 
   try {

--- a/services/app-api/handlers/templates/fetch.test.ts
+++ b/services/app-api/handlers/templates/fetch.test.ts
@@ -3,10 +3,11 @@ import { fetchTemplate } from "./fetch";
 import { proxyEvent } from "../../utils/testing/proxyEvent";
 import { error } from "../../utils/constants/constants";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
+import { StatusCodes } from "../../utils/responses/response-lib";
 
 jest.mock("../../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
 }));
 
 jest.mock("../../utils/s3/s3-lib", () => ({
@@ -39,7 +40,7 @@ describe("Test fetchTemplate API method", () => {
     const res = await fetchTemplate(mcparEvent, null);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
     expect(res.body).toContain("s3://fakeurl.bucket.here");
   });
 
@@ -51,7 +52,7 @@ describe("Test fetchTemplate API method", () => {
     const res = await fetchTemplate(mlrEvent, null);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
     expect(res.body).toContain("s3://fakeurl.bucket.here");
   });
 
@@ -63,7 +64,7 @@ describe("Test fetchTemplate API method", () => {
     const res = await fetchTemplate(naaarEvent, null);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
     expect(res.body).toContain("s3://fakeurl.bucket.here");
   });
 
@@ -74,8 +75,7 @@ describe("Test fetchTemplate API method", () => {
     };
     const res = await fetchTemplate(noKeyEvent, null);
 
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_TEMPLATE_NAME);
   });
 
@@ -86,8 +86,7 @@ describe("Test fetchTemplate API method", () => {
     };
     const res = await fetchTemplate(noKeyEvent, null);
 
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.INVALID_TEMPLATE_NAME);
   });
 });

--- a/services/app-api/handlers/templates/fetch.ts
+++ b/services/app-api/handlers/templates/fetch.ts
@@ -2,12 +2,13 @@ import handler from "../handler-lib";
 // utils
 import { error } from "../../utils/constants/constants";
 import s3Lib from "../../utils/s3/s3-lib";
+import { badRequest, ok } from "../../utils/responses/response-lib";
 // types
-import { StatusCodes, TemplateKeys } from "../../utils/types";
+import { TemplateKeys } from "../../utils/types";
 
 export const fetchTemplate = handler(async (event, _context) => {
   if (!event?.pathParameters?.templateName!) {
-    throw new Error(error.NO_TEMPLATE_NAME);
+    return badRequest(error.NO_TEMPLATE_NAME);
   }
   let key;
   if (event.pathParameters.templateName === "MCPAR") {
@@ -17,7 +18,7 @@ export const fetchTemplate = handler(async (event, _context) => {
   } else if (event.pathParameters.templateName === "NAAAR") {
     key = TemplateKeys.NAAAR;
   } else {
-    throw new Error(error.INVALID_TEMPLATE_NAME);
+    return badRequest(error.INVALID_TEMPLATE_NAME);
   }
   // get the signed URL string
   const params = {
@@ -26,5 +27,5 @@ export const fetchTemplate = handler(async (event, _context) => {
     Key: key,
   };
   const url = await s3Lib.getSignedDownloadUrl(params);
-  return { status: StatusCodes.SUCCESS, body: url };
+  return ok(url);
 });

--- a/services/app-api/utils/auth/authorization.ts
+++ b/services/app-api/utils/auth/authorization.ts
@@ -41,7 +41,7 @@ const loadCognitoValues = async () => {
   }
 };
 
-export const isAuthorized = async (event: APIGatewayProxyEvent) => {
+export const isAuthenticated = async (event: APIGatewayProxyEvent) => {
   const cognitoValues = await loadCognitoValues();
   // Verifier that expects valid access tokens:
   const verifier = CognitoJwtVerifier.create({
@@ -50,18 +50,12 @@ export const isAuthorized = async (event: APIGatewayProxyEvent) => {
     clientId: cognitoValues.userPoolClientId,
   });
 
-  let isAuthorized;
-
-  if (event?.headers?.["x-api-key"]) {
-    try {
-      isAuthorized = await verifier.verify(event.headers["x-api-key"]);
-    } catch {
-      // verification failed - unauthorized
-      isAuthorized = false;
-    }
+  try {
+    await verifier.verify(event?.headers?.["x-api-key"]!);
+    return true;
+  } catch {
+    return false;
   }
-
-  return !!isAuthorized;
 };
 
 export const hasPermissions = (

--- a/services/app-api/utils/constants/constants.ts
+++ b/services/app-api/utils/constants/constants.ts
@@ -23,7 +23,7 @@ export const error = {
   ALREADY_ARCHIVED: "Cannot update archived report.",
   ALREADY_LOCKED: "Cannot update locked report.",
   REPORT_INCOMPLETE: "Cannot submit incomplete form.",
-};
+} as const;
 
 export const buckets = {
   FORM_TEMPLATE: "formTemplates",

--- a/services/app-api/utils/constants/constants.ts
+++ b/services/app-api/utils/constants/constants.ts
@@ -5,7 +5,7 @@ export const error = {
   MISSING_DATA: "Missing required data.",
   INVALID_DATA: "Provided data is not valid.",
   NO_MATCHING_RECORD: "No matching record found.",
-  SERVER_ERROR: "An unspecified server error occured.",
+  SERVER_ERROR: "An unspecified server error occurred.",
   // bucket errors
   S3_OBJECT_CREATION_ERROR: "Report could not be created due to an S3 error.",
   S3_OBJECT_GET_ERROR: "Error while fetching report.",

--- a/services/app-api/utils/responses/response-lib.test.ts
+++ b/services/app-api/utils/responses/response-lib.test.ts
@@ -1,25 +1,39 @@
-import { buildResponse, internalServerError } from "./response-lib";
+import {
+  ok,
+  created,
+  badRequest,
+  unauthenticated,
+  forbidden,
+  notFound,
+  conflict,
+  internalServerError,
+} from "./response-lib";
 
-test("Internal Server Error should give a 500 status", () => {
-  const res = internalServerError("internal error");
-  expect(res.body).toBe(JSON.stringify("internal error"));
-  expect(res.statusCode).toBe(500);
-  expect(res.headers["Access-Control-Allow-Origin"]).toBe("*");
-  expect(res.headers["Access-Control-Allow-Credentials"]).toBe(true);
-});
+describe("HTTP Response helper functions", () => {
+  test("Responses should have correct status codes", () => {
+    expect(ok({}).statusCode).toBe(200);
+    expect(created({}).statusCode).toBe(201);
+    expect(badRequest({}).statusCode).toBe(400);
+    expect(unauthenticated({}).statusCode).toBe(401);
+    expect(forbidden({}).statusCode).toBe(403);
+    expect(notFound({}).statusCode).toBe(404);
+    expect(conflict({}).statusCode).toBe(409);
+    expect(internalServerError({}).statusCode).toBe(500);
+  });
 
-test("Build Response should create an object with a status code 420 and message", () => {
-  const res = buildResponse(400, "status is 400");
-  expect(res.body).toBe(JSON.stringify("status is 400"));
-  expect(res.statusCode).toBe(400);
-  expect(res.headers["Access-Control-Allow-Origin"]).toBe("*");
-  expect(res.headers["Access-Control-Allow-Credentials"]).toBe(true);
-});
+  test("Responses should exclude a body if not provided", () => {
+    const response = badRequest();
+    expect(response.body).toBeUndefined();
+  });
 
-test("Build Response should create an object with a status code 403 and message", () => {
-  const res = buildResponse(403, "Unauthorized");
-  expect(res.body).toBe(JSON.stringify("Unauthorized"));
-  expect(res.statusCode).toBe(403);
-  expect(res.headers["Access-Control-Allow-Origin"]).toBe("*");
-  expect(res.headers["Access-Control-Allow-Credentials"]).toBe(true);
+  test("Responses should include a body if provided", () => {
+    const res = badRequest("try again");
+    expect(res.body).toBe('"try again"');
+  });
+
+  test("Responses should have the correct headers", () => {
+    const response = ok({});
+    expect(response.headers["Access-Control-Allow-Origin"]).toBe("*");
+    expect(response.headers["Access-Control-Allow-Credentials"]).toBe(true);
+  });
 });

--- a/services/app-api/utils/responses/response-lib.ts
+++ b/services/app-api/utils/responses/response-lib.ts
@@ -1,14 +1,95 @@
-export function internalServerError(body: any) {
-  return buildResponse(500, body);
+/**
+ * The response for a successful request.
+ * Should include a body for GET, PUT, or POST.
+ * Need not include a body for DELETE
+ */
+export const ok = (body?: Object) => new HttpResponse(StatusCodes.Ok, body);
+
+/**
+ * The response for a successful POST or PUT request,
+ * which resulted in the creation of a new resource.
+ */
+export const created = (body: Object) =>
+  new HttpResponse(StatusCodes.Created, body);
+
+/**
+ * The response for a failed request, due to client-side issues.
+ * Typically indicates a missing parameter or malformed body.
+ */
+export const badRequest = (body?: Object) =>
+  new HttpResponse(StatusCodes.BadRequest, body);
+
+/**
+ * The response for a client without any authorization.
+ * Typically indicates an issue with the request's headers or token.
+ *
+ * Note: The usual name for HTTP 401 is "Unauthorized", but that's misleading.
+ * Authentication is for identity; authorization is for permissions.
+ */
+export const unauthenticated = (body?: Object) =>
+  new HttpResponse(StatusCodes.Unauthenticated, body);
+
+/**
+ * The response for a client without sufficient permissions.
+ * This is specific to the requested operation.
+ * For example, a regular user requesting an admin-only endpoint.
+ */
+export const forbidden = (body?: Object) =>
+  new HttpResponse(StatusCodes.Forbidden, body);
+
+/**
+ * The response for a request that assumes the existence of a missing resource.
+ * For example, attempting to submit a report that isn't in the database.
+ */
+export const notFound = (body?: Object) =>
+  new HttpResponse(StatusCodes.NotFound, body);
+
+/**
+ * The response for a request that assumes the server is in a different state.
+ * For example, attempting to submit a report that's already submitted.
+ */
+export const conflict = (body?: Object) =>
+  new HttpResponse(StatusCodes.Conflict, body);
+
+/**
+ * The response for a request that errored out on the server side.
+ * Typically indicates there is nothing the client can do to resolve the issue.
+ */
+export const internalServerError = (body?: Object) =>
+  new HttpResponse(StatusCodes.InternalServerError, body);
+
+/**
+ * Note: Production code shouldn't need to reference this directly.
+ * Use a helper method instead.
+ *
+ * This enum is listed mainly for the purpose of unit testing.
+ */
+export enum StatusCodes {
+  Ok = 200,
+  Created = 201,
+  BadRequest = 400,
+  Unauthenticated = 401,
+  Forbidden = 403,
+  NotFound = 404,
+  Conflict = 409,
+  InternalServerError = 500,
 }
 
-export function buildResponse(statusCode: number, body: any) {
-  return {
-    statusCode: statusCode,
-    headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Credentials": true,
-    },
-    body: JSON.stringify(body),
+/**
+ * Note: Production code shouldn't need to reference this directly.
+ * Use a helper method instead.
+ */
+export class HttpResponse {
+  readonly statusCode: number;
+  readonly body: string | undefined;
+  readonly headers = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Credentials": true,
   };
+  constructor(statusCode: number, body?: Object | undefined) {
+    this.statusCode = statusCode;
+    if (body !== undefined) {
+      this.body = JSON.stringify(body);
+    }
+  }
 }

--- a/services/app-api/utils/types/other.ts
+++ b/services/app-api/utils/types/other.ts
@@ -4,15 +4,6 @@ export interface AnyObject {
   [key: string]: any;
 }
 
-export const enum StatusCodes {
-  SUCCESS = 200,
-  CREATED = 201,
-  BAD_REQUEST = 400,
-  UNAUTHORIZED = 403,
-  NOT_FOUND = 404,
-  SERVER_ERROR = 500,
-}
-
 /**
  * Abridged copy of the type used by `aws-lambda@1.0.7` (from `@types/aws-lambda@8.10.88`)
  * We only this package for these types, and we use only a subset of the


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
New api response pattern. In short:
```ts
// Rather than constructing a response object on the fly (current state):
if (!allParamsValid) {
  return {
    status: StatusCodes.BadRequest,
    body: error.NO_KEY,
  };
}

// We will construct a response with a named helper:
if (!allParamsValid) {
  return badRequest(error.NO_KEY);
}
```

Additionally we had certain return blocks based on variables being undefined where they could not be undefined as a result of their flow. This fixes that logic with try/catches using the new response pattern.

Review guidance: Review the response-lib changes. Pick a handler and read the changes. Notice the new response pattern. Notice any changes to try/catch blocks. These changes will be very similar in all the other handlers.

Moving the work from these two MFP PRs to MCR:
https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/754
https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/762

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-none

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
This PR touches almost every file in the API, and most changes have to do with requests that are invalid, for one reason or another. That, together with AWS' request signing, makes it very difficult to test from the UI. But, the expected behavioral changes are also very small - for example, changing a 403 response to a 409, for a situation that we don't expect to ever happen.

For that reason, I would say that the automated e2e tests are sufficient here - coupled, of course, with a thorough reading of the code changes.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment