### PR TITLE
CMDCT-4257: NAAAR "Add standards" page (Part II) 

### DIFF
--- a/services/app-api/forms/naaar.json
+++ b/services/app-api/forms/naaar.json
@@ -300,7 +300,7 @@
                 "children": [
                   {
                     "type": "html",
-                    "content": "This program is missing plans. You won’t be able to complete this section until you’ve added all the plans that participate in this program in section A.7. "
+                    "content": "This program is missing plans. You won’t be able to complete this section until you’ve added all the managed care plans that serve enrollees in the program. "
                   },
                   {
                     "type": "internalLink",
@@ -308,6 +308,10 @@
                     "props": {
                       "to": "/naaar/state-and-program-information/add-plans"
                     }
+                  },
+                  {
+                    "type": "html",
+                    "content": "."
                   }
                 ]
               }
@@ -519,7 +523,29 @@
         "dashboardTitle": "Standard total count: ",
         "countEntitiesInTitle": true,
         "addEntityButtonText": "Add standard",
-        "drawerTitle": "Add access and network adequacy standard for "
+        "drawerTitle": "Add access and network adequacy standard for ",
+        "missingEntityMessage": [
+          {
+            "type": "p",
+            "children": [
+              {
+                "type": "html",
+                "content": "This program is missing required information. You won’t be able to complete this section until you’ve completed all the required questions in section "
+              },
+              {
+                "type": "internalLink",
+                "content": "I. State and program information",
+                "props": {
+                  "to": "/naaar/state-and-program-information/provider-type-coverage"
+                }
+              },
+              {
+                "type": "html",
+                "content": "."
+              }
+            ]
+          }
+        ]
       },
       "drawerForm": {
         "id": "danas",

--- a/services/ui-src/src/components/reports/DrawerReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.test.tsx
@@ -77,9 +77,17 @@ const drawerReportPageWithCustomEntities = (
   </RouterWrappedComponent>
 );
 
-const drawerReportPageWithNaaarRoutes = (
+const drawerReportPageWithNaaarRoutesEmptyState = (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockNaaarReportContext}>
+      <DrawerReportPage route={mockNaaarStandardsPageJson} />
+    </ReportContext.Provider>
+  </RouterWrappedComponent>
+);
+
+const drawerReportPageWithNaaarRoutes = (
+  <RouterWrappedComponent>
+    <ReportContext.Provider value={mockNaaarReportWithAnalysisMethodsContext}>
       <DrawerReportPage route={mockNaaarStandardsPageJson} />
     </ReportContext.Provider>
   </RouterWrappedComponent>
@@ -296,7 +304,13 @@ describe("<DrawerReportPage />", () => {
       expect(mockMcparReportContext.updateReport).toHaveBeenCalledTimes(0);
     });
 
-    test("Test DrawerReportPage for NAAAR standards", async () => {
+    test("Test DrawerReportPage for NAAAR standards (empty state)", async () => {
+      render(drawerReportPageWithNaaarRoutesEmptyState);
+      const addStandardsButton = screen.getAllByText("Add standard")[0];
+      expect(addStandardsButton).toBeDisabled();
+    });
+
+    test("Test DrawerReportPage for NAAAR standards (with provider types)", async () => {
       render(drawerReportPageWithNaaarRoutes);
       const addStandardsButton = screen.getAllByText("Add standard")[0];
       await userEvent.click(addStandardsButton);

--- a/services/ui-src/src/components/reports/DrawerReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.test.tsx
@@ -23,6 +23,7 @@ import {
   mockNaaarAnalysisMethodsReportStore,
   mockNaaarStandardsPageJson,
   mockNaaarReportContext,
+  mockNaaarReportStore,
 } from "utils/testing/setupJest";
 import { testA11y } from "utils/testing/commonTests";
 
@@ -87,7 +88,7 @@ const drawerReportPageWithNaaarRoutesEmptyState = (
 
 const drawerReportPageWithNaaarRoutes = (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockNaaarReportWithAnalysisMethodsContext}>
+    <ReportContext.Provider value={mockNaaarReportContext}>
       <DrawerReportPage route={mockNaaarStandardsPageJson} />
     </ReportContext.Provider>
   </RouterWrappedComponent>
@@ -311,10 +312,15 @@ describe("<DrawerReportPage />", () => {
     });
 
     test("Test DrawerReportPage for NAAAR standards (with provider types)", async () => {
+      mockedUseStore.mockReturnValue({
+        ...mockStateUserStore,
+        ...mockNaaarReportStore,
+        ...mockEntityStore,
+      });
       render(drawerReportPageWithNaaarRoutes);
       const addStandardsButton = screen.getAllByText("Add standard")[0];
       await userEvent.click(addStandardsButton);
-      expect(screen.getByText("mock label 1")).toBeVisible();
+      expect(screen.getByText("Mock dashboard title")).toBeVisible();
     });
   });
 

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -77,8 +77,12 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
   const hasIlos = ilos?.length;
   const hasPlans = report?.fieldData?.["plans"]?.length > 0;
   const plans = report?.fieldData?.plans?.map((plan: { name: string }) => plan);
-  const reportingOnStandards =
+  const isReportingOnStandards =
     route.path === "/naaar/program-level-access-and-network-adequacy-standards";
+  const hasProviderTypes = report?.fieldData?.["providerTypes"]?.length > 0;
+  const providerTypes = report?.fieldData?.providerTypes?.map(
+    (providerType: { name: string }) => providerType
+  );
 
   const getForm = (
     reportType?: string,
@@ -95,6 +99,14 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
                 "plan"
               )
             : generateDrawerItemFields(drawerForm, plans, "plan");
+        }
+        if (isReportingOnStandards && hasProviderTypes) {
+          const providerTypeFields = generateDrawerItemFields(
+            drawerForm,
+            providerTypes,
+            "standards"
+          );
+          modifiedForm.fields.splice(0, 1, providerTypeFields.fields[0]);
         }
         break;
       case ReportType.MCPAR:
@@ -358,7 +370,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
       selectedEntity?.name ||
       selectedEntity?.custom_analysis_method_name ||
       "Add other";
-    if (reportingOnStandards && report) {
+    if (isReportingOnStandards && report) {
       name = report?.programName;
     }
     return `${verbiage.drawerTitle} ${name}`;
@@ -369,6 +381,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
       sx={sx.bottomAddEntityButton}
       leftIcon={<Image sx={sx.buttonIcons} src={addIconWhite} alt="Add" />}
       onClick={() => openRowDrawer()}
+      disabled={!hasProviderTypes}
     >
       {verbiage.addEntityButtonText}
     </Button>
@@ -390,6 +403,11 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
           {parseCustomHtml(verbiage.missingEntityMessage || "")}
         </Box>
       )}
+      {isReportingOnStandards && !hasProviderTypes && (
+        <Box sx={sx.missingIlos}>
+          {parseCustomHtml(verbiage.missingEntityMessage || "")}
+        </Box>
+      )}
       {standardForm && (
         <Box sx={sx.standardForm}>
           <Form
@@ -405,7 +423,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
         </Box>
       )}
       <Box>
-        {reportingOnStandards ? (
+        {isReportingOnStandards ? (
           // table of standards
           <Box>
             {addStandardsButton}

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -60,7 +60,8 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
   const reportingOnIlos = route.path === "/mcpar/plan-level-indicators/ilos";
   const ilos = report?.fieldData?.["ilos"];
   const hasIlos = ilos?.length;
-  const hasPlans = report?.fieldData?.["plans"]?.length > 0;
+  const plans = report?.fieldData?.["plans"];
+  const hasPlans = plans?.length;
   const isReportingOnStandards =
     route.path === "/naaar/program-level-access-and-network-adequacy-standards";
   const hasProviderTypes = report?.fieldData?.["providerTypes"]?.length > 0;
@@ -201,9 +202,9 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
 
   const displayErrorMessages = () => {
     // if there are no ILOS but there are plans added, display this message
-    if (!hasIlos && !entities.length) {
+    if (!hasIlos && entities.length > 0) {
       return (
-        <Box sx={sx.missingIlos}>
+        <Box sx={sx.missingEntity}>
           {parseCustomHtml(verbiage.missingIlosMessage || "")}
         </Box>
       );
@@ -212,7 +213,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
       (isReportingOnStandards && !hasProviderTypes)
     ) {
       return (
-        <Box sx={sx.missingIlos}>
+        <Box sx={sx.missingEntity}>
           {parseCustomHtml(verbiage.missingEntityMessage || "")}
         </Box>
       );
@@ -236,24 +237,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
       {verbiage.intro && (
         <ReportPageIntro text={verbiage.intro} hasIlos={hasIlos} />
       )}
-      {/* working on it */}
       {displayErrorMessages()}
-      {/* if there are no ILOS but there are plans added, display this message
-      {!hasIlos && entities?.length && (
-        <Box sx={sx.missingIlos}>
-          {parseCustomHtml(verbiage.missingIlosMessage || "")}
-        </Box>
-      )}
-      {isAnalysisMethodsPage && !hasPlans && (
-        <Box sx={sx.missingIlos}>
-          {parseCustomHtml(verbiage.missingEntityMessage || "")}
-        </Box>
-      )}
-      {isReportingOnStandards && !hasProviderTypes && (
-        <Box sx={sx.missingIlos}>
-          {parseCustomHtml(verbiage.missingEntityMessage || "")}
-        </Box>
-      )} */}
       {standardForm && (
         <Box sx={sx.standardForm}>
           <Form
@@ -373,7 +357,7 @@ const sx = {
     marginLeft: "2.25rem",
     paddingRight: "1rem",
   },
-  missingIlos: {
+  missingEntity: {
     fontWeight: "bold",
     marginBottom: "2rem",
     a: {

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -52,7 +52,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
   const { entityType, verbiage, form: standardForm } = route;
   const addEntityDrawerForm = route.addEntityDrawerForm || ({} as FormJson);
   const canAddEntities = !!addEntityDrawerForm.id;
-  const entities = report?.fieldData?.[entityType];
+  const entities = report?.fieldData?.[entityType] || [];
 
   // check if there are ILOS and associated plans
   const isMcparReport = route.path.includes("mcpar");
@@ -199,6 +199,27 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
     return `${verbiage.drawerTitle} ${name}`;
   };
 
+  const displayErrorMessages = () => {
+    // if there are no ILOS but there are plans added, display this message
+    if (!hasIlos && !entities.length) {
+      return (
+        <Box sx={sx.missingIlos}>
+          {parseCustomHtml(verbiage.missingIlosMessage || "")}
+        </Box>
+      );
+    } else if (
+      (isAnalysisMethodsPage && !hasPlans) ||
+      (isReportingOnStandards && !hasProviderTypes)
+    ) {
+      return (
+        <Box sx={sx.missingIlos}>
+          {parseCustomHtml(verbiage.missingEntityMessage || "")}
+        </Box>
+      );
+    }
+    return <></>;
+  };
+
   const addStandardsButton = (
     <Button
       sx={sx.bottomAddEntityButton}
@@ -215,7 +236,9 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
       {verbiage.intro && (
         <ReportPageIntro text={verbiage.intro} hasIlos={hasIlos} />
       )}
-      {/* if there are no ILOS but there are plans added, display this message */}
+      {/* working on it */}
+      {displayErrorMessages()}
+      {/* if there are no ILOS but there are plans added, display this message
       {!hasIlos && entities?.length && (
         <Box sx={sx.missingIlos}>
           {parseCustomHtml(verbiage.missingIlosMessage || "")}
@@ -230,7 +253,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
         <Box sx={sx.missingIlos}>
           {parseCustomHtml(verbiage.missingEntityMessage || "")}
         </Box>
-      )}
+      )} */}
       {standardForm && (
         <Box sx={sx.standardForm}>
           <Form

--- a/services/ui-src/src/utils/forms/dynamicItemFields.test.ts
+++ b/services/ui-src/src/utils/forms/dynamicItemFields.test.ts
@@ -1,5 +1,8 @@
 import { FormJson, AnyObject } from "types";
-import { mockNaaarAnalysisMethodsPageJson } from "utils/testing/mockForm";
+import {
+  mockNaaarAnalysisMethodsPageJson,
+  mockNaaarStandardsPageJson,
+} from "utils/testing/mockForm";
 import {
   generateAddEntityDrawerItemFields,
   generateDrawerItemFields,
@@ -48,6 +51,8 @@ const mockAnalysisMethodsForm: FormJson =
 const mockAddAnalysisMethodsForm: FormJson =
   mockNaaarAnalysisMethodsPageJson.addEntityDrawerForm;
 
+const mockStandardsForm: FormJson = mockNaaarStandardsPageJson.drawerForm;
+
 const mockIlos: AnyObject[] = [
   {
     id: "mock-ilos-1",
@@ -67,6 +72,17 @@ const mockPlans: AnyObject[] = [
   {
     id: "mock-plan-2",
     name: "Plan 2",
+  },
+];
+
+const mockProviderTypes: AnyObject[] = [
+  {
+    key: "mock-provider-1",
+    value: "Provider Type 1",
+  },
+  {
+    key: "mock-provider-2",
+    value: "Provider Type 2",
   },
 ];
 
@@ -94,6 +110,17 @@ describe("generateDrawerItemFields for NAAAR analysis methods without custom ent
   );
   it("should generate checkboxes per each available plan", () => {
     expect(result.fields[0].props.choices[1].children.length).toBe(2);
+  });
+});
+
+describe("generateDrawerItemFields for NAAAR provider types", () => {
+  const result = generateDrawerItemFields(
+    mockStandardsForm,
+    mockProviderTypes,
+    "standards"
+  );
+  it("should generate radio buttons for each selected provider type", () => {
+    expect(result.fields[0].props.choices.length).toBe(2);
   });
 });
 

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -301,7 +301,7 @@ export const getForm = (params: getFormParams) => {
             )
           : generateDrawerItemFields(drawerForm, plans, "plan");
       }
-      if (isReportingOnStandards && providerTypes.length > 0) {
+      if (isReportingOnStandards && providerTypes?.length > 0) {
         const providerTypeFields = generateDrawerItemFields(
           drawerForm,
           providerTypes,

--- a/services/ui-src/src/utils/testing/mockReport.tsx
+++ b/services/ui-src/src/utils/testing/mockReport.tsx
@@ -372,6 +372,16 @@ export const mockNaaarReportFieldData = {
       name: "plan 2",
     },
   ],
+  providerTypes: [
+    {
+      key: "key1",
+      name: "provider1",
+    },
+    {
+      key: "key2",
+      name: "provider2",
+    },
+  ],
 };
 
 export const mockMcparReport = {

--- a/services/ui-src/src/utils/testing/mockReport.tsx
+++ b/services/ui-src/src/utils/testing/mockReport.tsx
@@ -569,6 +569,12 @@ export const mockNaaarReportWithAnalysisMethods = {
         name: "custom entity",
       },
     ],
+    providerTypes: [
+      {
+        key: "mock-key",
+        value: "mock-value",
+      },
+    ],
   },
   locked: false,
   fieldDataId: "mockFieldDataId",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This is the second part of the "Add standards" page for NAAAR, focusing on dynamically populating the core provider types selected in the `I. State and program information: Provider type coverage` section.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4257

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a NAAAR report
- Navigate to `/naaar/program-level-access-and-network-adequacy-standards`

You should see that the "Add standard" buttons are disabled by default and there is an error message displayed

<img width="440" alt="Screenshot 2025-02-06 at 1 57 04 PM" src="https://github.com/user-attachments/assets/d8a3001d-b4d6-4c08-9c88-ce7f07e2df99" />

- Click on the link or navigate to `/naaar/state-and-program-information/provider-type-coverage`
- Select a provider type (or two or three even)
- Navigate back to the Standards page

The buttons should be enabled and when you click on it, the first question should have the provider types you've selected as options:

![Screenshot 2025-02-06 at 1 56 29 PM](https://github.com/user-attachments/assets/887e9d40-686c-4a38-8846-d93a6aae1071)

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
