### PR TITLE
add border to footer on report pages, remove bottom border on last entity row

### DIFF
--- a/services/ui-src/src/components/reports/DrawerReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.test.tsx
@@ -298,6 +298,12 @@ describe("Test DrawerReportPage with completed entity", () => {
     expect(screen.queryAllByText("Enter")).toHaveLength(1);
     expect(screen.getAllByAltText("Entity is complete")).toHaveLength(1);
   });
+
+  test("should not render a bottom border on last entity row", () => {
+    const entityRows = screen.getAllByTestId("report-drawer");
+    const lastEntityRow = entityRows[1];
+    expect(lastEntityRow).toHaveStyle(`borderBottom: none`);
+  });
 });
 
 describe("Test DrawerReportPage accessibility", () => {

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -259,7 +259,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
         validateOnRender={validateOnRender}
         data-testid="report-drawer"
       />
-      <ReportPageFooter />
+      <ReportPageFooter drawerForm={true} />
     </Box>
   );
 };

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -183,7 +183,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
         : calculateEntityCompletion();
 
       return (
-        <Flex key={entity.id} sx={sx.entityRow}>
+        <Flex key={entity.id} sx={sx.entityRow} data-testid="report-drawer">
           {isEntityCompleted && (
             <Image
               src={completedIcon}
@@ -259,7 +259,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
         validateOnRender={validateOnRender}
         data-testid="report-drawer"
       />
-      <ReportPageFooter drawerForm={true} />
+      <ReportPageFooter />
     </Box>
   );
 };
@@ -288,6 +288,9 @@ const sx = {
     padding: "0.5rem",
     paddingLeft: "0.75rem",
     borderBottom: "1.5px solid var(--chakra-colors-palette-gray_lighter)",
+    "&:last-of-type": {
+      borderBottom: "none",
+    },
   },
   entityName: {
     fontSize: "lg",

--- a/services/ui-src/src/components/reports/ReportPageFooter.test.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.test.tsx
@@ -2,12 +2,13 @@ import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 // components
-import { ReportPageFooter } from "components";
+import { DrawerReportPage, ReportPageFooter } from "components";
 // types
 import { FormJson } from "types";
 // utils
 import {
   mockAdminUserStore,
+  mockDrawerReportPageJson,
   mockMcparReportStore,
   mockStateUserStore,
   RouterWrappedComponent,
@@ -38,7 +39,13 @@ mockedUseStore.mockReturnValue({
 
 const reportPageComponent = (
   <RouterWrappedComponent>
-    <ReportPageFooter data-testid="report-page-footer" />
+    <ReportPageFooter />
+  </RouterWrappedComponent>
+);
+
+const drawerReportPageComponent = (
+  <RouterWrappedComponent>
+    <DrawerReportPage route={mockDrawerReportPageJson} />
   </RouterWrappedComponent>
 );
 
@@ -49,7 +56,7 @@ describe("Test ReportPageFooter without form", () => {
 
   test("Check that ReportPageFooter without form renders", () => {
     const { getByTestId } = render(reportPageComponent);
-    expect(getByTestId("report-page-footer")).toBeVisible();
+    expect(getByTestId("report-footer")).toBeVisible();
   });
 
   test("ReportPageFooter without form previous navigation works", async () => {
@@ -64,6 +71,12 @@ describe("Test ReportPageFooter without form", () => {
     const continueButton = result.getByText("Continue");
     await userEvent.click(continueButton);
     expect(mockUseNavigate).toHaveBeenLastCalledWith("/mock-next-route");
+  });
+
+  test("should not render a border line on a DrawerReportPage", () => {
+    const result = render(drawerReportPageComponent);
+    const footer = result.getByTestId("report-footer");
+    expect(footer).not.toHaveStyle(`borderTop: 1px solid`);
   });
 });
 

--- a/services/ui-src/src/components/reports/ReportPageFooter.test.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.test.tsx
@@ -2,13 +2,12 @@ import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 // components
-import { DrawerReportPage, ReportPageFooter } from "components";
+import { ReportPageFooter } from "components";
 // types
 import { FormJson } from "types";
 // utils
 import {
   mockAdminUserStore,
-  mockDrawerReportPageJson,
   mockMcparReportStore,
   mockStateUserStore,
   RouterWrappedComponent,
@@ -43,12 +42,6 @@ const reportPageComponent = (
   </RouterWrappedComponent>
 );
 
-const drawerReportPageComponent = (
-  <RouterWrappedComponent>
-    <DrawerReportPage route={mockDrawerReportPageJson} />
-  </RouterWrappedComponent>
-);
-
 describe("Test ReportPageFooter without form", () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -71,12 +64,6 @@ describe("Test ReportPageFooter without form", () => {
     const continueButton = result.getByText("Continue");
     await userEvent.click(continueButton);
     expect(mockUseNavigate).toHaveBeenLastCalledWith("/mock-next-route");
-  });
-
-  test("should not render a border line on a DrawerReportPage", () => {
-    const result = render(drawerReportPageComponent);
-    const footer = result.getByTestId("report-page-footer");
-    expect(footer).not.toHaveStyle(`borderTop: 1px solid`);
   });
 });
 

--- a/services/ui-src/src/components/reports/ReportPageFooter.test.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.test.tsx
@@ -56,7 +56,7 @@ describe("Test ReportPageFooter without form", () => {
 
   test("Check that ReportPageFooter without form renders", () => {
     const { getByTestId } = render(reportPageComponent);
-    expect(getByTestId("report-footer")).toBeVisible();
+    expect(getByTestId("report-page-footer")).toBeVisible();
   });
 
   test("ReportPageFooter without form previous navigation works", async () => {
@@ -75,7 +75,7 @@ describe("Test ReportPageFooter without form", () => {
 
   test("should not render a border line on a DrawerReportPage", () => {
     const result = render(drawerReportPageComponent);
-    const footer = result.getByTestId("report-footer");
+    const footer = result.getByTestId("report-page-footer");
     expect(footer).not.toHaveStyle(`borderTop: 1px solid`);
   });
 });

--- a/services/ui-src/src/components/reports/ReportPageFooter.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.tsx
@@ -13,7 +13,6 @@ export const ReportPageFooter = ({
   submitting,
   form,
   praDisclosure,
-  drawerForm,
   ...props
 }: Props) => {
   const navigate = useNavigate();
@@ -68,11 +67,7 @@ export const ReportPageFooter = ({
   );
 
   return (
-    <Box
-      sx={drawerForm ? sx.footerBox : sx.footerBoxWithBorder}
-      {...props}
-      data-testid="report-page-footer"
-    >
+    <Box sx={sx.footerBox} {...props} data-testid="report-page-footer">
       <Flex>
         {!hidePrevious ? prevButton : null}
         {isReadOnly ? nextButtonNavOnly : nextButtonSubmit}
@@ -88,16 +83,11 @@ interface Props {
   form?: FormJson;
   submitting?: boolean;
   praDisclosure?: CustomHtmlElement[];
-  drawerForm?: boolean;
   [key: string]: any;
 }
 
 const sx = {
   footerBox: {
-    marginTop: "2.5rem",
-    paddingTop: "1.5rem",
-  },
-  footerBoxWithBorder: {
     marginTop: "2.5rem",
     paddingTop: "1.5rem",
     borderTop: "1px solid",

--- a/services/ui-src/src/components/reports/ReportPageFooter.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.tsx
@@ -71,7 +71,7 @@ export const ReportPageFooter = ({
     <Box
       sx={drawerForm ? sx.footerBox : sx.footerBoxWithBorder}
       {...props}
-      data-testid="report-footer"
+      data-testid="report-page-footer"
     >
       <Flex>
         {!hidePrevious ? prevButton : null}

--- a/services/ui-src/src/components/reports/ReportPageFooter.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.tsx
@@ -13,6 +13,7 @@ export const ReportPageFooter = ({
   submitting,
   form,
   praDisclosure,
+  drawerForm,
   ...props
 }: Props) => {
   const navigate = useNavigate();
@@ -67,7 +68,11 @@ export const ReportPageFooter = ({
   );
 
   return (
-    <Box sx={sx.footerBox} {...props}>
+    <Box
+      sx={drawerForm ? sx.footerBox : sx.footerBoxWithBorder}
+      {...props}
+      data-testid="report-footer"
+    >
       <Flex>
         {!hidePrevious ? prevButton : null}
         {isReadOnly ? nextButtonNavOnly : nextButtonSubmit}
@@ -83,6 +88,7 @@ interface Props {
   form?: FormJson;
   submitting?: boolean;
   praDisclosure?: CustomHtmlElement[];
+  drawerForm?: boolean;
   [key: string]: any;
 }
 
@@ -90,6 +96,12 @@ const sx = {
   footerBox: {
     marginTop: "2.5rem",
     paddingTop: "1.5rem",
+  },
+  footerBoxWithBorder: {
+    marginTop: "2.5rem",
+    paddingTop: "1.5rem",
+    borderTop: "1px solid",
+    borderColor: "palette.gray_light",
   },
   arrowIcon: {
     width: "1rem",

--- a/tests/cypress/e2e/mcpar/form.cy.js
+++ b/tests/cypress/e2e/mcpar/form.cy.js
@@ -129,16 +129,19 @@ const traverseRoutes = (routes) => {
 };
 
 const traverseRoute = (route) => {
-  // TODO: Don't just skip these routes
-  if (
-    [
-      "/mcpar/plan-level-indicators/patient-access-api",
-      "/mcpar/plan-level-indicators/prior-authorization",
-      "/mcpar/state-level-indicators/prior-authorization",
-    ].includes(route.path)
-  ) {
-    return;
-  }
+  /*
+   * TODO: account for flag status
+   *
+   * if (
+   *   [
+   *     "/mcpar/plan-level-indicators/patient-access-api",
+   *     "/mcpar/plan-level-indicators/prior-authorization",
+   *     "/mcpar/state-level-indicators/prior-authorization",
+   *   ].includes(route.path)
+   * ) {
+   *   return;
+   * }
+   */
 
   //only perform checks on route if it contains some time of form fill
   if (route.form || route.modalForm || route.drawerForm) {


### PR DESCRIPTION
### Description
After discussing with Kim, the MCPAR report pages are following MFP styling -- there is a footer border line before the navigation buttons at the bottom of every report page, and on drawer pages the last entity row  does not have a bottom border.

Also -- the update to the form e2e (commented out code block) is a very temporary solution until we have time to agree on what solution we want to use for tracking flag statuses in Cypress e2e tests since we are moving onto Playwright.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4161

---
### How to test
Create a MCPAR program, see that the pages all have a bottom border line that matches the spec, and see that the last row on a drawer page does not have a bottom border.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
