### PR TITLE
Add best-practice axe rule set

### DIFF
--- a/tests/cypress/support/accessibility.js
+++ b/tests/cypress/support/accessibility.js
@@ -23,7 +23,7 @@ Cypress.Commands.add("runAccessibilityTests", () => {
   cy.checkA11y(
     null,
     {
-      values: ["wcag2a", "wcag2aa"],
+      values: ["wcag2a", "wcag2aa", "best-practice"],
       includedImpacts: ["minor", "moderate", "serious", "critical"],
       rules: {
         "duplicate-id": { enabled: false },

--- a/tests/playwright/utils/a11y.ts
+++ b/tests/playwright/utils/a11y.ts
@@ -14,7 +14,7 @@ export async function e2eA11y(page: Page, url: string) {
   for (const size of Object.values(breakpoints)) {
     page.setViewportSize({ width: size[0], height: size[1] });
     const results = await new AxeBuilder({ page })
-      .withTags(["wcag2a", "wcag2aa"])
+      .withTags(["wcag2a", "wcag2aa", "best-practice"])
       .disableRules(["duplicate-id"])
       .analyze();
     expect(results.violations).toEqual([]);

--- a/tests/playwright/utils/pageObjects/base.page.ts
+++ b/tests/playwright/utils/pageObjects/base.page.ts
@@ -88,7 +88,7 @@ export default class BasePage {
     for (const size of Object.values(breakpoints)) {
       this.page.setViewportSize({ width: size[0], height: size[1] });
       const results = await new AxeBuilder({ page: this.page })
-        .withTags(["wcag2a", "wcag2aa"])
+        .withTags(["wcag2a", "wcag2aa", "best-practice"])
         .disableRules(["duplicate-id"])
         .analyze();
       expect(results.violations).toEqual([]);


### PR DESCRIPTION
### Description
Adds the [best practice](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md#best-practices-rules) axe-core rule set. This rule set will improve future development as it will catch more avoidable mistakes. 

I rant the tests locally with this new rule set and there were no error caught. I'm hoping that will also be the case in CI/CD of this PR.


---
### How to test
Run tests locally, they should still pass.


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment


