### PR TITLE
Amplify V6 Fix: Remove window.location call in logout to stop cancelling cognito call

### DIFF
--- a/services/ui-src/src/utils/auth/UserProvider.tsx
+++ b/services/ui-src/src/utils/auth/UserProvider.tsx
@@ -53,7 +53,6 @@ export const UserProvider = ({ children }: Props) => {
     } catch (error) {
       console.log(error); // eslint-disable-line no-console
     }
-    window.location.assign(config.POST_SIGNOUT_REDIRECT);
   }, []);
 
   const checkAuthState = useCallback(async () => {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Garrett and I have been working on the Amplify logout issues and we think its because the call get cancelled due to the redirect happening. Amplifys signout seems to handle this redirect just fine with out it, so we're hoping by just removing that line the logout issue will be fixed!

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Sign into MCR with IDM
Click logout in the application
Wait until you're in the IDM site and log out of that too
Navigate to mdctmcrdev.cms.gov
Click sign into MCR with IDM
If you were taken to the login screen to input your username and password, it worked!
If you were taken directly into the application, it did not work :(

