### PR TITLE
Cmdct 4236 - Refactor of DrawerReportPage

### DIFF
--- a/logs/launchdarkly-flags.log
+++ b/logs/launchdarkly-flags.log
@@ -2,21 +2,21 @@
 
 # LaunchDarkly flags in components
 ./services/ui-src/src/components/app/AppRoutes.tsx:30:useFlags()?.naaarReport;
-./services/ui-src/src/components/cards/TemplateCard.tsx:33:useFlags()?.naaarReport;
+./services/ui-src/src/components/cards/TemplateCard.tsx:34:useFlags()?.naaarReport;
 ./services/ui-src/src/components/forms/AdminDashSelector.tsx:40:useFlags()?.naaarReport;
 ./services/ui-src/src/components/modals/AddEditReportModal.tsx:43:useFlags()?.naaarReport;
 ./services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx:213:useFlags()?.sortableDashboardTable;
 
 # LaunchDarkly flags in tests
-./services/ui-src/src/components/app/AppRoutes.test.tsx:138:mockLDFlags.set({ naaarReport: true });
-./services/ui-src/src/components/app/AppRoutes.test.tsx:150:mockLDFlags.set({ naaarReport: false });
+./services/ui-src/src/components/app/AppRoutes.test.tsx:141:mockLDFlags.set({ naaarReport: true });
+./services/ui-src/src/components/app/AppRoutes.test.tsx:155:mockLDFlags.set({ naaarReport: false });
 ./services/ui-src/src/components/app/AppRoutes.test.tsx:25:mockLDFlags.setDefault({ naaarReport: false });
-./services/ui-src/src/components/cards/TemplateCard.test.tsx:140:mockLDFlags.set({ naaarReport: true });
-./services/ui-src/src/components/cards/TemplateCard.test.tsx:150:mockLDFlags.set({ naaarReport: false });
+./services/ui-src/src/components/cards/TemplateCard.test.tsx:145:mockLDFlags.set({ naaarReport: true });
+./services/ui-src/src/components/cards/TemplateCard.test.tsx:157:mockLDFlags.set({ naaarReport: false });
 ./services/ui-src/src/components/cards/TemplateCard.test.tsx:60:mockLDFlags.setDefault({ naaarReport: true });
 ./services/ui-src/src/components/forms/AdminDashSelector.test.tsx:32:mockLDFlags.setDefault({ naaarReport: true });
-./services/ui-src/src/components/forms/AdminDashSelector.test.tsx:62:mockLDFlags.set({ naaarReport: true });
-./services/ui-src/src/components/forms/AdminDashSelector.test.tsx:72:mockLDFlags.set({ naaarReport: false });
+./services/ui-src/src/components/forms/AdminDashSelector.test.tsx:63:mockLDFlags.set({ naaarReport: true });
+./services/ui-src/src/components/forms/AdminDashSelector.test.tsx:73:mockLDFlags.set({ naaarReport: false });
 ./services/ui-src/src/components/pages/Dashboard/SortableDashboardTable.test.tsx:143:mockLDFlags.set({ sortableDashboardTable: true });
 ./services/ui-src/src/components/pages/Dashboard/SortableDashboardTable.test.tsx:279:mockLDFlags.set({ sortableDashboardTable: true });
 ./services/ui-src/src/components/pages/Dashboard/SortableDashboardTable.test.tsx:297:mockLDFlags.set({ sortableDashboardTable: true });

--- a/logs/todos.log
+++ b/logs/todos.log
@@ -2,8 +2,8 @@
 
 ./services/app-api/handlers/reports/fetch.ts:69: TODO: strict typing
 ./services/app-api/handlers/reports/fetch.ts:80: TODO: strict typing
