### PR TITLE
move idm method back to amplify method

### DIFF
--- a/services/ui-src/src/utils/auth/UserProvider.test.tsx
+++ b/services/ui-src/src/utils/auth/UserProvider.test.tsx
@@ -48,8 +48,6 @@ const testComponent = (
 );
 
 // HELPERS
-const mockReplace = jest.fn();
-
 const originalLocationDescriptor: any = Object.getOwnPropertyDescriptor(
   global,
   "location"
@@ -61,7 +59,6 @@ const setWindowOrigin = (windowOrigin: string) => {
     value: {
       assign: jest.fn(),
       origin: windowOrigin,
-      replace: mockReplace,
       pathname: "/",
     },
     writable: true,
@@ -123,7 +120,6 @@ describe("<UserProvider />", () => {
       });
       expect(window.location.origin).toContain("mdctmcr.cms.gov");
       expect(screen.getByTestId("testdiv")).toHaveTextContent("User Test");
-      expect(mockReplace).toHaveBeenCalled();
     });
   });
 

--- a/services/ui-src/src/utils/auth/UserProvider.tsx
+++ b/services/ui-src/src/utils/auth/UserProvider.tsx
@@ -6,7 +6,11 @@ import {
   useMemo,
 } from "react";
 import { useLocation } from "react-router-dom";
-import { fetchAuthSession, signOut } from "aws-amplify/auth";
+import {
+  fetchAuthSession,
+  signInWithRedirect,
+  signOut,
+} from "aws-amplify/auth";
 import config from "config";
 // utils
 import { initAuthManager, updateTimeout, getExpiration, useStore } from "utils";
@@ -22,10 +26,7 @@ export const UserContext = createContext<UserContextShape>({
 });
 
 const authenticateWithIDM = async () => {
-  const cognitoHostedUrl = new URL(
-    `https://${config.cognito.APP_CLIENT_DOMAIN}/oauth2/authorize?identity_provider=${config.cognito.COGNITO_IDP_NAME}&redirect_uri=${config.APPLICATION_ENDPOINT}&response_type=CODE&client_id=${config.cognito.APP_CLIENT_ID}&scope=email openid profile`
-  );
-  window.location.replace(cognitoHostedUrl);
+  await signInWithRedirect({ provider: { custom: "Okta" } });
 };
 
 export const UserProvider = ({ children }: Props) => {

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -65,6 +65,7 @@ jest.mock("aws-amplify/auth", () => ({
     }),
   }),
   signOut: jest.fn().mockImplementation(() => Promise.resolve()),
+  signInWithRedirect: () => {},
 }));
 
 jest.mock("aws-amplify/utils", () => ({


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Move the IDM redirect back to the amplify provided method so it can manage the full auth flow.

completes the work from https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/11897

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4035

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment