### PR TITLE
Add individual plan compliance

### DIFF
--- a/logs/todos.log
+++ b/logs/todos.log
@@ -7,8 +7,7 @@
 ./services/ui-src/src/components/reports/OverlayReportPage.test.tsx:109:TODO: Update this when logic surrounding standards has been updated!
 ./services/ui-src/src/components/reports/OverlayReportPage.test.tsx:148:TODO: Update this when logic surrounding standards has been updated!
 ./services/ui-src/src/components/reports/OverlayReportPage.test.tsx:185:TODO: Update this when logic surrounding standards has been updated!
-./services/ui-src/src/components/reports/OverlayReportPage.test.tsx:208:TODO: Update this when the overlay has been updated!
 ./services/ui-src/src/components/reports/OverlayReportPage.test.tsx:75:TODO: Update this when logic surrounding standards has been updated!
-./services/ui-src/src/components/reports/OverlayReportPage.tsx:55: TODO - Update this when working through the actual logic pertaining to Standards and how it'll be checked
-./services/ui-src/src/components/tables/EntityRow.tsx:26: TODO: refactor to handle NAAAR analysis methods
+./services/ui-src/src/components/reports/OverlayReportPage.tsx:95: TODO - Update this when working through the actual logic pertaining to Standards and how it'll be checked
 ./services/ui-src/src/utils/autosave/autosave.ts:193: TODO: modify DynamicField hydrationValue lifecycle so we can implement a stricter check,
+./services/ui-src/src/utils/tables/getNaaarEntityStatus.ts:3: TODO: Update to actual logic

--- a/logs/todos.log
+++ b/logs/todos.log
@@ -10,4 +10,4 @@
 ./services/ui-src/src/components/reports/OverlayReportPage.test.tsx:75:TODO: Update this when logic surrounding standards has been updated!
 ./services/ui-src/src/components/reports/OverlayReportPage.tsx:95: TODO - Update this when working through the actual logic pertaining to Standards and how it'll be checked
 ./services/ui-src/src/utils/autosave/autosave.ts:193: TODO: modify DynamicField hydrationValue lifecycle so we can implement a stricter check,
-./services/ui-src/src/utils/tables/getNaaarEntityStatus.ts:3: TODO: Update to actual logic
+./services/ui-src/src/utils/tables/getNaaarEntityStatus.ts:4: TODO: Update to actual logic

--- a/logs/todos.log
+++ b/logs/todos.log
@@ -4,10 +4,8 @@
 ./services/app-api/handlers/reports/fetch.ts:80: TODO: strict typing
 ./services/ui-src/src/components/layout/Timeout.tsx:36: TODO: When autosave is implemented, set up a callback function to listen to calls to update in authLifecycle
 ./services/ui-src/src/components/reports/ModalOverlayReportPage.test.tsx:149:todo Write a test to make sure admins can't click/change details?
-./services/ui-src/src/components/reports/OverlayReportPage.test.tsx:109:TODO: Update this when logic surrounding standards has been updated!
-./services/ui-src/src/components/reports/OverlayReportPage.test.tsx:148:TODO: Update this when logic surrounding standards has been updated!
-./services/ui-src/src/components/reports/OverlayReportPage.test.tsx:185:TODO: Update this when logic surrounding standards has been updated!
-./services/ui-src/src/components/reports/OverlayReportPage.test.tsx:75:TODO: Update this when logic surrounding standards has been updated!
-./services/ui-src/src/components/reports/OverlayReportPage.tsx:95: TODO - Update this when working through the actual logic pertaining to Standards and how it'll be checked
+./services/ui-src/src/components/reports/OverlayReportPage.test.tsx:105:TODO: Update this when logic surrounding standards has been updated!
+./services/ui-src/src/components/reports/OverlayReportPage.test.tsx:146:TODO: Update this when logic surrounding standards has been updated!
+./services/ui-src/src/components/reports/OverlayReportPage.tsx:95: TODO: Update this when working through the actual logic pertaining to Standards and how it'll be checked
 ./services/ui-src/src/utils/autosave/autosave.ts:193: TODO: modify DynamicField hydrationValue lifecycle so we can implement a stricter check,
 ./services/ui-src/src/utils/tables/getNaaarEntityStatus.ts:4: TODO: Update to actual logic

--- a/services/app-api/forms/naaar.json
+++ b/services/app-api/forms/naaar.json
@@ -1033,7 +1033,7 @@
           "info": [
             {
               "type": "text",
-              "content": "States should use this section to report on plan compliance with the state's 42 C.F.R. § 438.68 and 42 C.F.R. § 438.206 standards."
+              "content": "States should use this section to report on plan compliance with the state’s 42 C.F.R. § 438.68 and 42 C.F.R. § 438.206 standards."
             }
           ]
         },
@@ -1085,6 +1085,106 @@
         },
         "tableHeader": "Plan Name",
         "enterEntityDetailsButtonText": "Enter"
+      },
+      "details": {
+        "verbiage": {
+          "backButton": "Return to plan compliance dashboard",
+          "intro" : {
+            "info": "States should use this section to report on plan compliance with the state’s 42 C.F.R. § 438.68 and 42 C.F.R. § 438.206 standards for the plan listed above.",
+            "section": "",
+            "subsection": "III. Plan compliance data for {{planName}}"
+          }
+        },
+        "forms": [
+          {
+            "form": {
+              "id": "planCompliance43868",
+              "fields": [
+                {
+                  "id": "planCompliance43868_assurance",
+                  "type": "radio",
+                  "validation": "radio",
+                  "props": {
+                    "choices": [
+                      {
+                        "id": "Jtt1p8Z9HtpRWN2E8lxzni",
+                        "label": "Yes, the plan complies on all standards based on all analyses"
+                      },
+                      {
+                        "id": "dq36WGX8Ev8wmALi1rg3bv",
+                        "label": "No, the plan does not comply on all standards based on all analyses and/or exceptions granted"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "table": {
+              "bodyRows": [
+                [
+                  "",
+                  "Select non-compliant / exception standards and provide details for 438.68",
+                  ""
+                ]
+              ],
+              "headRow": [
+                { "hiddenName": "Status" },
+                { "hiddenName": "Report section" },
+                { "hiddenName": "Action" }
+              ]
+            },
+            "verbiage": {
+              "heading": "Assurance of plan compliance for 438.68",
+              "hint": "Indicate whether the state assures that the plan complies with the state’s network adequacy standards based on each analysis the state conducted for the plan during the reporting period."
+            }
+          },
+          {
+            "form": {
+              "id": "planCompliance438206",
+              "fields": [
+                {
+                  "id": "planCompliance438206_assurance",
+                  "type": "radio",
+                  "validation": "radio",
+                  "props": {
+                    "choices": [
+                      {
+                        "id": "a4BjUY8odfV5TSNKHtFVGd",
+                        "label": "Yes, the plan complies on all standards based on all analyses"
+                      },
+                      {
+                        "id": "zC8SPm68FS8xI9igWQ0BdP",
+                        "label": "No, the plan does not comply on all standards based on all analyses and/or exceptions granted"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "table": {
+              "bodyRows": [
+                [
+                  "",
+                  "Select non-compliant / exception standards and provide details for 438.206",
+                  ""
+                ]
+              ],
+              "headRow": [
+                { "hiddenName": "Status" },
+                { "hiddenName": "Report section" },
+                { "hiddenName": "Action" }
+              ]
+            },
+            "verbiage": {
+              "accordion": {
+                "buttonLabel": "Assurance of 42 C.F.R. § 438.206",
+                "text": "<p>(b) <b>Delivery network.</b> The State must ensure, through its contracts, that each MCO, PIHP and PAHP, consistent with the scope of its contracted services, meets the following requirements:</p><p>(1) Maintains and monitors a network of appropriate providers that is supported by written agreements and is sufficient to provide adequate access to all services covered under the contract for all enrollees, including those with limited English proficiency or physical or mental disabilities.</p><p>(2) Provides female enrollees with direct access to a women’s health specialist within the provider network for covered care necessary to provide women’s routine and preventive health care services. This is in addition to the enrollee’s designated source of primary care if that source is not a women’s health specialist.</p><p>(3) Provides for a second opinion from a network provider, or arranges for the enrollee to obtain one outside the network, at no cost to the enrollee.</p><p>(4) If the provider network is unable to provide necessary services, covered under the contract, to a particular enrollee, the MCO, PIHP, or PAHP must adequately and timely cover these services out of network for the enrollee, for as long as the MCO, PIHP, or PAHP’s provider network is unable to provide them.</p><p>(5) Requires out-of-network providers to coordinate with the MCO, PIHP, or PAHP for payment and ensures the cost to the enrollee is no greater than it would be if the services were furnished within the network.</p><p>(6) Demonstrates that its network providers are credentialed as required by § 438.214.</p><p>(7) Demonstrates that its network includes sufficient family planning providers to ensure timely access to covered services.</p><p>(c) <b>Furnishing of services.</b> The State must ensure that each contract with a MCO, PIHP, and PAHP complies with the following requirements.</p><p>(1) <b>Timely access.</b> Each MCO, PIHP, and PAHP must do the following:</p><p>(i) Meet and require its network providers to meet State standards for timely access to care and services taking into account the urgency of the need for services, as well as appointment wait times specified in § 438.68(e).</p><p>(ii) Ensure that the network providers offer hours of operation that are no less than the hours of operation offered to commercial enrollees or comparable to Medicaid FFS, if the provider serves only Medicaid enrollees.</p><p>(iii) Make services included in the contract available 24 hours a day, 7 days a week, when medically necessary.</p><p>(iv) Establish mechanisms to ensure compliance by network providers.</p><p>(v) Monitor network providers regularly to determine compliance.</p><p>(vi) Take corrective action if there is a failure to comply by a network provider.</p><p>(2) Access and cultural considerations. Each MCO, PIHP, and PAHP participates in the State’s efforts to promote the delivery of services in a culturally competent manner to all enrollees, including those with limited English proficiency and diverse cultural and ethnic backgrounds, disabilities, and regardless of sex which includes sex characteristics, including intersex traits; pregnancy or related conditions; sexual orientation; gender identity and sex stereotypes.</p><p>(3) Accessibility considerations. Each MCO, PIHP, and PAHP must ensure that network providers provide physical access, reasonable accommodations, and accessible equipment for Medicaid enrollees with physical or mental disabilities.</p><p>(d) Applicability date. States will not be held out of compliance with the requirements of paragraphs (c)(1)(i) of this section prior to the first rating period that begins on or after 3 years after July 9, 2024, so long as they comply with the corresponding standard(s) codified in 42 CFR 438.2</p>"
+              },        
+              "heading": "Assurance of plan compliance for 438.206",
+              "hint": "Indicate whether the state assures that the plan complies with the state’s network adequacy standards based on each analysis the state conducted for the plan during the reporting period."
+            }
+          }
+        ]
       }
     },
     {

--- a/services/app-api/forms/naaar.json
+++ b/services/app-api/forms/naaar.json
@@ -1127,6 +1127,7 @@
                   ""
                 ]
               ],
+              "caption": "",
               "headRow": [
                 { "hiddenName": "Status" },
                 { "hiddenName": "Report section" },
@@ -1135,7 +1136,10 @@
             },
             "verbiage": {
               "heading": "Assurance of plan compliance for 438.68",
-              "hint": "Indicate whether the state assures that the plan complies with the state’s network adequacy standards based on each analysis the state conducted for the plan during the reporting period."
+              "hint": "Indicate whether the state assures that the plan complies with the state’s network adequacy standards based on each analysis the state conducted for the plan during the reporting period.",
+              "intro": {
+                "section": ""
+              }
             }
           },
           {

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -5,6 +5,7 @@ import {
   CustomHtmlElement,
   State,
   CompletionData,
+  ScreenReaderOnlyHeaderName,
 } from "./index";
 
 // REPORT TYPES
@@ -88,6 +89,16 @@ export interface ModalOverlayReportPageShape extends ReportPageShapeBase {
   form?: never;
 }
 
+export interface EntityDetailsMultiformShape {
+  form: FormJson;
+  table?: {
+    caption: string;
+    bodyRows: Array<[string]>;
+    headRow: Array<string | ScreenReaderOnlyHeaderName>;
+  };
+  verbiage?: EntityDetailsMultiformVerbiage;
+}
+
 export interface OverlayReportPageShape extends ReportPageShapeBase {
   entityType: string;
   verbiage: OverlayReportPageVerbiage;
@@ -95,6 +106,10 @@ export interface OverlayReportPageShape extends ReportPageShapeBase {
   modalForm?: never;
   drawerForm?: never;
   form?: never;
+  details?: {
+    forms: [EntityDetailsMultiformShape];
+    verbiage: EntityDetailsMultiformVerbiage;
+  };
 }
 
 export interface ReportRouteWithoutForm extends ReportRouteBase {
@@ -166,6 +181,16 @@ export interface OverlayReportPageVerbiage extends ReportPageVerbiage {
   tableHeader: string;
   emptyDashboardText: string;
   enterEntityDetailsButtonText: string;
+}
+
+export interface EntityDetailsMultiformVerbiage extends ReportPageVerbiage {
+  backButton?: string;
+  heading?: string;
+  hint?: string;
+  accordion?: {
+    buttonLabel: string;
+    text: string;
+  };
 }
 
 // REPORT METADATA

--- a/services/ui-src/src/components/accordions/InstructionsAccordion.tsx
+++ b/services/ui-src/src/components/accordions/InstructionsAccordion.tsx
@@ -11,13 +11,15 @@ export const InstructionsAccordion = ({ verbiage, ...props }: Props) => {
   return (
     <Accordion allowToggle={true} allowMultiple={true} sx={sx.root} {...props}>
       <AccordionItem label={buttonLabel} sx={sx.item}>
-        <Box sx={sx.textBox}>{parseCustomHtml(intro)}</Box>
-        <UnorderedList sx={sx.list}>
-          {list.map((listItem: string, index: number) => (
-            <ListItem key={index}>{sanitizeAndParseHtml(listItem)}</ListItem>
-          ))}
-        </UnorderedList>
-        <Box sx={sx.textBox}>{sanitizeAndParseHtml(text)}</Box>
+        {intro && <Box sx={sx.textBox}>{parseCustomHtml(intro)}</Box>}
+        {list?.length > 0 && (
+          <UnorderedList sx={sx.list}>
+            {list.map((listItem: string, index: number) => (
+              <ListItem key={index}>{sanitizeAndParseHtml(listItem)}</ListItem>
+            ))}
+          </UnorderedList>
+        )}
+        {text && <Box sx={sx.textBox}>{sanitizeAndParseHtml(text)}</Box>}
       </AccordionItem>
     </Accordion>
   );
@@ -46,6 +48,9 @@ const sx = {
     },
     p: {
       margin: "1rem 0",
+      "&:first-of-type": {
+        marginTop: 0,
+      },
     },
   },
   text: {

--- a/services/ui-src/src/components/accordions/TemplateCardAccordion.tsx
+++ b/services/ui-src/src/components/accordions/TemplateCardAccordion.tsx
@@ -15,7 +15,7 @@ export const TemplateCardAccordion = ({ verbiage, ...props }: Props) => (
           sxOverride={sx.table}
         />
       )}
-      {verbiage.list && (
+      {verbiage.list?.length > 0 && (
         <UnorderedList sx={sx.list}>
           {verbiage.list.map((listItem: string, index: number) => (
             <ListItem key={index}>{listItem}</ListItem>

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect } from "react";
+import { ForwardedRef, forwardRef, ReactNode, useEffect } from "react";
 import {
   FieldValues,
   FormProvider,
@@ -29,18 +29,21 @@ import {
   useStore,
 } from "utils";
 
-export const Form = ({
-  id,
-  formJson,
-  onSubmit,
-  onError,
-  formData,
-  validateOnRender,
-  autosave,
-  dontReset,
-  children,
-  ...props
-}: Props) => {
+export const Form = forwardRef(function Form(
+  {
+    id,
+    formJson,
+    onSubmit,
+    onError,
+    formData,
+    validateOnRender,
+    autosave,
+    dontReset,
+    children,
+    ...props
+  }: Props,
+  ref?: ForwardedRef<HTMLFormElement>
+) {
   const { fields, options } = formJson;
 
   // determine if fields should be disabled (based on admin roles )
@@ -104,6 +107,7 @@ export const Form = ({
         id={id}
         autoComplete="off"
         onSubmit={form.handleSubmit(onSubmit as any, onError || onErrorHandler)}
+        ref={ref}
         {...props}
       >
         <Box sx={sx}>{renderFormFields(fields)}</Box>
@@ -111,7 +115,7 @@ export const Form = ({
       </form>
     </FormProvider>
   );
-};
+});
 
 interface Props {
   id: string;

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -77,6 +77,7 @@ export { MenuOption } from "./menus/MenuOption";
 export { Sidebar } from "./menus/Sidebar";
 // overlays
 export { EntityDetailsOverlay } from "./overlays/EntityDetailsOverlay";
+export { EntityDetailsMultiformOverlay } from "./overlays/EntityDetailsMultiformOverlay";
 // modals
 export { Modal } from "./modals/Modal";
 export { AddEditReportModal } from "./modals/AddEditReportModal";

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -110,6 +110,7 @@ export { StatusTable } from "./statusing/StatusTable";
 export { Table } from "./tables/Table";
 export { EntityRow } from "./tables/EntityRow";
 export { MobileEntityRow } from "./tables/MobileEntityRow";
+export { ResponsiveEntityRow } from "./tables/ResponsiveEntityRow";
 export { EntityStatusIcon } from "./tables/EntityStatusIcon";
 export { SortableTable } from "./tables/SortableTable";
 // widgets

--- a/services/ui-src/src/components/overlays/EntityDetailsMultiformOverlay.test.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsMultiformOverlay.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+// components
+import { EntityDetailsMultiformOverlay } from "./EntityDetailsMultiformOverlay";
+// utils
+import {
+  mockEntityStore,
+  mockOverlayReportPageJson,
+  mockStateUserStore,
+  RouterWrappedComponent,
+} from "utils/testing/setupJest";
+import { useStore } from "utils";
+
+const { details } = mockOverlayReportPageJson;
+const mockCloseEntityDetailsOverlay = jest.fn();
+const mockOnSubmit = jest.fn();
+const mockSelectedEntity = jest.fn();
+const mockSetEntering = jest.fn();
+
+jest.mock("utils/state/useStore");
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+mockedUseStore.mockReturnValue({
+  ...mockStateUserStore,
+  ...mockEntityStore,
+});
+
+const entityDetailsMultiformOverlayComponent = (
+  disabled: boolean = false,
+  submitting = false
+) => (
+  <RouterWrappedComponent>
+    <EntityDetailsMultiformOverlay
+      closeEntityDetailsOverlay={mockCloseEntityDetailsOverlay}
+      disabled={disabled}
+      entityType={"plans"}
+      forms={details!.forms}
+      onSubmit={mockOnSubmit}
+      selectedEntity={mockEntityStore.selectedEntity}
+      setEntering={mockSetEntering}
+      setSelectedEntity={mockSelectedEntity}
+      submitting={submitting}
+      validateOnRender={false}
+      verbiage={details!.verbiage}
+    />
+  </RouterWrappedComponent>
+);
+
+describe("<EntityDetailsMultiformOverlay />", () => {
+  test("renders form", async () => {
+    render(entityDetailsMultiformOverlayComponent());
+
+    // Verbiage
+    const h2 = screen.getByRole("heading", {
+      level: 2,
+      name: "Mock Details: Example Plan",
+    });
+    const h3 = screen.getByRole("heading", { level: 3, name: "Mock heading" });
+    const accordion = screen.getByText("Mock Accordion");
+    expect(h2).toBeVisible();
+    expect(h3).toBeVisible();
+    expect(accordion).toBeVisible();
+
+    // Form
+    const radioButton = screen.getByRole("radio", { name: "Mock Yes" });
+    await userEvent.click(radioButton);
+
+    // Table
+    const entityTable = screen.getByRole("table");
+    const entityHeaders = screen.getByRole("row", {
+      name: "Status Mock table header Action",
+    });
+    const entityCells = screen.getByRole("row", {
+      name: "warning icon Mock Cell Enter",
+    });
+
+    expect(entityTable).toBeVisible();
+    expect(entityHeaders).toBeVisible();
+    expect(entityCells).toBeVisible();
+
+    // Submit
+    const submitButton = screen.getByRole("button", { name: "Save & return" });
+    await userEvent.click(submitButton);
+
+    expect(mockOnSubmit).toBeCalled();
+  });
+
+  test("closes overlay", async () => {
+    render(entityDetailsMultiformOverlayComponent());
+    const closeButton = screen.getByRole("button", {
+      name: "Return to dashboard",
+    });
+    await userEvent.click(closeButton);
+
+    expect(mockCloseEntityDetailsOverlay).toBeCalled();
+  });
+
+  test("disables submit button", async () => {
+    render(entityDetailsMultiformOverlayComponent(true, false));
+    const closeButton = screen.getByRole("button", { name: "Return" });
+    const submitButton = screen.queryByRole("button", {
+      name: "Save & return",
+    });
+    await userEvent.click(closeButton);
+
+    expect(mockCloseEntityDetailsOverlay).toBeCalled();
+    expect(submitButton).toBeNull();
+  });
+
+  test("shows spinner when submitting", () => {
+    render(entityDetailsMultiformOverlayComponent(false, true));
+    const loading = screen.getByRole("button", { name: "Loading..." });
+    expect(loading).toBeVisible();
+  });
+});

--- a/services/ui-src/src/components/overlays/EntityDetailsMultiformOverlay.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsMultiformOverlay.tsx
@@ -1,0 +1,287 @@
+import React, {
+  FormEvent,
+  MouseEventHandler,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+// components
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  Image,
+  Spinner,
+  Td,
+  Text,
+  Tr,
+} from "@chakra-ui/react";
+import {
+  EntityStatusIcon,
+  Form,
+  InstructionsAccordion,
+  ReportPageIntro,
+  Table,
+} from "components";
+// types
+import {
+  AnyObject,
+  EntityDetailsMultiformShape,
+  EntityDetailsMultiformVerbiage,
+  EntityShape,
+  EntityType,
+  ScreenReaderOnlyHeaderName,
+} from "types";
+// assets
+import arrowLeftBlue from "assets/icons/icon_arrow_left_blue.png";
+
+export const EntityDetailsMultiformOverlay = ({
+  closeEntityDetailsOverlay,
+  disabled,
+  entityType,
+  forms,
+  onSubmit,
+  selectedEntity,
+  setEntering,
+  setSelectedEntity,
+  submitting,
+  validateOnRender,
+  verbiage,
+}: Props) => {
+  const formRefs = useRef<HTMLFormElement[]>([]);
+  const [formCount, setFormCount] = useState<number>(0);
+  const [formData, setFormData] = useState<AnyObject>({});
+
+  useEffect(() => {
+    setEntering(false);
+  }, []);
+
+  useEffect(() => {
+    if (formCount === formRefs.current.length) {
+      // Prevent UI from resetting while waiting for API
+      const updatedEntity = { ...selectedEntity, ...formData };
+      setSelectedEntity(updatedEntity);
+      // Submit to API
+      onSubmit(formData);
+      // Reset
+      setFormData({});
+      setFormCount(0);
+    }
+  }, [formCount]);
+
+  const handleSubmit = (enteredData: AnyObject) => {
+    // Combine into one submission
+    const data = { ...formData, ...enteredData };
+    setFormData(data);
+    setFormCount(formCount + 1);
+  };
+
+  const submitForms = (event: FormEvent) => {
+    event.preventDefault();
+
+    formRefs.current.forEach((form, index) => {
+      // Stagger form submission
+      setTimeout(() => {
+        form.requestSubmit();
+      }, 100 * index);
+    });
+  };
+
+  const Intro = ({
+    verbiage,
+  }: {
+    verbiage: EntityDetailsMultiformVerbiage;
+  }) => {
+    const { heading, hint, accordion } = verbiage;
+
+    return (
+      <Box>
+        {heading && (
+          <Heading as="h3" sx={sx.plan.heading}>
+            {heading}
+          </Heading>
+        )}
+        {hint && <Text>{hint}</Text>}
+        {accordion && <InstructionsAccordion verbiage={accordion} />}
+      </Box>
+    );
+  };
+
+  const Cell = ({
+    header,
+    text,
+  }: {
+    header?: string | ScreenReaderOnlyHeaderName;
+    text: string;
+  }) => {
+    const headerName = typeof header === "object" ? header.hiddenName : header;
+
+    switch (headerName) {
+      case "Status":
+        return (
+          <EntityStatusIcon
+            entity={selectedEntity as EntityShape}
+            entityType={entityType}
+          />
+        );
+      case "Action":
+        return (
+          <Button variant="outline" disabled={true}>
+            Enter
+          </Button>
+        );
+      default:
+        return (
+          <Text as="span" sx={sx.plan.tableData}>
+            {text}
+          </Text>
+        );
+    }
+  };
+
+  return (
+    <Box>
+      <Button
+        sx={sx.backButton}
+        variant="none"
+        onClick={closeEntityDetailsOverlay as MouseEventHandler}
+        aria-label={`${verbiage.backButton}`}
+      >
+        <Image src={arrowLeftBlue} alt="Arrow left" sx={sx.backIcon} />
+        {verbiage.backButton}
+      </Button>
+      <ReportPageIntro text={verbiage.intro} />
+      <Box>
+        {forms.map((formObject: EntityDetailsMultiformShape, index) => (
+          <Box key={`${formObject.form.id}`} sx={sx.plan.container}>
+            {formObject.verbiage && <Intro verbiage={formObject.verbiage} />}
+            <Form
+              autosave={false}
+              disabled={disabled}
+              dontReset={true}
+              formData={selectedEntity}
+              formJson={formObject.form}
+              id={formObject.form.id}
+              onSubmit={(data: AnyObject) => handleSubmit(data)}
+              ref={(el) => (formRefs.current[index] = el as HTMLFormElement)}
+              validateOnRender={validateOnRender || false}
+            ></Form>
+            {formObject.table && (
+              <Table
+                content={{
+                  headRow: formObject.table.headRow,
+                  caption: formObject.table.caption,
+                }}
+                sx={sx.plan.table}
+              >
+                {formObject.table.bodyRows.map((row, rowIndex) => (
+                  <Tr key={`${formObject.form.id}-${rowIndex}`}>
+                    {row.map((cell: string, cellIndex: number) => (
+                      <Td
+                        key={`${formObject.form.id}-${rowIndex}-${cellIndex}}`}
+                        sx={sx.plan.tableCell}
+                      >
+                        <Cell
+                          text={cell}
+                          header={formObject.table?.headRow[cellIndex]}
+                        />
+                      </Td>
+                    ))}
+                  </Tr>
+                ))}
+              </Table>
+            )}
+          </Box>
+        ))}
+      </Box>
+      <Box sx={sx.footerBox}>
+        <Flex sx={sx.buttonFlex}>
+          {disabled ? (
+            <Button
+              variant="outline"
+              onClick={closeEntityDetailsOverlay as MouseEventHandler}
+            >
+              Return
+            </Button>
+          ) : (
+            <Button type="submit" sx={sx.saveButton} onClick={submitForms}>
+              {submitting ? <Spinner size="md" /> : "Save & return"}
+            </Button>
+          )}
+        </Flex>
+      </Box>
+    </Box>
+  );
+};
+
+interface Props {
+  closeEntityDetailsOverlay: Function;
+  disabled: boolean;
+  entityType: EntityType;
+  forms: [EntityDetailsMultiformShape];
+  onSubmit: Function;
+  selectedEntity?: EntityShape;
+  setEntering: Function;
+  setSelectedEntity: Function;
+  submitting: boolean;
+  validateOnRender?: boolean;
+  verbiage: EntityDetailsMultiformVerbiage;
+}
+
+const sx = {
+  overlayContainer: {
+    backgroundColor: "palette.white",
+    width: "100%",
+  },
+  backButton: {
+    padding: 0,
+    fontWeight: "normal",
+    color: "palette.primary",
+    display: "flex",
+    position: "relative",
+    right: "3rem",
+    marginBottom: "2rem",
+    marginTop: "-2rem",
+  },
+  backIcon: {
+    color: "palette.primary",
+    height: "1rem",
+    marginRight: "0.5rem",
+  },
+  footerBox: {
+    marginTop: "2rem",
+  },
+  buttonFlex: {
+    justifyContent: "end",
+    marginY: "1.5rem",
+  },
+  saveButton: {
+    width: "8.25rem",
+  },
+  plan: {
+    container: {
+      paddingTop: "1.75rem",
+      "&:first-of-type": {
+        borderTopColor: "palette.gray_lighter",
+        borderTopWidth: "1px",
+      },
+    },
+    heading: {
+      fontSize: "1.3rem",
+    },
+    table: {
+      marginBottom: "1.5rem",
+    },
+    tableCell: {
+      borderColor: "palette.gray_lighter",
+    },
+    tableData: {
+      display: "block",
+      fontSize: "1rem",
+      fontWeight: "bold",
+      lineHeight: "1.5rem",
+      maxWidth: "19rem",
+    },
+  },
+};

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
@@ -220,7 +220,7 @@ describe("<ModalDrawerReportPage />", () => {
       const entityCell = screen.getByText("plan 1");
 
       expect(entityTable).toBeVisible();
-      expect(entityHeader).not.toBeInTheDocument();
+      expect(entityHeader).toBeNull();
       expect(entityCell).toBeVisible();
     });
 

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
@@ -5,7 +5,7 @@ import { ReportContext, ModalDrawerReportPage } from "components";
 // constants
 import { saveAndCloseText } from "../../constants";
 // utils
-import { useStore } from "utils";
+import { useBreakpoint, useStore } from "utils";
 import {
   mockModalDrawerReportPageJson,
   mockRepeatedFormField,
@@ -16,6 +16,7 @@ import {
   mockNaaarReportStore,
 } from "utils/testing/setupJest";
 import { testA11y } from "utils/testing/commonTests";
+import { ModalDrawerReportPageShape } from "types";
 
 const mockUseNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
@@ -29,6 +30,10 @@ jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 mockedUseStore.mockReturnValue(mockStateUserStore);
 
+jest.mock("utils/other/useBreakpoint");
+const mockUseBreakpoint = useBreakpoint as jest.MockedFunction<
+  typeof useBreakpoint
+>;
 window.HTMLElement.prototype.scrollIntoView = jest.fn();
 
 const {
@@ -45,14 +50,23 @@ const modalDrawerReportPageComponentWithoutEntities = (
 );
 
 const modalDrawerReportPageComponentWithEntities = (
+  route: ModalDrawerReportPageShape = mockModalDrawerReportPageJson
+) => (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockMcparReportContext}>
-      <ModalDrawerReportPage route={mockModalDrawerReportPageJson} />
+      <ModalDrawerReportPage route={route} />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
 
 describe("<ModalDrawerReportPage />", () => {
+  beforeEach(() => {
+    mockUseBreakpoint.mockReturnValue({
+      isMobile: false,
+      isTablet: false,
+    });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -69,7 +83,7 @@ describe("<ModalDrawerReportPage />", () => {
         ...mockStateUserStore,
         ...mockMcparReportStore,
       });
-      render(modalDrawerReportPageComponentWithEntities);
+      render(modalDrawerReportPageComponentWithEntities());
     });
 
     test("ModalDrawerReportPage should render the view", () => {
@@ -161,19 +175,76 @@ describe("<ModalDrawerReportPage />", () => {
   });
 
   describe("Test ModalDrawerReportPage w/ Entity Table (NAAAR)", () => {
-    test("Entity table should render for a NAAAR report", async () => {
+    beforeEach(() => {
       mockedUseStore.mockReturnValue({
         ...mockStateUserStore,
         ...mockNaaarReportStore,
       });
+    });
 
-      render(modalDrawerReportPageComponentWithEntities);
-      const entityTable = screen.getByTestId("entity-table");
+    test("renders Entity table for a NAAAR report", async () => {
+      const naaarRoute = {
+        ...mockModalDrawerReportPageJson,
+        entityType: "plans",
+      };
+      render(modalDrawerReportPageComponentWithEntities(naaarRoute));
+
+      const entityTable = screen.getByRole("table");
+      const entityHeader = screen.getByRole("columnheader", {
+        name: "Mock table header",
+      });
+      const entityCell = screen.getByRole("gridcell", {
+        name: "plan 1 Select “Enter” to complete response.",
+      });
+
       expect(entityTable).toBeVisible();
+      expect(entityHeader).toBeVisible();
+      expect(entityCell).toBeVisible();
+    });
+
+    test("renders mobile Entity table for a NAAAR report", async () => {
+      mockUseBreakpoint.mockReturnValue({
+        isMobile: true,
+        isTablet: false,
+      });
+      const naaarRoute = {
+        ...mockModalDrawerReportPageJson,
+        entityType: "plans",
+      };
+      render(modalDrawerReportPageComponentWithEntities(naaarRoute));
+
+      const entityTable = screen.getByRole("table");
+      const entityHeader = screen.queryByRole("columnheader", {
+        name: "Mock table header",
+      });
+      const entityCell = screen.getByText("plan 1");
+
+      expect(entityTable).toBeVisible();
+      expect(entityHeader).not.toBeInTheDocument();
+      expect(entityCell).toBeVisible();
+    });
+
+    test("show error for missing plans in NAAAR report", async () => {
+      const noPlans = { ...mockNaaarReportStore };
+      delete noPlans.report?.fieldData.plans;
+
+      mockedUseStore.mockReturnValue({
+        ...mockStateUserStore,
+        ...noPlans,
+      });
+
+      const naaarRoute = {
+        ...mockModalDrawerReportPageJson,
+        entityType: "sanctions",
+      };
+      render(modalDrawerReportPageComponentWithEntities(naaarRoute));
+
+      const missingMessage = screen.getByTestId("missingEntityMessage");
+      expect(missingMessage).toBeVisible();
     });
   });
 
-  testA11y(modalDrawerReportPageComponentWithEntities, () => {
+  testA11y(modalDrawerReportPageComponentWithEntities(), () => {
     mockedUseStore.mockReturnValue({
       ...mockStateUserStore,
       ...mockMcparReportStore,

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -188,7 +188,7 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
       {verbiage.intro && <ReportPageIntro text={verbiage.intro} />}
       <Box>
         {!checkForPlans() ? (
-          <Box sx={sx.missingEntityMessage}>
+          <Box sx={sx.missingEntityMessage} data-testid="missingEntityMessage">
             {parseCustomHtml(verbiage.missingEntityMessage || "")}
           </Box>
         ) : report?.reportType === ReportType.NAAAR ? (
@@ -308,7 +308,7 @@ const entityTable = (
     return { headRow: ["", verbiage.tableHeader!, ""] };
   };
   return (
-    <Table sx={sx.table} content={tableHeaders()} data-testid={"entity-table"}>
+    <Table sx={sx.table} content={tableHeaders()}>
       {entities.map((entity: EntityShape) => (
         <ResponsiveEntityRow
           key={entity.id}

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -17,9 +17,9 @@ import {
   AnyObject,
   EntityShape,
   EntityType,
-  entityTypes,
   FormField,
   isFieldElement,
+  ModalDrawerEntityTypes,
   ModalDrawerReportPageShape,
   ModalDrawerReportPageVerbiage,
   ReportStatus,
@@ -57,7 +57,7 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
 
   // check if there is at least one (1) plan prior to being able to enter Sanctions
   const checkForPlans = () => {
-    if (entityType === entityTypes[4]) {
+    if (entityType === ModalDrawerEntityTypes.SANCTIONS) {
       return report?.fieldData["plans"]?.length;
     }
     return true;

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -5,12 +5,11 @@ import {
   AddEditEntityModal,
   DeleteEntityModal,
   EntityCard,
-  EntityRow,
-  MobileEntityRow,
   ReportContext,
   ReportDrawer,
   ReportPageFooter,
   ReportPageIntro,
+  ResponsiveEntityRow,
   Table,
 } from "components";
 // types
@@ -310,27 +309,16 @@ const entityTable = (
   };
   return (
     <Table sx={sx.table} content={tableHeaders()} data-testid={"entity-table"}>
-      {entities.map((entity: EntityShape) =>
-        isMobile || isTablet ? (
-          <MobileEntityRow
-            key={entity.id}
-            entity={entity}
-            verbiage={verbiage}
-            openAddEditEntityModal={openAddEditEntityModal}
-            openDeleteEntityModal={openDeleteEntityModal}
-            openOverlayOrDrawer={openOverlayOrDrawer}
-          />
-        ) : (
-          <EntityRow
-            key={entity.id}
-            entity={entity}
-            verbiage={verbiage}
-            openAddEditEntityModal={openAddEditEntityModal}
-            openDeleteEntityModal={openDeleteEntityModal}
-            openOverlayOrDrawer={openOverlayOrDrawer}
-          />
-        )
-      )}
+      {entities.map((entity: EntityShape) => (
+        <ResponsiveEntityRow
+          key={entity.id}
+          entity={entity}
+          verbiage={verbiage}
+          openAddEditEntityModal={openAddEditEntityModal}
+          openDeleteEntityModal={openDeleteEntityModal}
+          openOverlayOrDrawer={openOverlayOrDrawer}
+        />
+      ))}
     </Table>
   );
 };

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -6,11 +6,10 @@ import {
   DeleteEntityModal,
   EntityDetailsOverlay,
   EntityProvider,
-  EntityRow,
-  MobileEntityRow,
   ReportContext,
   ReportPageFooter,
   ReportPageIntro,
+  ResponsiveEntityRow,
   Table,
 } from "components";
 // types
@@ -208,31 +207,18 @@ export const ModalOverlayReportPage = ({
               </>
             ) : (
               <Table sx={sx.table} content={tableHeaders()}>
-                {reportFieldDataEntities.map((entity: EntityShape) =>
-                  isMobile || isTablet ? (
-                    <MobileEntityRow
-                      key={entity.id}
-                      entity={entity}
-                      verbiage={verbiage}
-                      locked={isLocked}
-                      entering={entering}
-                      openAddEditEntityModal={openAddEditEntityModal}
-                      openDeleteEntityModal={openDeleteEntityModal}
-                      openOverlayOrDrawer={openEntityDetailsOverlay}
-                    />
-                  ) : (
-                    <EntityRow
-                      key={entity.id}
-                      entity={entity}
-                      verbiage={verbiage}
-                      locked={isLocked}
-                      entering={entering}
-                      openAddEditEntityModal={openAddEditEntityModal}
-                      openDeleteEntityModal={openDeleteEntityModal}
-                      openOverlayOrDrawer={openEntityDetailsOverlay}
-                    />
-                  )
-                )}
+                {reportFieldDataEntities.map((entity: EntityShape) => (
+                  <ResponsiveEntityRow
+                    key={entity.id}
+                    entity={entity}
+                    verbiage={verbiage}
+                    locked={isLocked}
+                    entering={entering}
+                    openAddEditEntityModal={openAddEditEntityModal}
+                    openDeleteEntityModal={openDeleteEntityModal}
+                    openOverlayOrDrawer={openEntityDetailsOverlay}
+                  />
+                ))}
               </Table>
             )}
             <Button

--- a/services/ui-src/src/components/reports/OverlayReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/OverlayReportPage.test.tsx
@@ -205,8 +205,7 @@ describe("<OverlayReportPage />", () => {
       expect(enterButton).toBeVisible();
       await userEvent.click(enterButton);
 
-      //TODO: Update this when the overlay has been updated!
-      expect(screen.getByText(`You've opened the entity: ${planName}!`));
+      expect(screen.getByText(`Mock Details: ${planName}`));
     });
   });
 

--- a/services/ui-src/src/components/reports/OverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayReportPage.tsx
@@ -3,15 +3,15 @@ import { useContext, useState } from "react";
 import { Box } from "@chakra-ui/react";
 import {
   EntityDetailsMultiformOverlay,
-  EntityRow,
-  MobileEntityRow,
   ReportContext,
   ReportPageFooter,
   ReportPageIntro,
+  ResponsiveEntityRow,
   Table,
 } from "components";
 // types
 import {
+  AnyObject,
   CustomHtmlElement,
   EntityShape,
   EntityType,
@@ -25,9 +25,7 @@ import {
   useBreakpoint,
   useStore,
 } from "utils";
-import { EntityRowProps } from "components/tables/EntityRow";
 import { translate } from "utils/text/translate";
-import { AnyObject } from "yup/lib/types";
 
 export const OverlayReportPage = ({
   route,
@@ -66,13 +64,15 @@ export const OverlayReportPage = ({
     const standardEntities = report?.fieldData["standards"] || [];
 
     const tableHeaders = () => {
-      if (isTablet || isMobile)
+      if (isTablet || isMobile) {
         return {
           headRow: [
             { hiddenName: "Status" },
             { hiddenName: verbiage.tableHeader },
           ],
         };
+      }
+
       return {
         headRow: [
           { hiddenName: "Status" },
@@ -104,14 +104,6 @@ export const OverlayReportPage = ({
 
     const displayTable = () => {
       return entityData.length > 0;
-    };
-
-    const ResponsiveEntityRow = (props: EntityRowProps) => {
-      return isMobile || isTablet ? (
-        <MobileEntityRow {...props} />
-      ) : (
-        <EntityRow {...props} />
-      );
     };
 
     return (

--- a/services/ui-src/src/components/reports/OverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayReportPage.tsx
@@ -1,120 +1,232 @@
-import { useState } from "react";
+import { useContext, useState } from "react";
 // components
 import { Box } from "@chakra-ui/react";
 import {
+  EntityDetailsMultiformOverlay,
   EntityRow,
   MobileEntityRow,
+  ReportContext,
   ReportPageFooter,
   ReportPageIntro,
   Table,
 } from "components";
 // types
-import { CustomHtmlElement, EntityShape, OverlayReportPageShape } from "types";
+import {
+  CustomHtmlElement,
+  EntityShape,
+  EntityType,
+  OverlayReportPageShape,
+  ReportStatus,
+} from "types";
 // utils
-import { parseCustomHtml, useBreakpoint, useStore } from "utils";
+import {
+  entityWasUpdated,
+  parseCustomHtml,
+  useBreakpoint,
+  useStore,
+} from "utils";
+import { EntityRowProps } from "components/tables/EntityRow";
+import { translate } from "utils/text/translate";
+import { AnyObject } from "yup/lib/types";
 
-export const OverlayReportPage = ({ route, setSidebarHidden }: Props) => {
+export const OverlayReportPage = ({
+  route,
+  setSidebarHidden,
+  validateOnRender,
+}: Props) => {
   // Route Information
-  const { verbiage, entityType } = route;
+  const { verbiage, entityType, details } = route;
 
   // Context Information
   const { isTablet, isMobile } = useBreakpoint();
-  // state management
-  const { report } = useStore();
+  const { updateReport } = useContext(ReportContext);
   const [isEntityDetailsOpen, setIsEntityDetailsOpen] = useState<boolean>();
-  const [currentEntity, setCurrentEntity] = useState<EntityShape | undefined>(
+  const [selectedEntity, setSelectedEntity] = useState<EntityShape | undefined>(
     undefined
   );
   const [entering, setEntering] = useState<boolean>(false);
-  const entityData = report?.fieldData[entityType] || [];
-  const standardEntities = report?.fieldData["standards"] || [];
+  const [submitting, setSubmitting] = useState<boolean>(false);
 
-  const tableHeaders = () => {
-    if (isTablet || isMobile) return { headRow: ["", ""] };
-    return { headRow: ["", verbiage.tableHeader, ""] };
-  };
+  // state management
+  const { full_name, state } = useStore().user ?? {};
+  const { report } = useStore();
 
   // Open/Close overlay action methods
-  const openOverlay = (entity: EntityShape) => {
-    setEntering(true);
-    setCurrentEntity(entity);
-    setIsEntityDetailsOpen(true);
-    setSidebarHidden(true);
+  const toggleOverlay = (entity?: EntityShape) => {
+    const openOverlay = !!entity;
+
+    setSelectedEntity(entity);
+    setEntering(openOverlay);
+    setIsEntityDetailsOpen(openOverlay);
+    setSidebarHidden(openOverlay);
   };
 
-  const displayErrorMessages = () => {
-    if (!entityData.length) {
-      const errorMessage: CustomHtmlElement[] | undefined =
-        verbiage.requiredMessages[entityType];
-      return (
-        <Box sx={sx.missingEntityMessage}>
-          {parseCustomHtml(errorMessage || "")}
-        </Box>
-      );
-    } else if (standardEntities.length == 0) {
-      // TODO - Update this when working through the actual logic pertaining to Standards and how it'll be checked
-      return (
-        <Box sx={sx.missingEntityMessage}>
-          {parseCustomHtml(verbiage.requiredMessages.standards || "")}
-        </Box>
-      );
-    }
-    return <></>;
-  };
+  const TablePage = () => {
+    const entityData = report?.fieldData[entityType] || [];
+    const standardEntities = report?.fieldData["standards"] || [];
 
-  const displayTable = () => {
-    return entityData.length > 0;
-  };
+    const tableHeaders = () => {
+      if (isTablet || isMobile)
+        return {
+          headRow: [
+            { hiddenName: "Status" },
+            { hiddenName: verbiage.tableHeader },
+          ],
+        };
+      return {
+        headRow: [
+          { hiddenName: "Status" },
+          verbiage.tableHeader,
+          { hiddenName: "Action" },
+        ],
+      };
+    };
 
-  const openEntityMessage = `You've opened the entity: ${currentEntity?.name}!`;
-
-  return (
-    <Box>
-      {isEntityDetailsOpen && currentEntity ? (
-        <h1>{openEntityMessage}</h1>
-      ) : (
-        <Box sx={sx.content}>
-          {route.verbiage.intro && (
-            <ReportPageIntro
-              text={route.verbiage.intro}
-              reportType={report?.reportType}
-            />
-          )}
-
-          {displayErrorMessages()}
-
-          <Box sx={sx.dashboardBox}>
-            {displayTable() && (
-              <Table sx={sx.table} content={tableHeaders()}>
-                {entityData.map((entity: EntityShape) =>
-                  isMobile || isTablet ? (
-                    <MobileEntityRow
-                      key={entity.id}
-                      entity={entity}
-                      verbiage={verbiage}
-                      locked={undefined}
-                      entering={entering}
-                      openOverlayOrDrawer={openOverlay}
-                    />
-                  ) : (
-                    <EntityRow
-                      key={entity.id}
-                      entity={entity}
-                      verbiage={verbiage}
-                      locked={undefined}
-                      entering={entering}
-                      openOverlayOrDrawer={openOverlay}
-                    />
-                  )
-                )}
-              </Table>
-            )}
+    const displayErrorMessages = () => {
+      if (entityData.length === 0) {
+        const errorMessage: CustomHtmlElement[] | undefined =
+          verbiage.requiredMessages[entityType];
+        return (
+          <Box sx={sx.missingEntityMessage}>
+            {parseCustomHtml(errorMessage || "")}
           </Box>
-          <ReportPageFooter />
+        );
+      } else if (standardEntities.length === 0) {
+        // TODO - Update this when working through the actual logic pertaining to Standards and how it'll be checked
+        return (
+          <Box sx={sx.missingEntityMessage}>
+            {parseCustomHtml(verbiage.requiredMessages.standards || "")}
+          </Box>
+        );
+      }
+      return <></>;
+    };
+
+    const displayTable = () => {
+      return entityData.length > 0;
+    };
+
+    const ResponsiveEntityRow = (props: EntityRowProps) => {
+      return isMobile || isTablet ? (
+        <MobileEntityRow {...props} />
+      ) : (
+        <EntityRow {...props} />
+      );
+    };
+
+    return (
+      <Box sx={sx.content}>
+        {route.verbiage.intro && (
+          <ReportPageIntro
+            text={route.verbiage.intro}
+            reportType={report?.reportType}
+          />
+        )}
+
+        {displayErrorMessages()}
+
+        <Box sx={sx.dashboardBox}>
+          {displayTable() && (
+            <Table sx={sx.table} content={tableHeaders()}>
+              {entityData.map((entity: EntityShape) => (
+                <ResponsiveEntityRow
+                  entering={entering}
+                  entity={entity}
+                  entityType={entityType}
+                  key={entity.id}
+                  locked={undefined}
+                  openOverlayOrDrawer={() => toggleOverlay(entity)}
+                  verbiage={verbiage}
+                />
+              ))}
+            </Table>
+          )}
         </Box>
-      )}
-    </Box>
-  );
+        <ReportPageFooter />
+      </Box>
+    );
+  };
+
+  const DetailsOverlay = () => {
+    if (!details) {
+      return <></>;
+    }
+
+    const detailsVerbiage = { ...details.verbiage };
+    // Replace {{planName}}
+    detailsVerbiage.intro.subsection = translate(
+      detailsVerbiage.intro.subsection,
+      {
+        planName: selectedEntity?.name,
+      }
+    );
+
+    const onSubmit = async (enteredData: AnyObject) => {
+      setSubmitting(true);
+
+      const reportKeys = {
+        reportType: report?.reportType,
+        state,
+        id: report?.id,
+      };
+
+      const currentEntities = [...(report?.fieldData[entityType] || [])];
+      let selectedEntityIndex = currentEntities.findIndex(
+        (entity: EntityShape) => entity.id === selectedEntity?.id
+      );
+
+      if (selectedEntityIndex < 0) {
+        selectedEntityIndex = currentEntities.length;
+      }
+
+      const newEntity = {
+        ...selectedEntity,
+        ...enteredData,
+      };
+
+      const newEntities = [...currentEntities];
+      newEntities[selectedEntityIndex] = newEntity;
+
+      const shouldSave = entityWasUpdated(
+        currentEntities[selectedEntityIndex],
+        newEntity
+      );
+
+      if (shouldSave) {
+        const dataToWrite = {
+          metadata: {
+            status: ReportStatus.IN_PROGRESS,
+            lastAlteredBy: full_name,
+          },
+          fieldData: {
+            [entityType]: newEntities,
+          },
+        };
+        await updateReport(reportKeys, dataToWrite);
+      }
+
+      setSubmitting(false);
+      toggleOverlay();
+    };
+
+    return (
+      <EntityDetailsMultiformOverlay
+        closeEntityDetailsOverlay={() => toggleOverlay()}
+        disabled={false}
+        entityType={entityType as EntityType}
+        forms={details.forms}
+        onSubmit={onSubmit}
+        selectedEntity={selectedEntity}
+        setEntering={setEntering}
+        setSelectedEntity={setSelectedEntity}
+        submitting={submitting}
+        validateOnRender={validateOnRender}
+        verbiage={detailsVerbiage}
+      />
+    );
+  };
+
+  return isEntityDetailsOpen ? <DetailsOverlay /> : <TablePage />;
 };
 
 interface Props {
@@ -150,7 +262,7 @@ const sx = {
       paddingLeft: "1rem",
       paddingRight: "0",
       borderBottom: "1px solid",
-      borderColor: "palette.gray_light",
+      borderColor: "palette.gray_lighter",
       ".tablet &, .mobile &": {
         border: "none",
       },
@@ -159,6 +271,14 @@ const sx = {
       },
       "&:nth-of-type(3)": {
         width: "260px",
+      },
+    },
+    td: {
+      borderColor: "palette.gray_lighter",
+    },
+    tr: {
+      "&:last-of-type td": {
+        border: "0",
       },
     },
   },

--- a/services/ui-src/src/components/tables/EntityRow.test.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.test.tsx
@@ -90,7 +90,7 @@ describe("<EntityRow />", () => {
       const errorMessage = screen.queryByText(
         "Select “Enter MLR” to complete this report."
       );
-      expect(errorMessage).not.toBeInTheDocument();
+      expect(errorMessage).toBeNull();
     });
 
     test("Edit button opens the AddEditEntityModal", async () => {

--- a/services/ui-src/src/components/tables/EntityRow.test.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.test.tsx
@@ -1,88 +1,186 @@
-import { render, screen } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
+import * as React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
 // components
 import { ReportContext } from "components/reports/ReportProvider";
 import { EntityRow } from "./EntityRow";
 import { Table } from "./Table";
+// types
+import { EntityType } from "types";
 // utils
 import {
   mockMlrReportContext,
   mockMlrReportStore,
+  mockNaaarReportStore,
+  mockNaaarReportContext,
   mockStateUserStore,
   mockVerbiageIntro,
   RouterWrappedComponent,
+  mockMcparReportStore,
+  mockMcparReportContext,
+  mockAdminUserStore,
+  mockNoUserStore,
 } from "utils/testing/setupJest";
 import userEvent from "@testing-library/user-event";
-import { useStore } from "utils";
+import { getEntityStatus, useStore } from "utils";
+import { testA11y } from "utils/testing/commonTests";
 
 const openAddEditEntityModal = jest.fn();
 const openDeleteEntityModal = jest.fn();
 const mockOpenDrawer = jest.fn();
-const mockEntering = false;
+let mockEntering = false;
 
 jest.mock("utils/state/useStore");
+jest.mock("utils/tables/getEntityStatus");
+jest.spyOn(React, "useMemo").mockImplementation((fn) => fn());
+
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+const mockedGetEntityStatus = getEntityStatus as jest.MockedFunction<
+  typeof getEntityStatus
+>;
 
 const completeRowComponent = (
+  context: any = mockMlrReportContext,
+  entity: EntityType = "program"
+) => (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockMlrReportContext}>
+    <ReportContext.Provider value={context}>
       <Table content={{}}>
         <EntityRow
-          entity={mockMlrReportContext.report.fieldData.program[1]}
+          entity={context.report.fieldData[entity][0]}
           verbiage={mockVerbiageIntro}
           entering={mockEntering}
           openAddEditEntityModal={openAddEditEntityModal}
           openDeleteEntityModal={openDeleteEntityModal}
           openOverlayOrDrawer={mockOpenDrawer}
-        ></EntityRow>
+        />
       </Table>
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
 
 describe("<EntityRow />", () => {
-  beforeEach(() => {
-    mockedUseStore.mockReturnValue(mockStateUserStore);
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  test("It should NOT render an error if an entity is complete", async () => {
-    const { queryByText } = render(completeRowComponent);
-    expect(queryByText("Select “Enter MLR” to complete this report.")).toBe(
-      null
-    );
+  describe("MLR", () => {
+    beforeEach(() => {
+      mockedUseStore.mockReturnValue({
+        ...mockStateUserStore,
+        ...mockMlrReportStore,
+      });
+    });
+
+    test("render error if entity is incomplete", async () => {
+      mockedUseStore.mockReturnValue({
+        ...mockNoUserStore,
+        ...mockMlrReportStore,
+      });
+      mockedGetEntityStatus.mockReturnValue(false);
+      render(completeRowComponent(mockMlrReportContext));
+      const errorMessage = screen.getByText(
+        "Select “Enter MLR” to complete this report."
+      );
+      expect(errorMessage).toBeVisible();
+    });
+
+    test("don't render error if entity is complete", async () => {
+      mockedGetEntityStatus.mockReturnValue(true);
+      render(completeRowComponent(mockMlrReportContext));
+      const errorMessage = screen.queryByText(
+        "Select “Enter MLR” to complete this report."
+      );
+      expect(errorMessage).not.toBeInTheDocument();
+    });
+
+    test("Edit button opens the AddEditEntityModal", async () => {
+      render(completeRowComponent());
+      const addReportButton = screen.getByRole("button", { name: "Edit" });
+      expect(addReportButton).toBeVisible();
+      await userEvent.click(addReportButton);
+      await waitFor(() => {
+        expect(openAddEditEntityModal).toBeCalledTimes(1);
+      });
+    });
+
+    test("Enter Details button opens the Drawer", async () => {
+      render(completeRowComponent());
+      const enterDetailsButton = screen.getByRole("button", {
+        name: "Enter Details",
+      });
+      expect(enterDetailsButton).toBeVisible();
+      await userEvent.click(enterDetailsButton);
+      await waitFor(() => {
+        expect(mockOpenDrawer).toBeCalledTimes(1);
+      });
+    });
+
+    test("Delete button opens the DeleteEntityModal", async () => {
+      render(completeRowComponent());
+      const deleteButton = screen.getByRole("button", { name: "delete icon" });
+      expect(deleteButton).toBeVisible();
+      await userEvent.click(deleteButton);
+      await waitFor(() => {
+        expect(openDeleteEntityModal).toBeCalledTimes(1);
+      });
+    });
+
+    test("Delete button is disabled for admin", async () => {
+      mockedUseStore.mockReturnValue({
+        ...mockAdminUserStore,
+        ...mockMlrReportStore,
+      });
+      render(completeRowComponent());
+      const deleteButton = screen.getByRole("button", { name: "delete icon" });
+      expect(deleteButton).toBeDisabled();
+    });
+
+    test("render Spinner when entering", async () => {
+      mockEntering = true;
+      render(completeRowComponent(mockMlrReportContext));
+      const loading = screen.getByRole("button", { name: "Loading..." });
+      expect(loading).toBeVisible();
+      mockEntering = false;
+    });
   });
 
-  test("Clicking Edit button opens the AddEditEntityModal", async () => {
-    await act(async () => {
-      await render(completeRowComponent);
+  describe("NAAAR", () => {
+    beforeEach(() => {
+      mockedUseStore.mockReturnValue({
+        ...mockStateUserStore,
+        ...mockNaaarReportStore,
+      });
     });
-    const addReportButton = screen.getByText("Edit");
-    expect(addReportButton).toBeVisible();
-    await userEvent.click(addReportButton);
-    await expect(openAddEditEntityModal).toBeCalledTimes(1);
+
+    test("Edit button opens the AddEditEntityModal", async () => {
+      render(completeRowComponent(mockNaaarReportContext, "plans"));
+      const editButton = screen.getByRole("button", { name: "Edit" });
+      expect(editButton).toBeVisible();
+      await userEvent.click(editButton);
+      await waitFor(() => {
+        expect(openAddEditEntityModal).toBeCalledTimes(1);
+      });
+    });
   });
 
-  test("Clicking Enter Details button opens the Drawer", async () => {
-    mockedUseStore.mockReturnValue({
-      ...mockStateUserStore,
-      ...mockMlrReportStore,
+  describe("MCPAR", () => {
+    beforeEach(() => {
+      mockedUseStore.mockReturnValue({
+        ...mockStateUserStore,
+        ...mockMcparReportStore,
+      });
     });
-    await act(async () => {
-      await render(completeRowComponent);
+
+    test("MCPAR Enter Details button opens the Drawer", async () => {
+      render(completeRowComponent(mockMcparReportContext, "plans"));
+      const enterButton = screen.getByRole("button", { name: "Enter" });
+      expect(enterButton).toBeVisible();
+      await userEvent.click(enterButton);
+      await waitFor(() => {
+        expect(mockOpenDrawer).toBeCalledTimes(1);
+      });
     });
-    const enterDetailsButton = screen.getByText("Enter Details");
-    expect(enterDetailsButton).toBeVisible();
-    await userEvent.click(enterDetailsButton);
-    await expect(mockOpenDrawer).toBeCalledTimes(1);
   });
 
-  test("Clicking Delete button opens the DeleteEntityModal", async () => {
-    await act(async () => {
-      await render(completeRowComponent);
-    });
-    const deleteButton = screen.getByAltText("delete icon");
-    expect(deleteButton).toBeVisible();
-    await userEvent.click(deleteButton);
-    await expect(openDeleteEntityModal).toBeCalledTimes(1);
-  });
+  testA11y(completeRowComponent());
 });

--- a/services/ui-src/src/components/tables/EntityRow.test.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.test.tsx
@@ -71,7 +71,7 @@ describe("<EntityRow />", () => {
       });
     });
 
-    test("render error if entity is incomplete", async () => {
+    test("render error if entity is incomplete", () => {
       mockedUseStore.mockReturnValue({
         ...mockNoUserStore,
         ...mockMlrReportStore,
@@ -84,7 +84,7 @@ describe("<EntityRow />", () => {
       expect(errorMessage).toBeVisible();
     });
 
-    test("don't render error if entity is complete", async () => {
+    test("don't render error if entity is complete", () => {
       mockedGetEntityStatus.mockReturnValue(true);
       render(completeRowComponent(mockMlrReportContext));
       const errorMessage = screen.queryByText(
@@ -125,7 +125,7 @@ describe("<EntityRow />", () => {
       });
     });
 
-    test("Delete button is disabled for admin", async () => {
+    test("Delete button is disabled for admin", () => {
       mockedUseStore.mockReturnValue({
         ...mockAdminUserStore,
         ...mockMlrReportStore,
@@ -135,7 +135,7 @@ describe("<EntityRow />", () => {
       expect(deleteButton).toBeDisabled();
     });
 
-    test("render Spinner when entering", async () => {
+    test("render Spinner when entering", () => {
       mockEntering = true;
       render(completeRowComponent(mockMlrReportContext));
       const loading = screen.getByRole("button", { name: "Loading..." });

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { Button, Flex, Image, Spinner, Td, Text, Tr } from "@chakra-ui/react";
 import { EntityStatusIcon } from "components";
 // types
-import { AnyObject, EntityShape, ReportType } from "types";
+import { AnyObject, EntityShape, EntityType, ReportType } from "types";
 // utils
 import { eligibilityGroup, getEntityStatus, useStore } from "utils";
 // assets
@@ -25,7 +25,7 @@ export const EntityRow = ({
   const reportingPeriod = `${entity.report_reportingPeriodStartDate} to ${entity.report_reportingPeriodEndDate}`;
 
   const entityComplete = useMemo(() => {
-    return report ? getEntityStatus(report, entity, entityType) : false;
+    return getEntityStatus(entity, report, entityType);
   }, [report]);
 
   const enterDetailsText = () => {
@@ -111,7 +111,7 @@ export const EntityRow = ({
 
 export interface EntityRowProps {
   entity: EntityShape;
-  entityType?: string;
+  entityType?: EntityType;
   verbiage: AnyObject;
   locked?: boolean;
   entering?: boolean;

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -5,27 +5,27 @@ import { EntityStatusIcon } from "components";
 // types
 import { AnyObject, EntityShape, ReportType } from "types";
 // utils
-import { eligibilityGroup, getMlrEntityStatus, useStore } from "utils";
+import { eligibilityGroup, getEntityStatus, useStore } from "utils";
 // assets
 import deleteIcon from "assets/icons/icon_cancel_x_circle.png";
 
 export const EntityRow = ({
   entity,
+  entityType,
   verbiage,
   locked,
   entering,
   openAddEditEntityModal,
   openDeleteEntityModal,
   openOverlayOrDrawer,
-}: Props) => {
+}: EntityRowProps) => {
   const { report_programName, report_planName, name } = entity;
   const { report } = useStore();
   const { userIsEndUser } = useStore().user ?? {};
   const reportingPeriod = `${entity.report_reportingPeriodStartDate} to ${entity.report_reportingPeriodEndDate}`;
 
-  // TODO: refactor to handle NAAAR analysis methods
   const entityComplete = useMemo(() => {
-    return report ? getMlrEntityStatus(report, entity) : false;
+    return report ? getEntityStatus(report, entity, entityType) : false;
   }, [report]);
 
   const enterDetailsText = () => {
@@ -55,7 +55,7 @@ export const EntityRow = ({
   return (
     <Tr sx={sx.content}>
       <Td sx={sx.statusIcon}>
-        <EntityStatusIcon entity={entity as EntityShape} />
+        <EntityStatusIcon entity={entity} entityType={entityType} />
       </Td>
       <Td sx={sx.entityFields}>
         <ul>
@@ -109,8 +109,9 @@ export const EntityRow = ({
   );
 };
 
-interface Props {
+export interface EntityRowProps {
   entity: EntityShape;
+  entityType?: string;
   verbiage: AnyObject;
   locked?: boolean;
   entering?: boolean;

--- a/services/ui-src/src/components/tables/EntityStatusIcon.tsx
+++ b/services/ui-src/src/components/tables/EntityStatusIcon.tsx
@@ -2,20 +2,20 @@ import { useMemo } from "react";
 // components
 import { Box, Image, Text } from "@chakra-ui/react";
 // types
-import { EntityShape } from "types";
+import { EntityShape, EntityType } from "types";
 // utils
-import { getMlrEntityStatus, useStore } from "utils";
+import { getEntityStatus, useStore } from "utils";
 // assets
 import unfinishedIcon from "assets/icons/icon_error_circle_bright.png";
 import unfinishedIconDark from "assets/icons/icon_error_circle.png";
 import successIcon from "assets/icons/icon_check_circle.png";
 import successIconDark from "assets/icons/icon_check_circle_dark.png";
 
-export const EntityStatusIcon = ({ entity, isPdf }: Props) => {
+export const EntityStatusIcon = ({ entity, entityType, isPdf }: Props) => {
   const { report } = useStore();
 
   const entityComplete = useMemo(() => {
-    return report ? getMlrEntityStatus(report, entity) : false;
+    return report ? getEntityStatus(report, entity, entityType) : false;
   }, [report]);
 
   return (
@@ -58,6 +58,7 @@ interface Props {
    * Entity to show status for
    */
   entity: EntityShape;
+  entityType?: EntityType;
   /**
    * Whether or not icon is appearing on PDF page (used for styling)
    */

--- a/services/ui-src/src/components/tables/EntityStatusIcon.tsx
+++ b/services/ui-src/src/components/tables/EntityStatusIcon.tsx
@@ -15,7 +15,7 @@ export const EntityStatusIcon = ({ entity, entityType, isPdf }: Props) => {
   const { report } = useStore();
 
   const entityComplete = useMemo(() => {
-    return report ? getEntityStatus(report, entity, entityType) : false;
+    return getEntityStatus(entity, report, entityType);
   }, [report]);
 
   return (

--- a/services/ui-src/src/components/tables/MobileEntityRow.test.tsx
+++ b/services/ui-src/src/components/tables/MobileEntityRow.test.tsx
@@ -90,7 +90,7 @@ describe("<MobileEntityRow />", () => {
       const errorMessage = screen.queryByText(
         "Select “Enter MLR” to complete this report."
       );
-      expect(errorMessage).not.toBeInTheDocument();
+      expect(errorMessage).toBeNull;
     });
 
     test("Edit button opens the AddEditEntityModal", async () => {

--- a/services/ui-src/src/components/tables/MobileEntityRow.test.tsx
+++ b/services/ui-src/src/components/tables/MobileEntityRow.test.tsx
@@ -71,7 +71,7 @@ describe("<MobileEntityRow />", () => {
       });
     });
 
-    test("render error if entity is incomplete", async () => {
+    test("render error if entity is incomplete", () => {
       mockedUseStore.mockReturnValue({
         ...mockNoUserStore,
         ...mockMlrReportStore,
@@ -84,7 +84,7 @@ describe("<MobileEntityRow />", () => {
       expect(errorMessage).toBeVisible();
     });
 
-    test("don't render error if entity is complete", async () => {
+    test("don't render error if entity is complete", () => {
       mockedGetEntityStatus.mockReturnValue(true);
       render(completeRowComponent(mockMlrReportContext));
       const errorMessage = screen.queryByText(
@@ -125,7 +125,7 @@ describe("<MobileEntityRow />", () => {
       });
     });
 
-    test("Delete button is disabled for admin", async () => {
+    test("Delete button is disabled for admin", () => {
       mockedUseStore.mockReturnValue({
         ...mockAdminUserStore,
         ...mockMlrReportStore,
@@ -135,7 +135,7 @@ describe("<MobileEntityRow />", () => {
       expect(deleteButton).toBeDisabled();
     });
 
-    test("render Spinner when entering", async () => {
+    test("render Spinner when entering", () => {
       mockEntering = true;
       render(completeRowComponent(mockMlrReportContext));
       const loading = screen.getByRole("button", { name: "Loading..." });

--- a/services/ui-src/src/components/tables/MobileEntityRow.test.tsx
+++ b/services/ui-src/src/components/tables/MobileEntityRow.test.tsx
@@ -1,35 +1,52 @@
-import { render, screen } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
+import * as React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
 // components
 import { ReportContext } from "components/reports/ReportProvider";
 import { MobileEntityRow } from "./MobileEntityRow";
 import { Table } from "./Table";
+// types
+import { EntityType } from "types";
 // utils
 import {
   mockMlrReportContext,
   mockMlrReportStore,
+  mockNaaarReportStore,
+  mockNaaarReportContext,
   mockStateUserStore,
   mockVerbiageIntro,
   RouterWrappedComponent,
+  mockMcparReportStore,
+  mockMcparReportContext,
+  mockAdminUserStore,
+  mockNoUserStore,
 } from "utils/testing/setupJest";
 import userEvent from "@testing-library/user-event";
-import { useStore } from "utils";
+import { getEntityStatus, useStore } from "utils";
 import { testA11y } from "utils/testing/commonTests";
 
 const openAddEditEntityModal = jest.fn();
 const openDeleteEntityModal = jest.fn();
 const mockOpenDrawer = jest.fn();
-const mockEntering = false;
+let mockEntering = false;
 
 jest.mock("utils/state/useStore");
+jest.mock("utils/tables/getEntityStatus");
+jest.spyOn(React, "useMemo").mockImplementation((fn) => fn());
+
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+const mockedGetEntityStatus = getEntityStatus as jest.MockedFunction<
+  typeof getEntityStatus
+>;
 
 const completeRowComponent = (
+  context: any = mockMlrReportContext,
+  entity: EntityType = "program"
+) => (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockMlrReportContext}>
+    <ReportContext.Provider value={context}>
       <Table content={{}}>
         <MobileEntityRow
-          entity={mockMlrReportContext.report.fieldData.program[1]}
+          entity={context.report.fieldData[entity][0]}
           verbiage={mockVerbiageIntro}
           entering={mockEntering}
           openAddEditEntityModal={openAddEditEntityModal}
@@ -42,53 +59,128 @@ const completeRowComponent = (
 );
 
 describe("<MobileEntityRow />", () => {
-  beforeEach(() => {
-    mockedUseStore.mockReturnValue(mockStateUserStore);
-  });
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test("It should NOT render an error if an entity is complete", async () => {
-    const { queryByText } = render(completeRowComponent);
-    expect(queryByText("Select “Enter MLR” to complete this report.")).toBe(
-      null
-    );
+  describe("MLR", () => {
+    beforeEach(() => {
+      mockedUseStore.mockReturnValue({
+        ...mockStateUserStore,
+        ...mockMlrReportStore,
+      });
+    });
+
+    test("render error if entity is incomplete", async () => {
+      mockedUseStore.mockReturnValue({
+        ...mockNoUserStore,
+        ...mockMlrReportStore,
+      });
+      mockedGetEntityStatus.mockReturnValue(false);
+      render(completeRowComponent(mockMlrReportContext));
+      const errorMessage = screen.getByText(
+        "Select “Enter MLR” to complete this report."
+      );
+      expect(errorMessage).toBeVisible();
+    });
+
+    test("don't render error if entity is complete", async () => {
+      mockedGetEntityStatus.mockReturnValue(true);
+      render(completeRowComponent(mockMlrReportContext));
+      const errorMessage = screen.queryByText(
+        "Select “Enter MLR” to complete this report."
+      );
+      expect(errorMessage).not.toBeInTheDocument();
+    });
+
+    test("Edit button opens the AddEditEntityModal", async () => {
+      render(completeRowComponent());
+      const addReportButton = screen.getByRole("button", { name: "Edit" });
+      expect(addReportButton).toBeVisible();
+      await userEvent.click(addReportButton);
+      await waitFor(() => {
+        expect(openAddEditEntityModal).toBeCalledTimes(1);
+      });
+    });
+
+    test("Enter Details button opens the Drawer", async () => {
+      render(completeRowComponent());
+      const enterDetailsButton = screen.getByRole("button", {
+        name: "Enter Details",
+      });
+      expect(enterDetailsButton).toBeVisible();
+      await userEvent.click(enterDetailsButton);
+      await waitFor(() => {
+        expect(mockOpenDrawer).toBeCalledTimes(1);
+      });
+    });
+
+    test("Delete button opens the DeleteEntityModal", async () => {
+      render(completeRowComponent());
+      const deleteButton = screen.getByRole("button", { name: "delete icon" });
+      expect(deleteButton).toBeVisible();
+      await userEvent.click(deleteButton);
+      await waitFor(() => {
+        expect(openDeleteEntityModal).toBeCalledTimes(1);
+      });
+    });
+
+    test("Delete button is disabled for admin", async () => {
+      mockedUseStore.mockReturnValue({
+        ...mockAdminUserStore,
+        ...mockMlrReportStore,
+      });
+      render(completeRowComponent());
+      const deleteButton = screen.getByRole("button", { name: "delete icon" });
+      expect(deleteButton).toBeDisabled();
+    });
+
+    test("render Spinner when entering", async () => {
+      mockEntering = true;
+      render(completeRowComponent(mockMlrReportContext));
+      const loading = screen.getByRole("button", { name: "Loading..." });
+      expect(loading).toBeVisible();
+      mockEntering = false;
+    });
   });
 
-  test("Clicking Edit button opens the AddEditEntityModal", async () => {
-    await act(async () => {
-      await render(completeRowComponent);
+  describe("NAAAR", () => {
+    beforeEach(() => {
+      mockedUseStore.mockReturnValue({
+        ...mockStateUserStore,
+        ...mockNaaarReportStore,
+      });
     });
-    const addReportButton = screen.getByText("Edit");
-    expect(addReportButton).toBeVisible();
-    await userEvent.click(addReportButton);
-    await expect(openAddEditEntityModal).toBeCalledTimes(1);
+
+    test("Edit button opens the AddEditEntityModal", async () => {
+      render(completeRowComponent(mockNaaarReportContext, "plans"));
+      const editButton = screen.getByRole("button", { name: "Edit" });
+      expect(editButton).toBeVisible();
+      await userEvent.click(editButton);
+      await waitFor(() => {
+        expect(openAddEditEntityModal).toBeCalledTimes(1);
+      });
+    });
   });
 
-  test("Clicking Enter Details button opens the Drawer", async () => {
-    mockedUseStore.mockReturnValue({
-      ...mockStateUserStore,
-      ...mockMlrReportStore,
+  describe("MCPAR", () => {
+    beforeEach(() => {
+      mockedUseStore.mockReturnValue({
+        ...mockStateUserStore,
+        ...mockMcparReportStore,
+      });
     });
-    await act(async () => {
-      await render(completeRowComponent);
+
+    test("MCPAR Enter Details button opens the Drawer", async () => {
+      render(completeRowComponent(mockMcparReportContext, "plans"));
+      const enterButton = screen.getByRole("button", { name: "Enter" });
+      expect(enterButton).toBeVisible();
+      await userEvent.click(enterButton);
+      await waitFor(() => {
+        expect(mockOpenDrawer).toBeCalledTimes(1);
+      });
     });
-    const enterDetailsButton = screen.getByText("Enter Details");
-    expect(enterDetailsButton).toBeVisible();
-    await userEvent.click(enterDetailsButton);
-    await expect(mockOpenDrawer).toBeCalledTimes(1);
   });
 
-  test("Clicking Delete button opens the DeleteEntityModal", async () => {
-    await act(async () => {
-      await render(completeRowComponent);
-    });
-    const deleteButton = screen.getByAltText("delete icon");
-    expect(deleteButton).toBeVisible();
-    await userEvent.click(deleteButton);
-    await expect(openDeleteEntityModal).toBeCalledTimes(1);
-  });
-
-  testA11y(completeRowComponent);
+  testA11y(completeRowComponent());
 });

--- a/services/ui-src/src/components/tables/MobileEntityRow.tsx
+++ b/services/ui-src/src/components/tables/MobileEntityRow.tsx
@@ -42,7 +42,7 @@ export const MobileEntityRow = ({
   const { userIsEndUser } = useStore().user ?? {};
 
   const entityComplete = useMemo(() => {
-    return report ? getEntityStatus(report, entity, entityType) : false;
+    return getEntityStatus(entity, report, entityType);
   }, [report]);
 
   const enterDetailsText = () => {

--- a/services/ui-src/src/components/tables/MobileEntityRow.tsx
+++ b/services/ui-src/src/components/tables/MobileEntityRow.tsx
@@ -12,26 +12,28 @@ import {
 } from "@chakra-ui/react";
 import { EntityStatusIcon } from "components";
 // types
-import { AnyObject, EntityShape, ReportType } from "types";
+import { ReportType } from "types";
 // utils
 import {
   eligibilityGroup,
-  getMlrEntityStatus,
+  getEntityStatus,
   parseCustomHtml,
   useStore,
 } from "utils";
 // assets
 import deleteIcon from "assets/icons/icon_cancel_x_circle.png";
+import { EntityRowProps } from "./EntityRow";
 
 export const MobileEntityRow = ({
   entity,
+  entityType,
   verbiage,
   locked,
   entering,
   openAddEditEntityModal,
   openDeleteEntityModal,
   openOverlayOrDrawer,
-}: Props) => {
+}: EntityRowProps) => {
   const { editEntityButtonText, tableHeader } = verbiage;
   const { report } = useStore();
   const reportingPeriod = `${entity.report_reportingPeriodStartDate} to ${entity.report_reportingPeriodEndDate}`;
@@ -40,7 +42,7 @@ export const MobileEntityRow = ({
   const { userIsEndUser } = useStore().user ?? {};
 
   const entityComplete = useMemo(() => {
-    return report ? getMlrEntityStatus(report, entity) : false;
+    return report ? getEntityStatus(report, entity, entityType) : false;
   }, [report]);
 
   const enterDetailsText = () => {
@@ -70,7 +72,7 @@ export const MobileEntityRow = ({
   return (
     <Tr sx={sx.content}>
       <Td sx={sx.statusIcon}>
-        <EntityStatusIcon entity={entity as EntityShape} />
+        <EntityStatusIcon entity={entity} entityType={entityType} />
       </Td>
       <Td>
         <Text sx={sx.rowHeader}>
@@ -123,17 +125,6 @@ export const MobileEntityRow = ({
     </Tr>
   );
 };
-
-interface Props {
-  entity: EntityShape;
-  verbiage: AnyObject;
-  locked?: boolean;
-  entering?: boolean;
-  openAddEditEntityModal?: Function;
-  openDeleteEntityModal?: Function;
-  openOverlayOrDrawer?: Function;
-  [key: string]: any;
-}
 
 const sx = {
   statusIcon: {

--- a/services/ui-src/src/components/tables/ResponsiveEntityRow.test.tsx
+++ b/services/ui-src/src/components/tables/ResponsiveEntityRow.test.tsx
@@ -1,0 +1,71 @@
+import { render } from "@testing-library/react";
+// components
+import { ResponsiveEntityRow } from "./ResponsiveEntityRow";
+import { EntityRow } from "./EntityRow";
+import { MobileEntityRow } from "./MobileEntityRow";
+import { ReportContext, Table } from "components";
+// utils
+import {
+  mockMlrReportContext,
+  RouterWrappedComponent,
+} from "utils/testing/setupJest";
+import { useBreakpoint } from "utils";
+
+jest.mock("./EntityRow", () => ({
+  EntityRow: jest.fn(() => <></>),
+}));
+
+jest.mock("./MobileEntityRow", () => ({
+  MobileEntityRow: jest.fn(() => <></>),
+}));
+
+jest.mock("utils/other/useBreakpoint");
+const mockUseBreakpoint = useBreakpoint as jest.MockedFunction<
+  typeof useBreakpoint
+>;
+
+const entity = { id: "mock-entity" };
+const verbiage = {};
+
+const completeRowComponent = (
+  <RouterWrappedComponent>
+    <ReportContext.Provider value={mockMlrReportContext}>
+      <Table content={{}}>
+        <ResponsiveEntityRow entity={entity} verbiage={verbiage} />
+      </Table>
+    </ReportContext.Provider>
+  </RouterWrappedComponent>
+);
+
+describe("<ResponsiveEntityRow />", () => {
+  test("uses EntityRow for desktop", () => {
+    mockUseBreakpoint.mockReturnValue({
+      isMobile: false,
+      isTablet: false,
+    });
+    render(completeRowComponent);
+    const props = (EntityRow as jest.Mock).mock.calls[0][0];
+    expect(EntityRow).toHaveBeenCalled();
+    expect(props).toEqual({ entity, verbiage });
+  });
+
+  test("uses MobileEntityRow for tablet", () => {
+    mockUseBreakpoint.mockReturnValue({
+      isMobile: true,
+      isTablet: false,
+    });
+    render(completeRowComponent);
+    const props = (MobileEntityRow as jest.Mock).mock.calls[0][0];
+    expect(MobileEntityRow).toHaveBeenCalled();
+    expect(props).toEqual({ entity, verbiage });
+  });
+
+  test("uses MobileEntityRow for mobile", () => {
+    mockUseBreakpoint.mockReturnValue({
+      isMobile: false,
+      isTablet: true,
+    });
+    render(completeRowComponent);
+    expect(MobileEntityRow).toHaveBeenCalled();
+  });
+});

--- a/services/ui-src/src/components/tables/ResponsiveEntityRow.tsx
+++ b/services/ui-src/src/components/tables/ResponsiveEntityRow.tsx
@@ -1,0 +1,16 @@
+// components
+import { EntityRow, MobileEntityRow } from "components";
+// types
+import { EntityRowProps } from "./EntityRow";
+// utils
+import { useBreakpoint } from "utils";
+
+export const ResponsiveEntityRow = (props: EntityRowProps) => {
+  const { isTablet, isMobile } = useBreakpoint();
+
+  return isMobile || isTablet ? (
+    <MobileEntityRow {...props} />
+  ) : (
+    <EntityRow {...props} />
+  );
+};

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -93,7 +93,7 @@ export interface EntityDetailsMultiformShape {
   form: FormJson;
   table?: {
     caption: string;
-    bodyRows: Array<[string]>;
+    bodyRows: [Array<string>];
     headRow: Array<string | ScreenReaderOnlyHeaderName>;
   };
   verbiage?: EntityDetailsMultiformVerbiage;

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -4,6 +4,7 @@ import {
   CompletionData,
   CustomHtmlElement,
   FormJson,
+  ScreenReaderOnlyHeaderName,
   State,
 } from "types";
 
@@ -88,6 +89,16 @@ export interface ModalOverlayReportPageShape extends ReportPageShapeBase {
   form?: never;
 }
 
+export interface EntityDetailsMultiformShape {
+  form: FormJson;
+  table?: {
+    caption: string;
+    bodyRows: Array<[string]>;
+    headRow: Array<string | ScreenReaderOnlyHeaderName>;
+  };
+  verbiage?: EntityDetailsMultiformVerbiage;
+}
+
 export interface OverlayReportPageShape extends ReportPageShapeBase {
   entityType: string;
   verbiage: OverlayReportPageVerbiage;
@@ -95,6 +106,10 @@ export interface OverlayReportPageShape extends ReportPageShapeBase {
   modalForm?: never;
   drawerForm?: never;
   form?: never;
+  details?: {
+    forms: [EntityDetailsMultiformShape];
+    verbiage: EntityDetailsMultiformVerbiage;
+  };
 }
 
 export interface ReportRouteWithoutForm extends ReportRouteBase {
@@ -167,6 +182,16 @@ export interface OverlayReportPageVerbiage extends ReportPageVerbiage {
   tableHeader: string;
   emptyDashboardText: string;
   enterEntityDetailsButtonText: string;
+}
+
+export interface EntityDetailsMultiformVerbiage extends ReportPageVerbiage {
+  backButton?: string;
+  heading?: string;
+  hint?: string;
+  accordion?: {
+    buttonLabel: string;
+    text: string;
+  };
 }
 
 // REPORT METADATA

--- a/services/ui-src/src/utils/index.ts
+++ b/services/ui-src/src/utils/index.ts
@@ -20,7 +20,9 @@ export * from "./reports/routing";
 // statusing
 export * from "./statusing/getRouteStatus";
 // tables
+export * from "./tables/getEntityStatus";
 export * from "./tables/getMlrEntityStatus";
+export * from "./tables/getNaaarEntityStatus";
 // tracking
 export * from "./tracking/tealium";
 // validation

--- a/services/ui-src/src/utils/index.ts
+++ b/services/ui-src/src/utils/index.ts
@@ -42,3 +42,5 @@ export * from "./other/parsing";
 export * from "./other/typing";
 // state management (zustand)
 export * from "./state/useStore";
+// text
+export * from "./text/translate";

--- a/services/ui-src/src/utils/tables/getEntityStatus.test.ts
+++ b/services/ui-src/src/utils/tables/getEntityStatus.test.ts
@@ -1,5 +1,8 @@
-import { ReportShape, ReportType } from "types";
+// components
 import { getEntityStatus } from "./getEntityStatus";
+// types
+import { ReportShape, ReportType } from "types";
+// utils
 import { getMlrEntityStatus, getNaaarEntityStatus } from "utils";
 
 jest.mock("utils");
@@ -17,7 +20,11 @@ describe("getEntityStatus()", () => {
   test("calls getNaaarEntityStatus() for NAAAR", () => {
     report.reportType = ReportType.NAAAR;
     getEntityStatus(report, entity, entityType);
-    expect(getNaaarEntityStatus).toHaveBeenCalled();
+    expect(getNaaarEntityStatus).toHaveBeenCalledWith(
+      report,
+      entity,
+      entityType
+    );
   });
 
   test("returns false for unknown report type", () => {

--- a/services/ui-src/src/utils/tables/getEntityStatus.test.ts
+++ b/services/ui-src/src/utils/tables/getEntityStatus.test.ts
@@ -1,0 +1,35 @@
+import { ReportShape, ReportType } from "types";
+import { getEntityStatus } from "./getEntityStatus";
+import { getMlrEntityStatus, getNaaarEntityStatus } from "utils";
+
+jest.mock("utils");
+
+describe("getEntityStatus()", () => {
+  const report = { reportType: ReportType.MLR } as ReportShape;
+  const entity = { id: "mock-entity" };
+  const entityType = "plans";
+
+  test("calls getMlrEntityStatus() for MLR", () => {
+    getEntityStatus(report, entity);
+    expect(getMlrEntityStatus).toHaveBeenCalledWith(report, entity);
+  });
+
+  test("calls getNaaarEntityStatus() for NAAAR", () => {
+    report.reportType = ReportType.NAAAR;
+    getEntityStatus(report, entity, entityType);
+    expect(getNaaarEntityStatus).toHaveBeenCalled();
+  });
+
+  test("returns false for unknown report type", () => {
+    report.reportType = "unknown";
+    expect(getEntityStatus(report, entity)).toBe(false);
+  });
+
+  test("returns false for undefined report", () => {
+    expect(getEntityStatus(report, undefined)).toBe(false);
+  });
+
+  test("returns false for undefined entity", () => {
+    expect(getEntityStatus(undefined, entity)).toBe(false);
+  });
+});

--- a/services/ui-src/src/utils/tables/getEntityStatus.test.ts
+++ b/services/ui-src/src/utils/tables/getEntityStatus.test.ts
@@ -13,30 +13,26 @@ describe("getEntityStatus()", () => {
   const entityType = "plans";
 
   test("calls getMlrEntityStatus() for MLR", () => {
-    getEntityStatus(report, entity);
-    expect(getMlrEntityStatus).toHaveBeenCalledWith(report, entity);
+    getEntityStatus(entity, report);
+    expect(getMlrEntityStatus).toHaveBeenCalledWith(entity, report);
   });
 
   test("calls getNaaarEntityStatus() for NAAAR", () => {
     report.reportType = ReportType.NAAAR;
-    getEntityStatus(report, entity, entityType);
+    getEntityStatus(entity, report, entityType);
     expect(getNaaarEntityStatus).toHaveBeenCalledWith(
-      report,
       entity,
+      report,
       entityType
     );
   });
 
   test("returns false for unknown report type", () => {
     report.reportType = "unknown";
-    expect(getEntityStatus(report, entity)).toBe(false);
+    expect(getEntityStatus(entity, report)).toBe(false);
   });
 
   test("returns false for undefined report", () => {
-    expect(getEntityStatus(report, undefined)).toBe(false);
-  });
-
-  test("returns false for undefined entity", () => {
-    expect(getEntityStatus(undefined, entity)).toBe(false);
+    expect(getEntityStatus(entity, undefined)).toBe(false);
   });
 });

--- a/services/ui-src/src/utils/tables/getEntityStatus.ts
+++ b/services/ui-src/src/utils/tables/getEntityStatus.ts
@@ -1,20 +1,18 @@
-import { EntityShape, ReportShape, ReportType } from "types";
+// types
+import { EntityShape, EntityType, ReportShape, ReportType } from "types";
+// utils
 import { getMlrEntityStatus, getNaaarEntityStatus } from "utils";
 
 export const getEntityStatus = (
+  entity: EntityShape,
   report?: ReportShape,
-  entity?: EntityShape,
-  entityType?: string
+  entityType?: EntityType
 ) => {
-  if (!report || !entity) {
-    return false;
-  }
-
-  switch (report.reportType) {
+  switch (report?.reportType) {
     case ReportType.MLR:
-      return getMlrEntityStatus(report, entity);
+      return getMlrEntityStatus(entity, report);
     case ReportType.NAAAR:
-      return getNaaarEntityStatus(report, entity, entityType);
+      return getNaaarEntityStatus(entity, report, entityType);
     default:
       return false;
   }

--- a/services/ui-src/src/utils/tables/getEntityStatus.ts
+++ b/services/ui-src/src/utils/tables/getEntityStatus.ts
@@ -1,0 +1,21 @@
+import { EntityShape, ReportShape, ReportType } from "types";
+import { getMlrEntityStatus, getNaaarEntityStatus } from "utils";
+
+export const getEntityStatus = (
+  report?: ReportShape,
+  entity?: EntityShape,
+  entityType?: string
+) => {
+  if (!report || !entity) {
+    return false;
+  }
+
+  switch (report.reportType) {
+    case ReportType.MLR:
+      return getMlrEntityStatus(report, entity);
+    case ReportType.NAAAR:
+      return getNaaarEntityStatus(report, entity, entityType);
+    default:
+      return false;
+  }
+};

--- a/services/ui-src/src/utils/tables/getMlrEntityStatus.test.ts
+++ b/services/ui-src/src/utils/tables/getMlrEntityStatus.test.ts
@@ -5,34 +5,40 @@ describe("Test getMlrEntityStatus", () => {
   test("should return a truthy value if complete", () => {
     const report = mockMlrModalOverlayReport;
     expect(
-      getMlrEntityStatus(report, {
-        id: "1",
-        "report_modal-text-field": "1",
-        "report_optional-text-field": "2",
-        "report_text-field": "3",
-        "report_number-field": 4,
-        "report_nested-field": [
-          { key: "report_nested-field", value: "option 3" },
-        ],
-        "report_nested-text-field": "a",
-      })
+      getMlrEntityStatus(
+        {
+          id: "1",
+          "report_modal-text-field": "1",
+          "report_optional-text-field": "2",
+          "report_text-field": "3",
+          "report_number-field": 4,
+          "report_nested-field": [
+            { key: "report_nested-field", value: "option 3" },
+          ],
+          "report_nested-text-field": "a",
+        },
+        report
+      )
     ).toBeTruthy();
   });
 
   test("should return a falsy value if incomplete", () => {
     const report = mockMlrModalOverlayReport;
     expect(
-      getMlrEntityStatus(report, {
-        id: "1",
-        "report_modal-text-field": "1",
-        "report_optional-text-field": "2",
-        "report_text-field": null,
-        "report_number-field": null,
-        "report_nested-field": [
-          { key: "report_nested-field", value: "option 3" },
-        ],
-        "report_nested-text-field": "a",
-      })
+      getMlrEntityStatus(
+        {
+          id: "1",
+          "report_modal-text-field": "1",
+          "report_optional-text-field": "2",
+          "report_text-field": null,
+          "report_number-field": null,
+          "report_nested-field": [
+            { key: "report_nested-field", value: "option 3" },
+          ],
+          "report_nested-text-field": "a",
+        },
+        report
+      )
     ).not.toBeTruthy();
   });
 });

--- a/services/ui-src/src/utils/tables/getMlrEntityStatus.ts
+++ b/services/ui-src/src/utils/tables/getMlrEntityStatus.ts
@@ -3,8 +3,8 @@ import { mapValidationTypesToSchema } from "utils/validation/validation";
 import { object } from "yup";
 
 export const getMlrEntityStatus = (
-  report: ReportShape,
-  entity: EntityShape
+  entity: EntityShape,
+  report: ReportShape
 ) => {
   const reportFormValidation = Object.fromEntries(
     Object.entries(report?.formTemplate.validationJson ?? {}).filter(

--- a/services/ui-src/src/utils/tables/getNaaarEntityStatus.test.ts
+++ b/services/ui-src/src/utils/tables/getNaaarEntityStatus.test.ts
@@ -13,10 +13,10 @@ describe("getNaaarEntityStatus()", () => {
   const entityType = "plans";
 
   test("returns false", () => {
-    expect(getNaaarEntityStatus(report, entity)).toBe(false);
+    expect(getNaaarEntityStatus(entity, report)).toBe(false);
   });
 
   test("returns true", () => {
-    expect(getNaaarEntityStatus(report, entity, entityType)).toBe(true);
+    expect(getNaaarEntityStatus(entity, report, entityType)).toBe(true);
   });
 });

--- a/services/ui-src/src/utils/tables/getNaaarEntityStatus.test.ts
+++ b/services/ui-src/src/utils/tables/getNaaarEntityStatus.test.ts
@@ -1,12 +1,22 @@
-import { ReportShape, ReportType } from "types";
+// components
 import { getNaaarEntityStatus } from "./getNaaarEntityStatus";
+// types
+import { ReportShape, ReportType } from "types";
 
 describe("getNaaarEntityStatus()", () => {
   const report = { reportType: ReportType.NAAAR } as ReportShape;
-  const entity = { id: "mock-entity" };
+  const entity = {
+    id: "mock-entity",
+    planCompliance438206_assurance: [],
+    planCompliance43868_assurance: [],
+  };
   const entityType = "plans";
 
   test("returns false", () => {
-    expect(getNaaarEntityStatus(report, entity, entityType)).toBe(false);
+    expect(getNaaarEntityStatus(report, entity)).toBe(false);
+  });
+
+  test("returns true", () => {
+    expect(getNaaarEntityStatus(report, entity, entityType)).toBe(true);
   });
 });

--- a/services/ui-src/src/utils/tables/getNaaarEntityStatus.test.ts
+++ b/services/ui-src/src/utils/tables/getNaaarEntityStatus.test.ts
@@ -1,0 +1,12 @@
+import { ReportShape, ReportType } from "types";
+import { getNaaarEntityStatus } from "./getNaaarEntityStatus";
+
+describe("getNaaarEntityStatus()", () => {
+  const report = { reportType: ReportType.NAAAR } as ReportShape;
+  const entity = { id: "mock-entity" };
+  const entityType = "plans";
+
+  test("returns false", () => {
+    expect(getNaaarEntityStatus(report, entity, entityType)).toBe(false);
+  });
+});

--- a/services/ui-src/src/utils/tables/getNaaarEntityStatus.ts
+++ b/services/ui-src/src/utils/tables/getNaaarEntityStatus.ts
@@ -3,8 +3,8 @@ import { EntityShape, EntityType, ReportShape } from "types";
 
 // TODO: Update to actual logic
 export const getNaaarEntityStatus = (
-  report: ReportShape,
   entity: EntityShape,
+  report: ReportShape,
   entityType?: EntityType
 ) => {
   if (entityType === "plans") {

--- a/services/ui-src/src/utils/tables/getNaaarEntityStatus.ts
+++ b/services/ui-src/src/utils/tables/getNaaarEntityStatus.ts
@@ -1,0 +1,16 @@
+import { EntityShape, EntityType, ReportShape } from "types";
+
+// TODO: Update to actual logic
+export const getNaaarEntityStatus = (
+  report: ReportShape,
+  entity: EntityShape,
+  entityType?: EntityType
+) => {
+  if (entityType === "plans") {
+    return (
+      entity.planCompliance438206_assurance &&
+      entity.planCompliance43868_assurance
+    );
+  }
+  return false;
+};

--- a/services/ui-src/src/utils/tables/getNaaarEntityStatus.ts
+++ b/services/ui-src/src/utils/tables/getNaaarEntityStatus.ts
@@ -9,8 +9,8 @@ export const getNaaarEntityStatus = (
 ) => {
   if (entityType === "plans") {
     return !!(
-      entity.planCompliance438206_assurance &&
-      entity.planCompliance43868_assurance
+      entity?.planCompliance438206_assurance &&
+      entity?.planCompliance43868_assurance
     );
   }
   return false;

--- a/services/ui-src/src/utils/tables/getNaaarEntityStatus.ts
+++ b/services/ui-src/src/utils/tables/getNaaarEntityStatus.ts
@@ -1,3 +1,4 @@
+// types
 import { EntityShape, EntityType, ReportShape } from "types";
 
 // TODO: Update to actual logic
@@ -7,7 +8,7 @@ export const getNaaarEntityStatus = (
   entityType?: EntityType
 ) => {
   if (entityType === "plans") {
-    return (
+    return !!(
       entity.planCompliance438206_assurance &&
       entity.planCompliance43868_assurance
     );

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -201,6 +201,7 @@ export const mockVerbiageIntro = {
   ],
   editEntityButtonText: "Edit",
   enterReportText: "Enter Details",
+  tableHeader: "Mock table header",
 };
 
 export const mockStandardReportPageJson = {
@@ -519,6 +520,7 @@ export const mockModalDrawerReportPageVerbiage = {
   editEntityDetailsButtonText: "Mock edit entity details button text",
   drawerTitle: "Mock drawer title",
   drawerNoFormMessage: "Mock no form fields here",
+  tableHeader: "Mock table header",
 };
 
 export const mockModalOverlayReportPageVerbiage = {

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -609,7 +609,7 @@ export const mockOverlayReportPageJson: OverlayReportPageShape = {
     verbiage: {
       intro: {
         section: "",
-        subsection: "Mock Details: {{planName}}",
+        subsection: "Mock Details: Example Plan",
       },
       backButton: "Return to dashboard",
     },
@@ -617,7 +617,45 @@ export const mockOverlayReportPageJson: OverlayReportPageShape = {
       {
         form: {
           id: "mock-form",
-          fields: [],
+          fields: [
+            {
+              id: "mockRadio",
+              type: "radio",
+              validation: "radio",
+              props: {
+                choices: [
+                  {
+                    id: "yes",
+                    label: "Mock Yes",
+                  },
+                  {
+                    id: "no",
+                    label: "Mock No",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        table: {
+          bodyRows: [["", "Mock Cell", ""]],
+          caption: "",
+          headRow: [
+            { hiddenName: "Status" },
+            "Mock table header",
+            { hiddenName: "Action" },
+          ],
+        },
+        verbiage: {
+          accordion: {
+            buttonLabel: "Mock Accordion",
+            text: "",
+          },
+          intro: {
+            section: "",
+          },
+          heading: "Mock heading",
+          hint: "Mock hint",
         },
       },
     ],

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -603,6 +603,23 @@ export const mockOverlayReportPageJson: OverlayReportPageShape = {
   pageType: "modalOverlay",
   entityType: "plans",
   verbiage: mockOverlayReportPageVerbiage,
+  details: {
+    verbiage: {
+      intro: {
+        section: "",
+        subsection: "Mock Details: {{planName}}",
+      },
+      backButton: "Return to dashboard",
+    },
+    forms: [
+      {
+        form: {
+          id: "mock-form",
+          fields: [],
+        },
+      },
+    ],
+  },
 };
 
 export const mockReviewSubmitPageJson = {

--- a/services/ui-src/src/utils/text/translate.test.ts
+++ b/services/ui-src/src/utils/text/translate.test.ts
@@ -1,0 +1,39 @@
+import { translate } from "./translate";
+
+describe("translate()", () => {
+  const stateName = "State Name";
+  const heading = "Heading";
+  const reportYear = "2024";
+  const reportPeriod = "1";
+
+  test("returns translated text", () => {
+    const result = translate(
+      "{{stateName}} {{heading}} {{reportYear}} - Period {{reportPeriod}}",
+      { stateName, heading, reportYear, reportPeriod }
+    );
+    expect(result).toBe("State Name Heading 2024 - Period 1");
+  });
+
+  test("returns empty value for missing key", () => {
+    const result = translate(
+      "{{stateName}} {{heading}} {{reportYear}} - Period {{reportPeriod}}",
+      { heading, reportYear, reportPeriod }
+    );
+
+    expect(result).toBe(" Heading 2024 - Period 1");
+  });
+
+  test("returns empty value for non-existent key", () => {
+    const result = translate(
+      "{{stateName}} {{heading}} {{reportYear}} - Period {{reportPeriod}}",
+      { stateName, nonExistent: "nonExistent", reportYear, reportPeriod }
+    );
+
+    expect(result).toBe("State Name  2024 - Period 1");
+  });
+
+  test("returns empty string for undefined values", () => {
+    const result = translate(undefined, undefined);
+    expect(result).toBe("");
+  });
+});

--- a/services/ui-src/src/utils/text/translate.ts
+++ b/services/ui-src/src/utils/text/translate.ts
@@ -1,0 +1,14 @@
+export function translate(text: string = "", keysToReplace: any = {}) {
+  const keys = Object.keys(keysToReplace);
+  let translatedText = text;
+
+  keys.forEach((key) => {
+    const matches = new RegExp(`{{${key}}}`, "gm");
+    translatedText = translatedText.replace(matches, keysToReplace[key]);
+  });
+
+  const unmatched = /{{\w*}}/gm;
+  translatedText = translatedText.replace(unmatched, "");
+
+  return translatedText;
+}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Add individual plan compliance overlay
- Refactor `OverlayReportPage` to separate concerns for page vs overlay 
- Add `getEntityStatus` method, refactor where `getMlrEntityStatus` is called
- Add `ResponsiveEntityRow` that switches between `EntityRow` and `MobileEntityRow`
- Add `translate` util from MFP

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4261

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Create a NAAAR
2. Add a plan
3. Go to III. Plan Compliance
4. Click "Enter" on your plan
5. Select Yes or No, save

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

TODO:
- When "No" is selected, the `Enter` button in the table becomes active.
- `getNaaarEntityStatus` logic

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- ---

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
