### PR TITLE
add padding in between fields

### DIFF
--- a/services/ui-src/src/components/fields/DynamicField.tsx
+++ b/services/ui-src/src/components/fields/DynamicField.tsx
@@ -329,6 +329,9 @@ const sx = {
     ".ds-u-clearfix": {
       width: "100%",
     },
+    "&:not(:first-of-type)": {
+      paddingTop: "2rem",
+    },
   },
   textField: {
     width: "100%",


### PR DESCRIPTION
### Description
Padding was lost between fields: 

<img width="549" alt="Screenshot 2024-12-02 at 8 53 20 AM" src="https://github.com/user-attachments/assets/ec9c1373-ad3b-415a-9ee0-82e78d0a16e3">


Added top padding like so:

<img width="546" alt="Screenshot 2024-12-02 at 8 53 08 AM" src="https://github.com/user-attachments/assets/88aa5552-aab1-45ca-8ecf-098f25571d24">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
bug found by Kim

---
### How to test
Create a work plan, see that the dynamic fields have 2rem padding in between fields, no change to padding above the first field and below the last field.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