-./services/ui-src/src/components/layout/Timeout.tsx:33: TODO: When autosave is implemented, set up a callback function to listen to calls to update in authLifecycle
-./services/ui-src/src/components/reports/ModalOverlayReportPage.test.tsx:148:todo Write a test to make sure admins can't click/change details?
+./services/ui-src/src/components/layout/Timeout.tsx:36: TODO: When autosave is implemented, set up a callback function to listen to calls to update in authLifecycle
+./services/ui-src/src/components/reports/ModalOverlayReportPage.test.tsx:149:todo Write a test to make sure admins can't click/change details?
 ./services/ui-src/src/components/tables/EntityRow.tsx:26: TODO: refactor to handle NAAAR analysis methods
 ./services/ui-src/src/components/tables/SortableTable.tsx:196: TODO: add additional styling for two-column dynamic field tables if needed
 ./services/ui-src/src/components/tables/Table.tsx:135: TODO: add additional styling for two-column dynamic field tables if needed

--- a/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
@@ -1,0 +1,303 @@
+import { Box, Button, Flex, Heading, Image, Text } from "@chakra-ui/react";
+import {
+  DrawerReportPageShape,
+  EntityShape,
+  FormField,
+  FormJson,
+  isFieldElement,
+  ReportType,
+} from "types";
+import { AnyObject } from "yup/lib/types";
+import unfinishedIcon from "assets/icons/icon_error_circle_bright.png";
+import deleteIcon from "assets/icons/icon_cancel_x_circle.png";
+import completedIcon from "assets/icons/icon_check_circle.png";
+import { isIlosCompleted, useStore } from "utils";
+import {
+  generateAddEntityDrawerItemFields,
+  generateDrawerItemFields,
+} from "utils/forms/dynamicItemFields";
+import { getDefaultAnalysisMethodIds } from "../../constants";
+
+export const DrawerReportPageEntityRows = ({
+  route,
+  entities,
+  openRowDrawer,
+  openDeleteEntityModal,
+  priorAuthDisabled,
+  patientAccessDisabled,
+}: Props) => {
+  const { drawerForm } = route;
+  const addEntityDrawerForm = route.addEntityDrawerForm || ({} as FormJson);
+  const canAddEntities = !!addEntityDrawerForm.id;
+  const { report } = useStore();
+  const { userIsEndUser } = useStore().user ?? {};
+
+  const isAnalysisMethodsPage = route.path.includes("analysis-methods");
+  const hasPlans = report?.fieldData?.["plans"]?.length > 0;
+  const plans = report?.fieldData?.plans?.map((plan: { name: string }) => plan);
+  const reportingOnIlos = route.path === "/mcpar/plan-level-indicators/ilos";
+  const ilos = report?.fieldData?.["ilos"];
+  const hasIlos = ilos?.length;
+
+  const getForm = (
+    reportType?: string,
+    isCustomEntityForm: boolean = false
+  ) => {
+    let modifiedForm = drawerForm;
+    switch (reportType) {
+      case ReportType.NAAAR:
+        if (isAnalysisMethodsPage && hasPlans) {
+          modifiedForm = isCustomEntityForm
+            ? generateAddEntityDrawerItemFields(
+                addEntityDrawerForm,
+                plans,
+                "plan"
+              )
+            : generateDrawerItemFields(drawerForm, plans, "plan");
+        }
+        break;
+      case ReportType.MCPAR:
+        if (ilos && reportingOnIlos) {
+          modifiedForm = generateDrawerItemFields(drawerForm, ilos, "ilos");
+        }
+        break;
+      default:
+    }
+    return modifiedForm;
+  };
+
+  const enterButton = (entity: EntityShape, isEntityCompleted: boolean) => {
+    let disabled = false;
+    let style = sx.enterButton;
+    const buttonText = userIsEndUser
+      ? isEntityCompleted
+        ? "Edit"
+        : "Enter"
+      : "View";
+
+    if (
+      (route.path === "/mcpar/plan-level-indicators/ilos" && !hasIlos) ||
+      (route.path === "/mcpar/plan-level-indicators/prior-authorization" &&
+        priorAuthDisabled) ||
+      (route.path === "/mcpar/plan-level-indicators/patient-access-api" &&
+        patientAccessDisabled) ||
+      (isAnalysisMethodsPage && !hasPlans)
+    ) {
+      style = sx.disabledButton;
+      disabled = true;
+    }
+
+    return (
+      <Button
+        sx={style}
+        onClick={() => openRowDrawer(entity)}
+        variant="outline"
+        disabled={disabled}
+      >
+        {buttonText}
+      </Button>
+    );
+  };
+
+  const form = getForm(report?.reportType);
+  const addEntityForm = getForm(report?.reportType, true);
+
+  const entityRows = (entities: EntityShape[]) => {
+    return entities?.map((entity) => {
+      const isCustomEntity =
+        canAddEntities && !getDefaultAnalysisMethodIds().includes(entity.id);
+      const calculateEntityCompletion = () => {
+        let formFields = form.fields;
+        if (isCustomEntity) {
+          formFields = addEntityForm.fields;
+        }
+        return formFields
+          ?.filter(isFieldElement)
+          .every((field: FormField) => field.id in entity);
+      };
+
+      /*
+       * If the entity has the same fields from drawerForms fields, it was completed
+       * at somepoint.
+       */
+      const isEntityCompleted = reportingOnIlos
+        ? calculateEntityCompletion() &&
+          isIlosCompleted(reportingOnIlos, entity)
+        : calculateEntityCompletion();
+
+      return (
+        <Flex
+          key={entity.id}
+          sx={entityRowStyling(canAddEntities)}
+          data-testid="report-drawer"
+        >
+          {isEntityCompleted ? (
+            <Image
+              src={completedIcon}
+              alt={"Entity is complete"}
+              sx={sx.statusIcon}
+            />
+          ) : (
+            canAddEntities && (
+              <Image
+                src={unfinishedIcon}
+                alt={"Entity is incomplete"}
+                sx={sx.statusIcon}
+              />
+            )
+          )}
+          {isCustomEntity ? (
+            <Flex direction={"column"} sx={sx.customEntityRow}>
+              <Heading as="h4" sx={sx.customEntityName}>
+                {entity.custom_analysis_method_name}
+              </Heading>
+              {entity.custom_analysis_method_description && (
+                <Text>{entity.custom_analysis_method_description}</Text>
+              )}
+              {entity.analysis_method_frequency &&
+                entity.analysis_method_applicable_plans && (
+                  <Text>
+                    {entity.analysis_method_frequency[0].value}:&nbsp;
+                    {entity.analysis_method_applicable_plans
+                      .map((entity: AnyObject) => entity.value)
+                      .join(", ")}
+                  </Text>
+                )}
+            </Flex>
+          ) : (
+            <Heading as="h4" sx={sx.entityName}>
+              {entity.name}
+            </Heading>
+          )}
+          <Box sx={buttonBoxStyling(canAddEntities)}>
+            {enterButton(entity, isEntityCompleted)}
+            {canAddEntities && !entity.isRequired && (
+              <Button
+                sx={sx.deleteButton}
+                data-testid="delete-entity"
+                onClick={() => openDeleteEntityModal(entity)}
+              >
+                <Image src={deleteIcon} alt="delete" boxSize="2xl" />
+              </Button>
+            )}
+          </Box>
+        </Flex>
+      );
+    });
+  };
+  return <>{entityRows(entities)}</>;
+};
+
+interface Props {
+  route: DrawerReportPageShape;
+  entities: EntityShape[];
+  openRowDrawer: Function;
+  openDeleteEntityModal: Function;
+  priorAuthDisabled: Boolean;
+  patientAccessDisabled: Boolean;
+}
+
+function entityRowStyling(canAddEntities: boolean) {
+  return {
+    justifyContent: "space-between",
+    alignItems: "center",
+    minHeight: "3.25rem",
+    padding: "0.5rem",
+    paddingLeft: "0.75rem",
+    borderBottom: "1.5px solid var(--chakra-colors-palette-gray_lighter)",
+    "&:last-of-type": {
+      borderBottom: canAddEntities ?? "none",
+    },
+  };
+}
+
+function buttonBoxStyling(canAddEntities: boolean) {
+  return {
+    marginRight: canAddEntities && "1.5rem",
+  };
+}
+
+const sx = {
+  buttonIcons: {
+    height: "1rem",
+  },
+  statusIcon: {
+    height: "1.25rem",
+    position: "absolute",
+  },
+  customEntityRow: {
+    paddingLeft: "2.25rem",
+    maxWidth: "32rem",
+    gap: "4px",
+  },
+  entityName: {
+    fontSize: "lg",
+    fontWeight: "bold",
+    flexGrow: 1,
+    marginLeft: "2.25rem",
+    paddingRight: "1rem",
+  },
+  customEntityName: {
+    fontSize: "lg",
+    fontWeight: "bold",
+    flexGrow: 1,
+  },
+  missingIlos: {
+    fontWeight: "bold",
+    marginBottom: "2rem",
+    a: {
+      color: "palette.primary",
+      textDecoration: "underline",
+      "&:hover": {
+        color: "palette.primary_darker",
+      },
+    },
+  },
+  missingEntityMessage: {
+    paddingTop: "1rem",
+    fontWeight: "bold",
+    a: {
+      color: "palette.primary",
+      textDecoration: "underline",
+      "&:hover": {
+        color: "palette.primary_darker",
+      },
+    },
+    ol: {
+      paddingLeft: "1rem",
+    },
+  },
+  enterButton: {
+    width: "4.25rem",
+    height: "1.75rem",
+    fontSize: "md",
+    fontWeight: "normal",
+  },
+  deleteButton: {
+    marginRight: "-2.5rem",
+    padding: 0,
+    background: "white",
+    "&:hover, &:hover:disabled, :disabled": {
+      background: "white",
+    },
+  },
+  disabledButton: {
+    width: "4.25rem",
+    height: "1.75rem",
+    fontSize: "md",
+    fontWeight: "normal",
+    color: "palette.gray_lighter",
+    borderColor: "palette.gray_lighter",
+    "&:hover": {
+      color: "palette.gray_lighter",
+      borderColor: "palette.gray_lighter",
+    },
+  },
+  standardForm: {
+    paddingBottom: "1rem",
+  },
+  bottomAddEntityButton: {
+    marginTop: "2rem",
+    marginBottom: "0",
+  },
+};

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -335,6 +335,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
       );
     });
   };
