### PR TITLE
Use flag to filter routes

### DIFF
--- a/services/app-api/utils/formTemplates/formTemplates.test.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.test.ts
@@ -1,5 +1,6 @@
 import {
   compileValidationJsonFromRoutes,
+  filterByFlag,
   flattenReportRoutesArray,
   formTemplateForReportType,
   generatePCCMTemplate,
@@ -407,5 +408,34 @@ describe("Test compileValidationJsonFromRoutes", () => {
       "with-label": "text",
       "mock-nested-field": "radio",
     });
+  });
+});
+
+describe("filterByFlag()", () => {
+  it("Return whether route is allowed", () => {
+    const routes: ReportRoute[] = [
+      {
+        name: "noFlag",
+        path: "/noFlag",
+      },
+      {
+        name: "filteredFlag",
+        path: "/filteredFlag",
+        flag: "filteredFlag",
+      },
+      {
+        name: "allowedFlag",
+        path: "/allowedFlag",
+        flag: "allowedFlag",
+      },
+    ];
+    const route1 = filterByFlag(routes[0], "filteredFlag");
+    expect(route1).toEqual(true);
+
+    const route2 = filterByFlag(routes[1], "filteredFlag");
+    expect(route2).toEqual(false);
+
+    const route3 = filterByFlag(routes[2], "filteredFlag");
+    expect(route3).toEqual(true);
   });
 });

--- a/services/app-api/utils/formTemplates/formTemplates.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.ts
@@ -323,18 +323,17 @@ const makePCCMTemplateModifications = (reportTemplate: ReportJson) => {
   programTypeQuestion.props!.disabled = true;
 };
 
+export const filterByFlag = (route: ReportRoute, flag: string) => {
+  return route?.flag !== flag;
+};
+
 const handleTemplateForNovMcparRelease = (originalReportTemplate: any) => {
   const reportTemplate = structuredClone(originalReportTemplate);
-  const routesToFilter = [
-    "/mcpar/state-level-indicators/prior-authorization",
-    "/mcpar/plan-level-indicators/prior-authorization",
-    "/mcpar/plan-level-indicators/patient-access-api",
-  ];
 
   for (let route of reportTemplate.routes) {
     if (route?.children) {
-      route.children = route.children.filter(
-        (childRoute: ReportRoute) => !routesToFilter.includes(childRoute.path)
+      route.children = route.children.filter((childRoute: ReportRoute) =>
+        filterByFlag(childRoute, "novMcparRelease")
       );
     }
   }

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -36,6 +36,7 @@ export interface ReportRouteBase {
   name: string;
   path: string;
   pageType?: string;
+  flag?: string;
 }
 
 export type ReportRouteWithForm =


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Add a method that uses the `flag` attribute added to `mcpar.json` to remove a route when building a form template
- Follow up to https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/11962

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

1. cd `app-api`
2. `yarn test` should pass

<!-- ### Notes -->
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

<!-- --- -->
<!-- ### Pre-merge checklist -->
<!-- Complete the following steps before merging -->

<!-- #### Review -->
<!-- - [ ] Design: This work has been reviewed and approved by design, if necessary -->
<!-- - [ ] Product: This work has been reviewed and approved by product owner, if necessary -->

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->

