### PR TITLE
MCPAR PDF Feedback (Empty State)

### DIFF
--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -202,7 +202,7 @@
                     },
                     {
                       "type": "html",
-                      "content": " See Glossary in Excel Workbook for the definition of BSS entities."
+                      "content": ". See Glossary in Excel Workbook for the definition of BSS entities."
                     }
                   ]
                 },

--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -202,7 +202,7 @@
                     },
                     {
                       "type": "html",
-                      "content": "See Glossary in Excel Workbook for the definition of BSS entities."
+                      "content": " See Glossary in Excel Workbook for the definition of BSS entities."
                     }
                   ]
                 },

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.test.tsx
@@ -9,6 +9,8 @@ import {
   mockStandardReportPageJson,
   mockMlrReportStore,
   mockMcparReportStore,
+  mockVerbiageIntro,
+  mockDrawerForm,
 } from "utils/testing/setupJest";
 import { useStore } from "utils";
 // components
@@ -73,6 +75,18 @@ const mockDrawerPageJson = {
   ...mockDrawerReportPageJson,
   drawerForm: { id: "drawer", fields: reportJsonFields },
 };
+const mockMissingPlansPageJson = {
+  name: "mock-route-2a",
+  path: "/mcpar/plan-level-indicators/ilos",
+  pageType: "drawer",
+  entityType: "plans",
+  verbiage: {
+    intro: mockVerbiageIntro,
+    dashboardTitle: "Mock dashboard title",
+    drawerTitle: "Mock drawer title",
+  },
+  drawerForm: mockDrawerForm,
+};
 const mockEmptyPageJson = {
   ...mockStandardReportPageJson,
   form: {
@@ -115,11 +129,19 @@ const hintJson = {
 const exportedStandardTableComponent = (
   <ExportedReportFieldTable section={mockStandardPageJson} />
 );
+
 const exportedDrawerTableComponent = (
   <ExportedReportFieldTable
     section={mockDrawerPageJson as DrawerReportPageShape}
   />
 );
+
+const exportedMissingEntitiesComponent = (
+  <ExportedReportFieldTable
+    section={mockMissingPlansPageJson as DrawerReportPageShape}
+  />
+);
+
 const emptyTableComponent = (
   <ExportedReportFieldTable section={mockEmptyPageJson} />
 );
@@ -138,6 +160,21 @@ describe("ExportedReportFieldRow", () => {
   test("handles drawer pages with children", async () => {
     render(exportedDrawerTableComponent);
     const row = screen.getByTestId("exportTable");
+    expect(row).toBeVisible();
+  });
+
+  test("handles drawer pages with missing plans", async () => {
+    const missingEntitiesStore = {
+      ...mockMcparReportStore,
+      report: {
+        fieldData: {},
+      },
+    };
+    mockedUseStore.mockReturnValue({
+      ...missingEntitiesStore,
+    });
+    render(exportedMissingEntitiesComponent);
+    const row = screen.getByTestId("missingEntityMessage");
     expect(row).toBeVisible();
   });
 

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
@@ -48,8 +48,9 @@ export const ExportedReportFieldTable = ({ section }: Props) => {
 
   const hasPlans = report?.fieldData["plans"]?.length;
   const hasIlos = report?.fieldData["ilos"]?.length;
+  const hasBss = report?.fieldData["bssEntities"]?.length;
 
-  // handle missing entities rendering logic
+  // handle missing plans / ilos rendering logic
   const renderMissingEntityVerbiage = () => {
     let missingVerbiage;
     // verbiage for ILOS
@@ -68,14 +69,22 @@ export const ExportedReportFieldTable = ({ section }: Props) => {
     return missingVerbiage;
   };
 
-  const missingEntity = !(hasIlos || hasPlans);
+  const missingPlansOrIlos = !(hasIlos || hasPlans);
 
   return (
-    // if there are no plans or BSS entities added, render the appropriate verbiage
+    // if there are no plans added, render the appropriate verbiage
     <Box>
-      {entityType === entityTypes[0] && missingEntity ? (
+      {entityType === entityTypes[0] && missingPlansOrIlos ? (
         <Box sx={sx.missingEntityMessage}>
           {parseCustomHtml(renderMissingEntityVerbiage() || "")}
+        </Box>
+      ) : entityType === entityTypes[1] && !hasBss ? (
+        // if there are no BSS entities added, render the appropriate verbiage
+        <Box sx={sx.missingEntityMessage}>
+          {parseCustomHtml(
+            (section as DrawerReportPageShape).verbiage.missingEntityMessage ||
+              ""
+          )}
         </Box>
       ) : (
         <Table

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
@@ -52,21 +52,15 @@ export const ExportedReportFieldTable = ({ section }: Props) => {
 
   // handle missing plans / ilos rendering logic
   const renderMissingEntityVerbiage = () => {
-    let missingVerbiage;
+    const { path, verbiage: v } = section as DrawerReportPageShape;
+
     // verbiage for ILOS
-    if (section.path === "/mcpar/plan-level-indicators/ilos" && !hasIlos) {
-      !hasPlans
-        ? (missingVerbiage = (section as DrawerReportPageShape).verbiage
-            .missingPlansAndIlosMessage)
-        : (missingVerbiage = (section as DrawerReportPageShape).verbiage
-            .missingIlosMessage);
-      return missingVerbiage;
+    if (path === "/mcpar/plan-level-indicators/ilos" && !hasIlos) {
+      return !hasPlans ? v.missingPlansAndIlosMessage : v.missingIlosMessage;
     }
+
     // verbiage for missing plans
-    !hasPlans &&
-      (missingVerbiage = (section as DrawerReportPageShape).verbiage
-        .missingEntityMessage);
-    return missingVerbiage;
+    return !hasPlans ? v.missingEntityMessage : undefined;
   };
 
   const missingPlansOrIlos = !(hasIlos || hasPlans);

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
@@ -235,7 +235,6 @@ const sx = {
   },
   missingEntityMessage: {
     fontWeight: "bold",
-
     ol: {
       paddingLeft: "1rem",
     },

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
@@ -75,12 +75,12 @@ export const ExportedReportFieldTable = ({ section }: Props) => {
     // if there are no plans added, render the appropriate verbiage
     <Box>
       {entityType === entityTypes[0] && missingPlansOrIlos ? (
-        <Box sx={sx.missingEntityMessage}>
+        <Box sx={sx.missingEntityMessage} data-testid="missingEntityMessage">
           {parseCustomHtml(renderMissingEntityVerbiage() || "")}
         </Box>
       ) : entityType === entityTypes[1] && !hasBss ? (
         // if there are no BSS entities added, render the appropriate verbiage
-        <Box sx={sx.missingEntityMessage}>
+        <Box sx={sx.missingEntityMessage} data-testid="missingEntityMessage">
           {parseCustomHtml(
             (section as DrawerReportPageShape).verbiage.missingEntityMessage ||
               ""

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
@@ -13,6 +13,7 @@ import {
   FormLayoutElement,
   isFieldElement,
   ReportType,
+  entityTypes,
 } from "types";
 // verbiage
 import verbiage from "verbiage/pages/mcpar/mcpar-export";
@@ -45,24 +46,36 @@ export const ExportedReportFieldTable = ({ section }: Props) => {
   const reportType = report?.reportType as ReportType;
   const hideHintText = reportType === ReportType.MLR;
 
-  // handle ILOS rendering logic
-  const renderIlosVerbiage = () => {
-    const hasIlos = report?.fieldData["ilos"]?.length;
-    return section.path === "/mcpar/plan-level-indicators/ilos" && !hasIlos;
+  const hasPlans = report?.fieldData["plans"]?.length;
+  const hasIlos = report?.fieldData["ilos"]?.length;
+
+  // handle missing entities rendering logic
+  const renderMissingEntityVerbiage = () => {
+    let missingVerbiage;
+    // verbiage for ILOS
+    if (section.path === "/mcpar/plan-level-indicators/ilos" && !hasIlos) {
+      !hasPlans
+        ? (missingVerbiage = (section as DrawerReportPageShape).verbiage
+            .missingPlansAndIlosMessage)
+        : (missingVerbiage = (section as DrawerReportPageShape).verbiage
+            .missingIlosMessage);
+      return missingVerbiage;
+    }
+    // verbiage for missing plans
+    !hasPlans &&
+      (missingVerbiage = (section as DrawerReportPageShape).verbiage
+        .missingEntityMessage);
+    return missingVerbiage;
   };
 
-  const hasPlans = report?.fieldData["plans"]?.length;
-
-  const missingVerbiage = !hasPlans
-    ? (section as DrawerReportPageShape).verbiage.missingPlansAndIlosMessage
-    : (section as DrawerReportPageShape).verbiage.missingIlosMessage;
+  const missingEntity = !(hasIlos || hasPlans);
 
   return (
-    // if there are no ILOS added, render the appropriate verbiage
+    // if there are no plans or BSS entities added, render the appropriate verbiage
     <Box>
-      {renderIlosVerbiage() ? (
+      {entityType === entityTypes[0] && missingEntity ? (
         <Box sx={sx.missingEntityMessage}>
-          {parseCustomHtml(missingVerbiage ?? "")}
+          {parseCustomHtml(renderMissingEntityVerbiage() || "")}
         </Box>
       ) : (
         <Table

--- a/services/ui-src/src/components/export/ExportedSectionHeading.tsx
+++ b/services/ui-src/src/components/export/ExportedSectionHeading.tsx
@@ -78,6 +78,14 @@ const sx = {
     p: {
       margin: "1.5rem 0",
     },
+    a: {
+      color: "palette.base",
+      textDecoration: "none",
+      "&:hover": {
+        color: "palette.base",
+        textDecoration: "none",
+      },
+    },
     h3: {
       fontSize: "xl",
     },

--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -196,24 +196,15 @@ export const renderResponseData = (
 
   const missingEntryStyle = notApplicable ? sx.notApplicable : sx.noResponse;
 
-  if (!hasResponse && !isChoiceListField) {
-    return <Text sx={missingEntryStyle}>{missingEntryVerbiage}</Text>;
+  if (!hasResponse) {
+    const isIlos = formField.id === "plan_ilosOfferedByPlan";
+    return (
+      !isIlos && <Text sx={missingEntryStyle}>{missingEntryVerbiage}</Text>
+    );
     // need to explicitly make this else if conditional so
   }
 
-  if (
-    !hasResponse &&
-    isChoiceListField &&
-    formField.id !== "plan_ilosOfferedByPlan"
-  ) {
-    return (
-      <Text
-        sx={sx.noResponseOptional}
-      >{`${verbiage.missingEntry.noResponse}, optional`}</Text>
-    );
-  }
-
-  // chandle choice list fields (checkbox, radio)
+  // handle choice list fields (checkbox, radio)
   if (isChoiceListField) {
     return renderChoiceListFieldResponse(
       formField,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Addressing PDF feedback from Design:
- Rendering links as regular text
- If there are missing entities (i.e. `Plans`, `ILOS`, or `BSS entities`), the appropriate verbiage is displayed
- Fixed a bug where required fields were rendering as optional

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a new MCPAR
- Don't add anything to the report
- Navigate to the `Review & submit` page to export PDF

There should be no visible hyperlinks across the PDF and **Section D** and **Section E** should be displaying the appropriate "missing entities" verbiage.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
