### PR TITLE
CMDCT-4087: NAAAR Dashboard Page Setup

### DIFF
--- a/services/ui-src/src/components/accordions/TemplateCardAccordion.tsx
+++ b/services/ui-src/src/components/accordions/TemplateCardAccordion.tsx
@@ -47,6 +47,7 @@ const sx = {
     paddingLeft: "1rem",
     "li:last-of-type": {
       fontWeight: "bold",
+      textDecoration: "underline",
     },
   },
 };

--- a/services/ui-src/src/verbiage/pages/home.ts
+++ b/services/ui-src/src/verbiage/pages/home.ts
@@ -61,7 +61,8 @@ export default {
     NAAAR: {
       title: "Network Adequacy and Access Assurances Report (NAAAR)",
       body: {
-        available: "Placeholder",
+        available:
+          "The requirement for states to submit this information to CMS began with all contracts with rating periods beginning on or after July 1, 2018. However, prior to June 2022, there had been no requirement to use a standard reporting template. The Excel template is available for states to use immediately if they choose. However, all states submitting rate certification packages on or after October 1, 2022 are required to use the template. Further, CMS recommends that the report be submitted as supporting documentation at the same time a state submits the associated managed care contract to CMS for approval, including a new contract, a renewal, or an amendment.",
         unavailable:
           "The requirement for states to submit this information to CMS began with all contracts with rating periods beginning on or after July 1, 2018. However, prior to June 2022, there had been no requirement to use a standard reporting template. The Excel template is available for states to use immediately if they choose. However, all states submitting rate certification packages on or after October 1, 2022 are required to use the template. Further, CMS recommends that the report be submitted as supporting documentation at the same time a state submits the associated managed care contract to CMS for approval, including a new contract, a renewal, or an amendment.",
       },

--- a/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard.ts
+++ b/services/ui-src/src/verbiage/pages/mcpar/mcpar-dashboard.ts
@@ -3,23 +3,27 @@ export default {
     header: "Managed Care Program Annual Report (MCPAR)",
     body: [
       {
-        type: "text",
-        content:
-          "One MCPAR is required for every managed care program in your state.",
-      },
-      {
-        type: "text",
-        as: "span",
-        content: "MCPAR is required by 42 CFR § 438.66(e). ",
-      },
-      {
-        type: "externalLink",
-        content: "Learn more",
-        props: {
-          href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#AMCPR",
-          target: "_blank",
-          "aria-label": "Learn more (link opens in new tab)",
-        },
+        type: "p",
+        children: [
+          {
+            type: "html",
+            content:
+              "One MCPAR is required for every managed care program in your state.<br/>",
+          },
+          {
+            type: "html",
+            content: "MCPAR is required by 42 CFR § 438.66(e). ",
+          },
+          {
+            type: "externalLink",
+            content: "Learn more",
+            props: {
+              href: "https://www.medicaid.gov/medicaid/managed-care/guidance/medicaid-and-chip-managed-care-reporting/index.html#AMCPR",
+              target: "_blank",
+              "aria-label": "Learn more (link opens in new tab)",
+            },
+          },
+        ],
       },
     ],
   },

--- a/services/ui-src/src/verbiage/pages/naaar/naaar-dashboard.ts
+++ b/services/ui-src/src/verbiage/pages/naaar/naaar-dashboard.ts
@@ -7,12 +7,31 @@ export default {
         children: [
           {
             type: "html",
-            content: "",
+            content:
+              "Complete one (1) report with information for applicable managed care plans and their applicable managed care programs. MMPs are considered both Medicaid and Medicare managed care plans and are not exempt from ",
           },
           {
             type: "externalLink",
-            content: "",
-            props: {},
+            content: "42 CFR 438.207",
+            props: {
+              href: "https://www.google.com",
+              target: "_blank",
+              "aria-label": "Link opens in new tab",
+            },
+          },
+          {
+            type: "html",
+            content:
+              ". Therefore, states must submit the tool for integrated plans; however, to reduce duplication, states can complete network adequacy sections of the tool (II.A.1-II.A.5) for Medicaid-only covered services. Reporting on Program of All-Inclusive Care for the Elderly (PACE) programs/plans is not required. ",
+          },
+          {
+            type: "externalLink",
+            content: "Learn more about NAAAR.",
+            props: {
+              href: "https://www.google.com",
+              target: "_blank",
+              "aria-label": "Learn more (link opens in new tab)",
+            },
           },
         ],
       },

--- a/services/ui-src/src/verbiage/pages/naaar/naaar-dashboard.ts
+++ b/services/ui-src/src/verbiage/pages/naaar/naaar-dashboard.ts
@@ -4,21 +4,36 @@ export default {
     body: [
       {
         type: "text",
-        content: "",
+        content:
+          "Complete one (1) report with information for applicable managed care plans and their applicable managed care programs. MMPs are considered both Medicaid and Medicare managed care plans and are not exempt from 42 CFR 438.207. Therefore, states must submit the tool for integrated plans; however, to reduce duplication, states can complete network adequacy sections of the tool (II.A.1-II.A.5) for Medicaid-only covered services. Reporting on Program of All-Inclusive Care for the Elderly (PACE) programs/plans is not required.",
       },
       {
         type: "externalLink",
-        content: "",
-        props: {},
+        content: "Learn more about NAAAR.",
+        props: {
+          href: "",
+          target: "_blank",
+          "aria-label": "Learn more (link opens in new tab)",
+        },
       },
     ],
   },
   body: {
     table: {
       caption: "NAAAR Submissions",
-      headRow: [],
+      headRow: [
+        { hiddenName: "Edit report name and details" },
+        "Program name",
+        "Plan type",
+        "Due date",
+        "Last edited",
+        "Edited by",
+        "Status",
+        { hiddenName: "Actions" },
+      ],
     },
-    empty: "",
-    callToAction: "",
+    empty:
+      "For this report, a managed care program is defined by a set of distinct benefits and eligibility criteria articulated in a contract between states and the state’s managed care plans.",
+    callToAction: "Add / copy managed care program",
   },
 };

--- a/services/ui-src/src/verbiage/pages/naaar/naaar-dashboard.ts
+++ b/services/ui-src/src/verbiage/pages/naaar/naaar-dashboard.ts
@@ -3,18 +3,37 @@ export default {
     header: "Network Adequacy and Access Assurances Report (NAAAR)",
     body: [
       {
-        type: "text",
-        content:
-          "Complete one (1) report with information for applicable managed care plans and their applicable managed care programs. MMPs are considered both Medicaid and Medicare managed care plans and are not exempt from 42 CFR 438.207. Therefore, states must submit the tool for integrated plans; however, to reduce duplication, states can complete network adequacy sections of the tool (II.A.1-II.A.5) for Medicaid-only covered services. Reporting on Program of All-Inclusive Care for the Elderly (PACE) programs/plans is not required.",
-      },
-      {
-        type: "externalLink",
-        content: "Learn more about NAAAR.",
-        props: {
-          href: "",
-          target: "_blank",
-          "aria-label": "Learn more (link opens in new tab)",
-        },
+        type: "p",
+        children: [
+          {
+            type: "html",
+            content:
+              "Complete one (1) report with information for applicable managed care plans and their applicable managed care programs. MMPs are considered both Medicaid and Medicare managed care plans and are not exempt from ",
+          },
+          {
+            type: "externalLink",
+            content: "42 CFR 438.207",
+            props: {
+              href: "https://www.google.com",
+              target: "_blank",
+              "aria-label": "Learn more (link opens in new tab)",
+            },
+          },
+          {
+            type: "html",
+            content:
+              ". Therefore, states must submit the tool for integrated plans; however, to reduce duplication, states can complete network adequacy sections of the tool (II.A.1-II.A.5) for Medicaid-only covered services. Reporting on Program of All-Inclusive Care for the Elderly (PACE) programs/plans is not required. ",
+          },
+          {
+            type: "externalLink",
+            content: "Learn more about NAAAR.",
+            props: {
+              href: "https://www.google.com",
+              target: "_blank",
+              "aria-label": "Learn more (link opens in new tab)",
+            },
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Adding the verbiage for the NAAAR template card and the empty state of a NAAAR dashboard upon entering `/naaar`:

![Screenshot 2024-10-30 at 11 56 50 AM](https://github.com/user-attachments/assets/5d9d95f3-018c-4234-8fc6-e1281b8085a6)

![Screenshot 2024-10-30 at 11 56 58 AM](https://github.com/user-attachments/assets/0fb2f955-c4c7-4535-8c44-129e397c4fd8)

**Note:** The links in the dashboard description are placeholders. 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4087

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Verify the verbiage in the template card
- Click on "Enter NAAAR"
- Verify the verbiage on the dashboard

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
