### PR TITLE
Remove unnecessary prop drilling and add tests

### DIFF
--- a/services/ui-src/src/components/app/App.tsx
+++ b/services/ui-src/src/components/app/App.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from "react";
+import { useEffect } from "react";
 import { useLocation, Route, Routes } from "react-router-dom";
 import { ErrorBoundary } from "react-error-boundary";
 // components
@@ -21,7 +21,6 @@ import {
   fireTealiumPageView,
   isApparentReportPage,
   makeMediaQueryClasses,
-  UserContext,
   useStore,
 } from "utils";
 
@@ -29,8 +28,6 @@ export const App = () => {
   const mqClasses = makeMediaQueryClasses();
 
   // state management
-  const context = useContext(UserContext);
-  const { logout } = context;
   const { user, showLocalLogins } = useStore();
 
   const { pathname, key } = useLocation();
@@ -53,7 +50,7 @@ export const App = () => {
           <ReportProvider>
             <Timeout />
             <MainSkipNav />
-            {!isExportPage && <Header handleLogout={logout} />}
+            {!isExportPage && <Header />}
             {isExportPage && <ExportedReportBanner />}
             <Container sx={sx.appContainer} data-testid="app-container">
               <ErrorBoundary FallbackComponent={Error}>

--- a/services/ui-src/src/components/layout/Header.test.tsx
+++ b/services/ui-src/src/components/layout/Header.test.tsx
@@ -20,14 +20,14 @@ mockedUseStore.mockReturnValue({
 
 const headerComponent = (
   <RouterWrappedComponent>
-    <Header handleLogout={() => {}} />
+    <Header />
   </RouterWrappedComponent>
 );
 
 const reportComponent = (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockMcparReportContext}>
-      <Header handleLogout={() => {}} />
+      <Header />
       <ReportPageWrapper />
     </ReportContext.Provider>
   </RouterWrappedComponent>

--- a/services/ui-src/src/components/layout/Header.tsx
+++ b/services/ui-src/src/components/layout/Header.tsx
@@ -12,7 +12,7 @@ import getHelpIcon from "assets/icons/icon_help.png";
 import checkIcon from "assets/icons/icon_check_gray.png";
 import closeIcon from "assets/icons/icon_cancel_x_circle.png";
 
-export const Header = ({ handleLogout }: Props) => {
+export const Header = () => {
   const { isMobile } = useBreakpoint();
   const { isReportPage } = useContext(ReportContext);
 
@@ -47,7 +47,7 @@ export const Header = ({ handleLogout }: Props) => {
                   hideText={isMobile}
                 />
               </Link>
-              <Menu handleLogout={handleLogout} />
+              <Menu />
             </Flex>
           </Flex>
         </Container>
@@ -100,10 +100,6 @@ export const Header = ({ handleLogout }: Props) => {
     </Box>
   );
 };
-
-interface Props {
-  handleLogout: () => void;
-}
 
 const sx = {
   root: {

--- a/services/ui-src/src/components/menus/Menu.test.tsx
+++ b/services/ui-src/src/components/menus/Menu.test.tsx
@@ -1,13 +1,27 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
-// utils
-import { RouterWrappedComponent } from "utils/testing/setupJest";
 //components
 import { Menu } from "components";
+// utils
+import { RouterWrappedComponent } from "utils/testing/setupJest";
+import { UserContext } from "utils";
+
+const mockLogout = jest.fn();
+
+const mockUserContext = {
+  user: undefined,
+  logout: mockLogout,
+  loginWithIDM: jest.fn(),
+  updateTimeout: jest.fn(),
+  getExpiration: jest.fn(),
+};
 
 const menuComponent = (
   <RouterWrappedComponent>
-    <Menu handleLogout={() => {}} />
+    <UserContext.Provider value={mockUserContext}>
+      <Menu />
+    </UserContext.Provider>
   </RouterWrappedComponent>
 );
 
@@ -18,6 +32,12 @@ describe("Test Menu", () => {
 
   test("Menu button is visible", () => {
     expect(screen.getByAltText("Arrow down")).toBeVisible();
+  });
+
+  test("Menu button logout fires logout function", async () => {
+    const logoutButton = screen.getByText("Log Out");
+    await userEvent.click(logoutButton);
+    expect(mockLogout).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/services/ui-src/src/components/menus/Menu.tsx
+++ b/services/ui-src/src/components/menus/Menu.tsx
@@ -1,3 +1,4 @@
+import { useContext } from "react";
 import { Link as RouterLink } from "react-router-dom";
 // components
 import {
@@ -12,14 +13,15 @@ import {
 } from "@chakra-ui/react";
 import { MenuOption } from "components";
 // utils
-import { useBreakpoint } from "utils";
+import { useBreakpoint, UserContext } from "utils";
 // assets
 import accountCircleIcon from "assets/icons/icon_account_circle.png";
 import chevronDownIcon from "assets/icons/icon_arrow_down.png";
 import editIcon from "assets/icons/icon_edit_square.png";
 import logoutIcon from "assets/icons/icon_arrow_right_square.png";
 
-export const Menu = ({ handleLogout }: Props) => {
+export const Menu = () => {
+  const { logout } = useContext(UserContext);
   const { isMobile } = useBreakpoint();
   return (
     <MenuRoot offset={[8, 20]}>
@@ -54,7 +56,7 @@ export const Menu = ({ handleLogout }: Props) => {
           </MenuItem>
         </Link>
         <MenuItem
-          onClick={handleLogout}
+          onClick={logout}
           sx={sx.menuItem}
           tabIndex={0}
           data-testid="header-menu-option-log-out"
@@ -65,10 +67,6 @@ export const Menu = ({ handleLogout }: Props) => {
     </MenuRoot>
   );
 };
-
-interface Props {
-  handleLogout: () => void;
-}
 
 const sx = {
   menuButton: {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Stumbled upon some prop drilling which I believe had no benefit. This removes it, simplifies context access, and adds a test!

First found in [MFP](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/826)

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Tests pass
Logout still works as a user