+
   const getDrawerTitle = () => {
     let name = "Add other";
     if (selectedEntity?.name) {
@@ -392,6 +393,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
           </Box>
         ) : (
           entityRows(entities)
+          // <DrawerReportEntityRows
         )}
         {canAddEntities && hasPlans && (
           <Button

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -51,6 +51,7 @@ import addIcon from "assets/icons/icon_add_blue.png";
 import completedIcon from "assets/icons/icon_check_circle.png";
 import unfinishedIcon from "assets/icons/icon_error_circle_bright.png";
 import deleteIcon from "assets/icons/icon_cancel_x_circle.png";
+import { DrawerReportPageEntityRows } from "./DrawerReportEntityRows";
 
 export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
   const [submitting, setSubmitting] = useState<boolean>(false);
@@ -392,8 +393,8 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
             {parseCustomHtml(verbiage.missingEntityMessage || "")}
           </Box>
         ) : (
-          entityRows(entities)
-          // <DrawerReportEntityRows
+          // entityRows(entities)
+          {DrawerReportPageEntityRows(entities)}
         )}
         {canAddEntities && hasPlans && (
           <Button

--- a/services/ui-src/src/constants.ts
+++ b/services/ui-src/src/constants.ts
@@ -76,6 +76,15 @@ export enum States {
   WY = "Wyoming",
 }
 
+// ILOS
+export const PLAN_ILOS = [
+  {
+    id: "k9t7YoOeTOAXX3s7qF6XfN44",
+    name: "ilos",
+    isRequired: true,
+  },
+];
+
 // ANALYSIS METHODS (NAAAR)
 export const DEFAULT_ANALYSIS_METHODS = [
   {

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -14,15 +14,22 @@ import {
 // types
 import {
   AnyObject,
+  DrawerReportPageShape,
   FieldChoice,
   FormField,
+  FormJson,
   FormLayoutElement,
   isFieldElement,
+  ReportType,
 } from "types";
 import {
   SectionContent,
   SectionHeader,
 } from "components/forms/FormLayoutElements";
+import {
+  generateAddEntityDrawerItemFields,
+  generateDrawerItemFields,
+} from "./dynamicItemFields";
 
 // return created elements from provided fields
 export const formFieldFactory = (
@@ -261,4 +268,39 @@ export const resetClearProp = (fields: (FormField | FormLayoutElement)[]) => {
         break;
     }
   });
+};
+
+export const getForm = (
+  route: DrawerReportPageShape,
+  reportType?: string,
+  isCustomEntityForm: boolean = false,
+  isAnalysisMethodsPage?: boolean,
+  hasPlans?: boolean,
+  ilos?: AnyObject[],
+  reportingOnIlos?: boolean,
+  plans?: any
+) => {
+  const { drawerForm } = route;
+  const addEntityDrawerForm = route.addEntityDrawerForm || ({} as FormJson);
+  let modifiedForm = drawerForm;
+  switch (reportType) {
+    case ReportType.NAAAR:
+      if (isAnalysisMethodsPage && hasPlans) {
+        modifiedForm = isCustomEntityForm
+          ? generateAddEntityDrawerItemFields(
+              addEntityDrawerForm,
+              plans,
+              "plan"
+            )
+          : generateDrawerItemFields(drawerForm, plans, "plan");
+      }
+      break;
+    case ReportType.MCPAR:
+      if (ilos && reportingOnIlos) {
+        modifiedForm = generateDrawerItemFields(drawerForm, ilos, "ilos");
+      }
+      break;
+    default:
+  }
+  return modifiedForm;
 };

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -243,6 +243,65 @@ export const mockNestedReportPageJson = {
   drawerForm: mockNestedForm,
 };
 
+export const mockMcparIlosPageJson = {
+  name: "mock-route",
+  path: "/mcpar/ilos",
+  pageType: "drawer",
+  entityType: "ilos",
+  verbiage: {
+    intro: mockVerbiageIntro,
+    dashboardTitle: "Mock dashboard title",
+    drawerTitle: "Mock drawer title",
+  },
+  drawerForm: {
+    id: "dilos",
+    fields: [
+      {
+        id: "mock-field-id",
+        props: {
+          choices: [
+            {
+              id: "mock-choice-id-1",
+              label: "mock label 1 - ILOS",
+            },
+            {
+              id: "mock-choice-id-2",
+              label: "mock label 2",
+              children: [
+                {
+                  id: "mock-child-id-0",
+                  type: "radio",
+                  validation: {
+                    type: "radio",
+                    nested: true,
+                    parentFieldName: "ilos",
+                  },
+                  props: {
+                    label: "ILOSs utilization by plan",
+                    choices: [],
+                  },
+                },
+                {
+                  id: "mock-child-id-1",
+                  type: "checkbox",
+                  validation: {
+                    type: "radio",
+                    nested: true,
+                    parentFieldName: "mock-field-id",
+                    parentOptionId: "mock-field-id-mock-choice-id-1",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        type: "radio",
+        validation: "radio",
+      },
+    ],
+  },
+};
+
 export const mockNaaarAnalysisMethodsPageJson = {
   name: "mock-route",
   path: "/naaar/analysis-methods",
@@ -331,7 +390,7 @@ export const mockNaaarAnalysisMethodsPageJson = {
         type: "radio",
         props: {
           label: "Frequency of analysis",
-          choices: [],
+          choices: [{ id: "option1", label: "Weekly" }],
         },
       },
       {
@@ -339,11 +398,7 @@ export const mockNaaarAnalysisMethodsPageJson = {
         type: "checkbox",
         props: {
           label: "Plans utilizing this method",
-          choices: [
-            {
-              label: "Plans",
-            },
-          ],
+          choices: [{ label: "Plan 1" }],
         },
       },
     ],


### PR DESCRIPTION
### Description
I decided to take `entityRows` out of the DrawerReportPage, which also involved pulling out `enterButton` and `getForm`, though currently `getForm` is in both components. If anyone has any ideas on how to not duplicate `getForm`, that would be great. Also open to any feedback. Currently working on test coverage.
### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4263

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
