### PR TITLE
Add a longer wait to Cypress test

### DIFF
--- a/logs/launchdarkly-flags.log
+++ b/logs/launchdarkly-flags.log
@@ -2,21 +2,21 @@
 
 # LaunchDarkly flags in components
 ./services/ui-src/src/components/app/AppRoutes.tsx:30:useFlags()?.naaarReport;
-./services/ui-src/src/components/cards/TemplateCard.tsx:33:useFlags()?.naaarReport;
+./services/ui-src/src/components/cards/TemplateCard.tsx:34:useFlags()?.naaarReport;
 ./services/ui-src/src/components/forms/AdminDashSelector.tsx:40:useFlags()?.naaarReport;
 ./services/ui-src/src/components/modals/AddEditReportModal.tsx:43:useFlags()?.naaarReport;
 ./services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx:213:useFlags()?.sortableDashboardTable;
 
 # LaunchDarkly flags in tests
-./services/ui-src/src/components/app/AppRoutes.test.tsx:138:mockLDFlags.set({ naaarReport: true });
-./services/ui-src/src/components/app/AppRoutes.test.tsx:150:mockLDFlags.set({ naaarReport: false });
+./services/ui-src/src/components/app/AppRoutes.test.tsx:141:mockLDFlags.set({ naaarReport: true });
+./services/ui-src/src/components/app/AppRoutes.test.tsx:155:mockLDFlags.set({ naaarReport: false });
 ./services/ui-src/src/components/app/AppRoutes.test.tsx:25:mockLDFlags.setDefault({ naaarReport: false });
-./services/ui-src/src/components/cards/TemplateCard.test.tsx:140:mockLDFlags.set({ naaarReport: true });
-./services/ui-src/src/components/cards/TemplateCard.test.tsx:150:mockLDFlags.set({ naaarReport: false });
+./services/ui-src/src/components/cards/TemplateCard.test.tsx:145:mockLDFlags.set({ naaarReport: true });
+./services/ui-src/src/components/cards/TemplateCard.test.tsx:157:mockLDFlags.set({ naaarReport: false });
 ./services/ui-src/src/components/cards/TemplateCard.test.tsx:60:mockLDFlags.setDefault({ naaarReport: true });
 ./services/ui-src/src/components/forms/AdminDashSelector.test.tsx:32:mockLDFlags.setDefault({ naaarReport: true });
-./services/ui-src/src/components/forms/AdminDashSelector.test.tsx:62:mockLDFlags.set({ naaarReport: true });
-./services/ui-src/src/components/forms/AdminDashSelector.test.tsx:72:mockLDFlags.set({ naaarReport: false });
+./services/ui-src/src/components/forms/AdminDashSelector.test.tsx:63:mockLDFlags.set({ naaarReport: true });
+./services/ui-src/src/components/forms/AdminDashSelector.test.tsx:73:mockLDFlags.set({ naaarReport: false });
 ./services/ui-src/src/components/pages/Dashboard/SortableDashboardTable.test.tsx:143:mockLDFlags.set({ sortableDashboardTable: true });
 ./services/ui-src/src/components/pages/Dashboard/SortableDashboardTable.test.tsx:279:mockLDFlags.set({ sortableDashboardTable: true });
 ./services/ui-src/src/components/pages/Dashboard/SortableDashboardTable.test.tsx:297:mockLDFlags.set({ sortableDashboardTable: true });

--- a/logs/todos.log
+++ b/logs/todos.log
@@ -2,8 +2,8 @@
 
 ./services/app-api/handlers/reports/fetch.ts:69: TODO: strict typing
 ./services/app-api/handlers/reports/fetch.ts:80: TODO: strict typing
-./services/ui-src/src/components/layout/Timeout.tsx:33: TODO: When autosave is implemented, set up a callback function to listen to calls to update in authLifecycle
-./services/ui-src/src/components/reports/ModalOverlayReportPage.test.tsx:148:todo Write a test to make sure admins can't click/change details?
+./services/ui-src/src/components/layout/Timeout.tsx:36: TODO: When autosave is implemented, set up a callback function to listen to calls to update in authLifecycle
+./services/ui-src/src/components/reports/ModalOverlayReportPage.test.tsx:149:todo Write a test to make sure admins can't click/change details?
 ./services/ui-src/src/components/tables/EntityRow.tsx:26: TODO: refactor to handle NAAAR analysis methods
 ./services/ui-src/src/components/tables/SortableTable.tsx:196: TODO: add additional styling for two-column dynamic field tables if needed
 ./services/ui-src/src/components/tables/Table.tsx:135: TODO: add additional styling for two-column dynamic field tables if needed

--- a/tests/cypress/e2e/mcpar/dashboard.cy.js
+++ b/tests/cypress/e2e/mcpar/dashboard.cy.js
@@ -100,7 +100,7 @@ describe("Admin Archiving", () => {
     }).should("be.visible");
 
     cy.get('button:contains("Unarchive")').last().click();
-    cy.wait(500);
+    cy.wait(1000);
     cy.get('button:contains("Archive")').should("be.visible");
   });
 });


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Follow up to https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12015. This test passes locally and in branches, but has been failing when merged to `main`. Adding a longer wait to see if that helps.

Also update `todos` and `flags` logs from latest main updates.

<!-- ### Related ticket(s) -->
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
<!-- CMDCT- -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. `yarn test` to test locally

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

The failing test was changed from `cy.contains("Archive").should("be.visible");` to `cy.get('button:contains("Archive")').should("be.visible");` in https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12009/ because the former test was a false positive, since the text is also used in a table header. We want to test that the text is within a button in a table row.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

<!-- --- -->
<!-- ### Pre-merge checklist -->
<!-- Complete the following steps before merging -->

<!-- #### Review -->
<!-- - [ ] Design: This work has been reviewed and approved by design, if necessary -->
<!-- - [ ] Product: This work has been reviewed and approved by product owner, if necessary -->

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->

