### PR TITLE
Add oauth listener import to app root

### DIFF
--- a/services/ui-src/src/index.tsx
+++ b/services/ui-src/src/index.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router } from "react-router-dom";
 import { ErrorBoundary } from "react-error-boundary";
 import { Amplify } from "aws-amplify";
 import config from "config";
+import "aws-amplify/auth/enable-oauth-listener";
 // utils
 import { ApiProvider, UserProvider } from "utils";
 import { asyncWithLDProvider } from "launchdarkly-react-client-sdk";


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
We have SPAs, right? Apparently the vite build adds some flavor to this. It bundles different pages separately, even though in entirety it's an SPA. So when our IDM login is redirecting it's hitting an issue where (¿)Amplify stops being able to track it(?) or something.

Anyway adding this import to the root of our app allows our app to track the redirects to "different pages" as if it were an MPA.

Let's hope this works! The relevant issue had a _very_ similar use case to us, so I'm hopeful

References:
[Amplify GitHub issue](https://github.com/aws-amplify/amplify-js/issues/13688)
[Amplify MPA docs](https://docs.amplify.aws/gen1/react/build-a-backend/auth/add-social-provider/#required-for-multi-page-applications-complete-social-sign-in-after-redirect)
[The import](https://github.com/aws-amplify/amplify-js/blob/847fb51acee1ee8585503625a6f73d67265217d0/packages/auth/src/providers/cognito/utils/oauth/enableOAuthListener.ts)

Related: the first sentence of [this post](https://github.com/firebase/firebase-js-sdk/issues/7037#issuecomment-1431819924)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4035

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Merge to main

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment