### PR TITLE
Bug Fix: Admin Dashboard Button Styling

### DIFF
--- a/services/ui-src/src/components/forms/AdminDashSelector.tsx
+++ b/services/ui-src/src/components/forms/AdminDashSelector.tsx
@@ -89,7 +89,12 @@ export const AdminDashSelector = ({ verbiage }: Props) => {
         dontReset={false}
       />
       <Flex sx={sx.navigationButton}>
-        <Button type="submit" form={formJson.id} isDisabled={!reportSelected}>
+        <Button
+          type="submit"
+          form={formJson.id}
+          isDisabled={!reportSelected}
+          sx={!reportSelected ? sx.disabledButton : {}}
+        >
           {verbiage.buttonLabel}
         </Button>
       </Flex>
@@ -114,5 +119,9 @@ const sx = {
   },
   navigationButton: {
     padding: "1.5rem 0 2rem 0",
+  },
+  disabledButton: {
+    color: "palette.gray",
+    background: "palette.gray_lighter",
   },
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
@rocio-desantiago pointed out that the MCR admin dashboard button doesn't have the correct styling when it's disabled, this PR addresses that based on Kim's suggestions.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as an admin user
- By default, you should see the following button colors:

<img width="660" alt="Screenshot 2024-10-24 at 10 36 44 AM" src="https://github.com/user-attachments/assets/3e56fe45-80a2-4bbc-b9e9-62922d44e2a2">

- Select a state and a report to see the following colors:

<img width="615" alt="Screenshot 2024-10-24 at 10 36 23 AM" src="https://github.com/user-attachments/assets/cc6c59b1-56a8-49ef-9eb5-7990c1483ee4">

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
