### PR TITLE
fix some validation that was removing fields, and only add applicable fields

### DIFF
--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -97,11 +97,16 @@ export const createReport = handler(async (event, _context) => {
   const fieldDataId: string = KSUID.randomSync().string;
   const formTemplateId: string = formTemplateVersion?.id;
 
+  let validationSchema = formTemplate.validationJson;
+  if (reportType === "NAAAR") {
+    validationSchema["analysisMethods"] = "objectArray";
+  }
+
   // Validate field data
   let validatedFieldData;
   try {
     validatedFieldData = await validateFieldData(
-      formTemplate.validationJson,
+      validationSchema,
       unvalidatedFieldData
     );
   } catch {

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -132,7 +132,14 @@ export const AddEditReportModal = ({
         previousRevisions: [],
       },
       fieldData: {
-        programName,
+        // All new MLR reports are NOT resubmissions by definition.
+        versionControl: [
+          {
+            // pragma: allowlist nextline secret
+            key: "versionControl-KFCd3rfEu3eT4UFskUhDtx",
+            value: "No, this is an initial submission",
+          },
+        ],
       },
     };
   };
@@ -170,8 +177,7 @@ export const AddEditReportModal = ({
         naaarReport,
       },
       fieldData: {
-        programName,
-        ["analysisMethods"]: DEFAULT_ANALYSIS_METHODS,
+        analysisMethods: DEFAULT_ANALYSIS_METHODS,
       },
     };
   };
@@ -220,18 +226,6 @@ export const AddEditReportModal = ({
         fieldData: {
           ...dataToWrite.fieldData,
           stateName: States[activeState as keyof typeof States],
-          submissionCount: 0,
-          // All new MLR reports are NOT resubmissions by definition.
-          versionControl:
-            reportType === "MLR"
-              ? [
-                  {
-                    // pragma: allowlist nextline secret
-                    key: "versionControl-KFCd3rfEu3eT4UFskUhDtx",
-                    value: "No, this is an initial submission",
-                  },
-                ]
-              : undefined,
         },
       });
     }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Analysis methods gets stripped from our fieldData unless we add it to the validation schema
  - Check if report is NAAAR and then add to validation
  - Note: still not positive the drawer information will save correctly with this but we can figure it out later
- Move `versionControl` to mlr-only method, since it's only for that report type
- Remove `submissionCount` from fieldData
  - It exists in metadata and is never referenced from fieldData (as far as I could tell)
  - It is stripped from fieldData on create anyway because it's not in the validation schema
- Remove `programName` from MLR and NAAAR
  - It is only used in mcpar and likely just got copied over by accident
  - It is stripped from fieldData on create anyway because it's not the in validation schema (other than mcpar)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4115 (partial)

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[deployed url](https://d3uzmu4pvkgkrr.cloudfront.net/)
- create a NAAAR and verify that analysis methods exists in fieldData when you enter the report (verify with react plugin or by going to analysis methods page)
- creating and editing reports works as before
- do a double check that removed fields are not used anywhere (or at least not referenced where they were created, like in fieldData)

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
i forgot how to write nice pr descriptions

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
