### PR TITLE
Amplify: add implicit oauth grant to see if it fixes IDM login

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -173,6 +173,7 @@ resources:
         GenerateSecret: false # pragma: allowlist secret
         AllowedOAuthFlows:
           - code
+          - implicit
         AllowedOAuthFlowsUserPoolClient: true
         AllowedOAuthScopes:
           - email


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Currently if you login with IDM in MCR dev it lets you finish the IDM flow and then lands on a blank screen. The local storage has no tokens or anything.

[CARTS](https://github.com/Enterprise-CMCS/macpro-mdct-carts/blob/main/services/ui-auth/serverless.yml#L144-L146) has the implicit grant flow enabled which according to [documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolclient.html#cfn-cognito-userpoolclient-allowedoauthflows) will grant the tokens directly to the user which I _think_ is what we do? Anyway let's see if this fixes it.

My other idea if this doesn't work is adding this package which CARTS has `@aws-amplify/rtn-web-browser`. I don't know what it does.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4035

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Merge to main (it's already broken with IDM anyway)

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment