### PR TITLE
CMDCT-4336 Add wcag 21 and 22 rules

### DIFF
--- a/tests/cypress/support/accessibility.js
+++ b/tests/cypress/support/accessibility.js
@@ -23,7 +23,14 @@ Cypress.Commands.add("runAccessibilityTests", () => {
   cy.checkA11y(
     null,
     {
-      values: ["wcag2a", "wcag2aa", "best-practice"],
+      values: [
+        "wcag2a",
+        "wcag2aa",
+        "wcag21a",
+        "wcag21aa",
+        "wcag22aa",
+        "best-practice",
+      ],
       includedImpacts: ["minor", "moderate", "serious", "critical"],
       rules: {
         "duplicate-id": { enabled: false },

--- a/tests/playwright/utils/a11y.ts
+++ b/tests/playwright/utils/a11y.ts
@@ -14,7 +14,14 @@ export async function e2eA11y(page: Page, url: string) {
   for (const size of Object.values(breakpoints)) {
     page.setViewportSize({ width: size[0], height: size[1] });
     const results = await new AxeBuilder({ page })
-      .withTags(["wcag2a", "wcag2aa", "best-practice"])
+      .withTags([
+        "wcag2a",
+        "wcag2aa",
+        "wcag21a",
+        "wcag21aa",
+        "wcag22aa",
+        "best-practice",
+      ])
       .disableRules(["duplicate-id"])
       .analyze();
     expect(results.violations).toEqual([]);

--- a/tests/playwright/utils/pageObjects/base.page.ts
+++ b/tests/playwright/utils/pageObjects/base.page.ts
@@ -88,7 +88,14 @@ export default class BasePage {
     for (const size of Object.values(breakpoints)) {
       this.page.setViewportSize({ width: size[0], height: size[1] });
       const results = await new AxeBuilder({ page: this.page })
-        .withTags(["wcag2a", "wcag2aa", "best-practice"])
+        .withTags([
+          "wcag2a",
+          "wcag2aa",
+          "wcag21a",
+          "wcag21aa",
+          "wcag22aa",
+          "best-practice",
+        ])
         .disableRules(["duplicate-id"])
         .analyze();
       expect(results.violations).toEqual([]);


### PR DESCRIPTION
### Description
Add WCAG 2.1 AA and WCAG 2.2 AA [rules to axe-core](https://www.deque.com/axe/core-documentation/api-documentation/#:~:text=the%20analysis%20again.-,axe-core%20tags,-Each%20rule%20in).


### Related ticket(s)
CMDCT-4336

---
### How to test
- Pull down branch
- Run tests
- The new rules will be applied (currently no violations)


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
