### PR TITLE
Console Cleanup

### DIFF
--- a/services/ui-src/src/components/drawers/ReportDrawer.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawer.tsx
@@ -46,7 +46,6 @@ export const ReportDrawer = ({
           formData={selectedEntity}
           validateOnRender={validateOnRender || false}
           dontReset={true}
-          {...props}
         />
       ) : (
         <Text sx={sx.noFormMessage}>{verbiage.drawerNoFormMessage}</Text>

--- a/services/ui-src/src/components/drawers/ReportDrawer.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawer.tsx
@@ -46,6 +46,7 @@ export const ReportDrawer = ({
           formData={selectedEntity}
           validateOnRender={validateOnRender || false}
           dontReset={true}
+          {...props}
         />
       ) : (
         <Text sx={sx.noFormMessage}>{verbiage.drawerNoFormMessage}</Text>

--- a/services/ui-src/src/components/fields/NumberField.tsx
+++ b/services/ui-src/src/components/fields/NumberField.tsx
@@ -31,6 +31,7 @@ export const NumberField = ({
   nested,
   styleAsOptional,
   clear,
+  decimalPlacesToRoundTo,
   ...props
 }: Props) => {
   const defaultValue = "";
@@ -63,7 +64,7 @@ export const NumberField = ({
       const maskedFieldValue = applyMask(
         fieldValue,
         mask,
-        props?.decimalPlacesToRoundTo
+        decimalPlacesToRoundTo
       ).maskedValue;
       setDisplayValue(maskedFieldValue);
     }
@@ -76,7 +77,7 @@ export const NumberField = ({
         const formattedHydrationValue = applyMask(
           hydrationValue,
           mask,
-          props?.decimalPlacesToRoundTo
+          decimalPlacesToRoundTo
         );
         const maskedHydrationValue = formattedHydrationValue.maskedValue;
         setDisplayValue(maskedHydrationValue);
@@ -103,11 +104,7 @@ export const NumberField = ({
     // if field is blank, trigger client-side field validation error
     if (!value.trim()) form.trigger(name);
     // mask value and set as display value
-    const formattedFieldValue = applyMask(
-      value,
-      mask,
-      props?.decimalPlacesToRoundTo
-    );
+    const formattedFieldValue = applyMask(value, mask, decimalPlacesToRoundTo);
     const maskedFieldValue = formattedFieldValue.maskedValue;
 
     // this value eventually gets sent to the database, so we need to make it parseable as a number again
@@ -193,6 +190,7 @@ interface Props {
   autosave?: boolean;
   validateOnRender?: boolean;
   clear?: boolean;
+  decimalPlacesToRoundTo?: number;
   [key: string]: any;
 }
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The following error appeared on the console when we added a new prop `decimalPlacesToRoundTo` to a MCPAR drawer:

![Screenshot 2024-10-22 at 10 21 50 AM](https://github.com/user-attachments/assets/aec80cab-5e27-4653-8655-52492342a5e9)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a MCPAR report
- Add a plan
- Navigate to `/mcpar/plan-level-indicators/prior-authorization`
- Select "Yes" and enter the plan

You shouldn't see the error! 🪄 

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
