### PR TITLE
Multi banner

### DIFF
--- a/services/app-api/handlers/banners/fetch.ts
+++ b/services/app-api/handlers/banners/fetch.ts
@@ -1,20 +1,14 @@
 import handler from "../handler-lib";
 import dynamoDb from "../../utils/dynamo/dynamodb-lib";
 // utils
-import { error } from "../../utils/constants/constants";
-import { badRequest, ok } from "../../utils/responses/response-lib";
+import { ok } from "../../utils/responses/response-lib";
 
-export const fetchBanner = handler(async (event, _context) => {
-  if (!event?.pathParameters?.bannerId!) {
-    return badRequest(error.NO_KEY);
-  }
-  const params = {
+export const fetchBanner = handler(async (_event, _context) => {
+  const scanParams = {
     TableName: process.env.BANNER_TABLE_NAME!,
-    Key: {
-      key: event.pathParameters.bannerId,
-    },
   };
-  const response = await dynamoDb.get(params);
+
+  const response = await dynamoDb.scanAll(scanParams);
 
   return ok(response);
 });

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -148,14 +148,10 @@ functions:
     handler: handlers/banners/fetch.fetchBanner
     events:
       - http:
-          path: banners/{bannerId}
+          path: banners
           method: get
           cors: true
           authorizer: aws_iam
-          request:
-            parameters:
-              paths:
-                bannerId: true
   createBanner:
     handler: handlers/banners/create.createBanner
     events:

--- a/services/app-api/utils/dynamo/dynamodb-lib.ts
+++ b/services/app-api/utils/dynamo/dynamodb-lib.ts
@@ -9,6 +9,8 @@ import {
   QueryCommandInput,
   PutCommand,
   PutCommandInput,
+  ScanCommandInput,
+  ScanCommand,
 } from "@aws-sdk/lib-dynamodb";
 // utils
 import { logger } from "../debugging/debug-lib";
@@ -48,6 +50,19 @@ export default {
 
     do {
       const command = new QueryCommand({ ...params, ExclusiveStartKey });
+      const result = await client.send(command);
+      items = items.concat(result.Items ?? []);
+      ExclusiveStartKey = result.LastEvaluatedKey;
+    } while (ExclusiveStartKey);
+
+    return items;
+  },
+  scanAll: async (params: Omit<ScanCommandInput, "ExclusiveStartKey">) => {
+    let items: AnyObject[] = [];
+    let ExclusiveStartKey: Record<string, any> | undefined;
+
+    do {
+      const command = new ScanCommand({ ...params, ExclusiveStartKey });
       const result = await client.send(command);
       items = items.concat(result.Items ?? []);
       ExclusiveStartKey = result.LastEvaluatedKey;

--- a/services/ui-src/src/components/banners/AdminBannerProvider.test.tsx
+++ b/services/ui-src/src/components/banners/AdminBannerProvider.test.tsx
@@ -12,7 +12,7 @@ import { bannerErrors } from "verbiage/errors";
 
 jest.mock("utils/api/requestMethods/banner", () => ({
   deleteBanner: jest.fn(() => {}),
-  getBanner: jest.fn(() => {}),
+  getBanners: jest.fn(() => {}),
   writeBanner: jest.fn(() => {}),
 }));
 
@@ -51,20 +51,20 @@ describe("<AdminBannerProvider />", () => {
   });
   describe("test fetch banner method", () => {
     test("fetchAdminBanner method is called on load", async () => {
-      expect(mockAPI.getBanner).toHaveBeenCalledTimes(1);
+      expect(mockAPI.getBanners).toHaveBeenCalledTimes(1);
     });
 
-    test("fetchAdminBanner method calls API getBanner method", async () => {
-      expect(mockAPI.getBanner).toHaveBeenCalledTimes(1);
+    test("fetchAdminBanner method calls API getBanners method", async () => {
+      expect(mockAPI.getBanners).toHaveBeenCalledTimes(1);
       await act(async () => {
         const fetchButton = screen.getByText("Fetch");
         await userEvent.click(fetchButton);
       });
       // 1 call on render + 1 call on button click
-      await waitFor(() => expect(mockAPI.getBanner).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(mockAPI.getBanners).toHaveBeenCalledTimes(2));
     });
     test("Shows error if fetchBanner throws error", async () => {
-      mockAPI.getBanner.mockImplementation(() => {
+      mockAPI.getBanners.mockImplementation(() => {
         throw new Error();
       });
       await act(async () => {
@@ -85,7 +85,7 @@ describe("<AdminBannerProvider />", () => {
       expect(mockAPI.deleteBanner).toHaveBeenCalledWith(mockBannerData.key);
 
       // 1 call on render + 1 call on button click
-      await waitFor(() => expect(mockAPI.getBanner).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(mockAPI.getBanners).toHaveBeenCalledTimes(2));
     });
   });
 

--- a/services/ui-src/src/components/banners/AdminBannerProvider.test.tsx
+++ b/services/ui-src/src/components/banners/AdminBannerProvider.test.tsx
@@ -85,7 +85,7 @@ describe("<AdminBannerProvider />", () => {
       expect(mockAPI.deleteBanner).toHaveBeenCalledWith(mockBannerData.key);
 
       // 1 call on render + 1 call on button click
-      await waitFor(() => expect(mockAPI.getBanners).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(mockAPI.getBanners).toHaveBeenCalledTimes(3));
     });
   });
 

--- a/services/ui-src/src/components/forms/AdminBannerForm.test.tsx
+++ b/services/ui-src/src/components/forms/AdminBannerForm.test.tsx
@@ -2,8 +2,6 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 // components
 import { AdminBannerForm } from "components";
-// constants
-import { bannerId } from "../../constants";
 // utils
 import { convertDateTimeEtToUtc } from "utils";
 import { RouterWrappedComponent } from "utils/testing/mockRouter";
@@ -13,6 +11,11 @@ const mockWriteAdminBanner = jest.fn();
 const mockWriteAdminBannerWithError = jest.fn(() => {
   throw new Error();
 });
+
+jest.mock("react-uuid", () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue("mock-key"),
+}));
 
 const adminBannerFormComponent = (writeAdminBanner: Function) => (
   <RouterWrappedComponent>
@@ -51,7 +54,7 @@ describe("<AdminBannerForm />", () => {
     const submitButton = screen.getByRole("button");
     await userEvent.click(submitButton);
     await expect(mockWriteAdminBanner).toHaveBeenCalledWith({
-      key: bannerId,
+      key: "mock-key",
       title: "this is the title text",
       description: "this is the description text",
       link: undefined,

--- a/services/ui-src/src/components/forms/AdminBannerForm.tsx
+++ b/services/ui-src/src/components/forms/AdminBannerForm.tsx
@@ -59,7 +59,7 @@ export const AdminBannerForm = ({ writeAdminBanner, ...props }: Props) => {
       </Form>
       <Flex sx={sx.previewFlex}>
         <Button form={form.id} type="submit" sx={sx.replaceBannerButton}>
-          {submitting ? <Spinner size="md" /> : "Replace Current Banner"}
+          {submitting ? <Spinner size="md" /> : "Create banner"}
         </Button>
       </Flex>
     </>
@@ -79,7 +79,7 @@ const sx = {
     flexDirection: "column",
   },
   replaceBannerButton: {
-    width: "14rem",
+    width: "10rem",
     marginTop: "1rem !important",
     alignSelf: "end",
   },

--- a/services/ui-src/src/components/forms/AdminBannerForm.tsx
+++ b/services/ui-src/src/components/forms/AdminBannerForm.tsx
@@ -1,9 +1,8 @@
 import { useState } from "react";
+import uuid from "react-uuid";
 // components
 import { Button, Flex, Spinner } from "@chakra-ui/react";
 import { ErrorAlert, Form, PreviewBanner } from "components";
-// constants
-import { bannerId } from "../../constants";
 // types
 import { AlertTypes, ErrorVerbiage, FormJson } from "types";
 // utils
@@ -23,7 +22,7 @@ export const AdminBannerForm = ({ writeAdminBanner, ...props }: Props) => {
   const onSubmit = async (formData: any) => {
     setSubmitting(true);
     const newBannerData = {
-      key: bannerId,
+      key: uuid(),
       title: formData["bannerTitle"],
       description: formData["bannerDescription"],
       link: formData["bannerLink"] || undefined,

--- a/services/ui-src/src/components/pages/Admin/AdminPage.test.tsx
+++ b/services/ui-src/src/components/pages/Admin/AdminPage.test.tsx
@@ -38,7 +38,7 @@ describe("<AdminPage />", () => {
         mockedUseStore.mockReturnValue(mockBannerStore);
         await render(adminView(mockBannerMethods));
       });
-      const deleteButton = screen.getByText("Delete Current Banner");
+      const deleteButton = screen.getByText("Delete Banner");
       await userEvent.click(deleteButton);
       await waitFor(() =>
         expect(mockBannerMethods.deleteAdminBanner).toHaveBeenCalled()
@@ -52,6 +52,7 @@ describe("<AdminPage />", () => {
         mockedUseStore.mockReturnValue({
           ...mockBannerStore,
           bannerData: undefined,
+          allBanners: undefined,
         });
         await render(adminView(mockBannerMethods));
       });
@@ -87,7 +88,7 @@ describe("<AdminPage />", () => {
       const currentBannerStatus = screen.queryByText("Status:");
       expect(currentBannerStatus).toBeVisible();
 
-      const deleteButton = screen.getByText("Delete Current Banner");
+      const deleteButton = screen.getByText("Delete Banner");
       expect(deleteButton).toBeVisible();
     });
 
@@ -113,6 +114,7 @@ describe("<AdminPage />", () => {
       await act(async () => {
         mockedUseStore.mockReturnValue({
           ...mockBannerStore,
+          allBanners: [activeBannerData],
           bannerData: activeBannerData,
           bannerActive: true,
         });
@@ -150,7 +152,7 @@ describe("<AdminPage />", () => {
         await render(adminView(mockBannerMethods));
       });
 
-      const deleteButton = screen.getByText("Delete Current Banner");
+      const deleteButton = screen.getByText("Delete Banner");
       await userEvent.click(deleteButton);
       expect(
         screen.getByText("Current banner could not be deleted")

--- a/services/ui-src/src/components/pages/Admin/AdminPage.tsx
+++ b/services/ui-src/src/components/pages/Admin/AdminPage.tsx
@@ -19,7 +19,7 @@ import {
 // types
 import { AdminBannerData, AlertTypes } from "types";
 // utils
-import { convertDateUtcToEt, useStore } from "utils";
+import { checkDateRangeStatus, convertDateUtcToEt, useStore } from "utils";
 // verbiage
 import verbiage from "verbiage/pages/admin";
 
@@ -28,42 +28,40 @@ export const AdminPage = () => {
     useContext(AdminBannerContext);
 
   // state management
-  const {
-    allBanners,
-    bannerActive,
-    bannerLoading,
-    bannerErrorMessage,
-    bannerDeleting,
-  } = useStore();
+  const { allBanners, bannerLoading, bannerErrorMessage, bannerDeleting } =
+    useStore();
 
-  const BannerPreview = (banner: AdminBannerData) => (
-    <React.Fragment key={banner.key}>
-      <Flex sx={sx.currentBannerInfo}>
-        <Text sx={sx.currentBannerStatus}>
-          Status:{" "}
-          <span className={bannerActive ? "active" : "inactive"}>
-            {bannerActive ? "Active" : "Inactive"}
-          </span>
-        </Text>
-        <Text sx={sx.currentBannerDate}>
-          Start Date: <span>{convertDateUtcToEt(banner?.startDate)}</span>
-        </Text>
-        <Text sx={sx.currentBannerDate}>
-          End Date: <span>{convertDateUtcToEt(banner?.endDate)}</span>
-        </Text>
-      </Flex>
-      <Flex sx={sx.currentBannerFlex}>
-        <Banner status={AlertTypes.INFO} bannerData={banner} />
-        <Button
-          variant="danger"
-          sx={sx.deleteBannerButton}
-          onClick={() => deleteAdminBanner(banner.key)}
-        >
-          {bannerDeleting ? <Spinner size="md" /> : "Delete Current Banner"}
-        </Button>
-      </Flex>
-    </React.Fragment>
-  );
+  const BannerPreview = (banner: AdminBannerData) => {
+    const bannerActive = checkDateRangeStatus(banner.startDate, banner.endDate);
+    return (
+      <React.Fragment key={banner.key}>
+        <Flex sx={sx.currentBannerInfo}>
+          <Text sx={sx.currentBannerStatus}>
+            Status:{" "}
+            <span className={bannerActive ? "active" : "inactive"}>
+              {bannerActive ? "Active" : "Inactive"}
+            </span>
+          </Text>
+          <Text sx={sx.currentBannerDate}>
+            Start Date: <span>{convertDateUtcToEt(banner?.startDate)}</span>
+          </Text>
+          <Text sx={sx.currentBannerDate}>
+            End Date: <span>{convertDateUtcToEt(banner?.endDate)}</span>
+          </Text>
+        </Flex>
+        <Flex sx={sx.currentBannerFlex}>
+          <Banner status={AlertTypes.INFO} bannerData={banner} />
+          <Button
+            variant="danger"
+            sx={sx.deleteBannerButton}
+            onClick={() => deleteAdminBanner(banner.key)}
+          >
+            {bannerDeleting ? <Spinner size="md" /> : "Delete Banner"}
+          </Button>
+        </Flex>
+      </React.Fragment>
+    );
+  };
 
   return (
     <PageTemplate sxOverride={sx.layout} data-testid="admin-view">
@@ -75,7 +73,7 @@ export const AdminPage = () => {
         <Text>{verbiage.intro.body}</Text>
       </Box>
       <Box sx={sx.currentBannerSectionBox}>
-        <Text sx={sx.sectionHeader}>Current Banner</Text>
+        <Text sx={sx.sectionHeader}>Current Banner(s)</Text>
         {bannerLoading ? (
           <Flex sx={sx.spinnerContainer}>
             <Spinner size="md" />
@@ -85,9 +83,7 @@ export const AdminPage = () => {
             <Collapse in={allBanners && allBanners?.length > 0}>
               {allBanners?.map((banner) => BannerPreview(banner))}
             </Collapse>
-            {allBanners?.length === 0 && (
-              <Text>There is no current banner</Text>
-            )}
+            {!allBanners?.length && <Text>There is no current banner</Text>}
           </>
         )}
       </Box>
@@ -162,9 +158,9 @@ const sx = {
     },
   },
   deleteBannerButton: {
-    width: "13.3rem",
+    width: "10rem",
     alignSelf: "end",
-    marginTop: "1rem !important",
+    marginTop: "-1rem",
   },
   newBannerBox: {
     width: "100%",

--- a/services/ui-src/src/components/pages/Admin/AdminPage.tsx
+++ b/services/ui-src/src/components/pages/Admin/AdminPage.tsx
@@ -1,4 +1,4 @@
-import { useContext, MouseEventHandler } from "react";
+import React, { useContext } from "react";
 // components
 import {
   Box,
@@ -17,7 +17,7 @@ import {
   PageTemplate,
 } from "components";
 // types
-import { AlertTypes } from "types";
+import { AdminBannerData, AlertTypes } from "types";
 // utils
 import { convertDateUtcToEt, useStore } from "utils";
 // verbiage
@@ -29,12 +29,41 @@ export const AdminPage = () => {
 
   // state management
   const {
-    bannerData,
+    allBanners,
     bannerActive,
     bannerLoading,
     bannerErrorMessage,
     bannerDeleting,
   } = useStore();
+
+  const BannerPreview = (banner: AdminBannerData) => (
+    <React.Fragment key={banner.key}>
+      <Flex sx={sx.currentBannerInfo}>
+        <Text sx={sx.currentBannerStatus}>
+          Status:{" "}
+          <span className={bannerActive ? "active" : "inactive"}>
+            {bannerActive ? "Active" : "Inactive"}
+          </span>
+        </Text>
+        <Text sx={sx.currentBannerDate}>
+          Start Date: <span>{convertDateUtcToEt(banner?.startDate)}</span>
+        </Text>
+        <Text sx={sx.currentBannerDate}>
+          End Date: <span>{convertDateUtcToEt(banner?.endDate)}</span>
+        </Text>
+      </Flex>
+      <Flex sx={sx.currentBannerFlex}>
+        <Banner status={AlertTypes.INFO} bannerData={banner} />
+        <Button
+          variant="danger"
+          sx={sx.deleteBannerButton}
+          onClick={() => deleteAdminBanner(banner.key)}
+        >
+          {bannerDeleting ? <Spinner size="md" /> : "Delete Current Banner"}
+        </Button>
+      </Flex>
+    </React.Fragment>
+  );
 
   return (
     <PageTemplate sxOverride={sx.layout} data-testid="admin-view">
@@ -53,43 +82,12 @@ export const AdminPage = () => {
           </Flex>
         ) : (
           <>
-            <Collapse in={!!bannerData?.key}>
-              {bannerData && (
-                <>
-                  <Flex sx={sx.currentBannerInfo}>
-                    <Text sx={sx.currentBannerStatus}>
-                      Status:{" "}
-                      <span className={bannerActive ? "active" : "inactive"}>
-                        {bannerActive ? "Active" : "Inactive"}
-                      </span>
-                    </Text>
-                    <Text sx={sx.currentBannerDate}>
-                      Start Date:{" "}
-                      <span>{convertDateUtcToEt(bannerData?.startDate)}</span>
-                    </Text>
-                    <Text sx={sx.currentBannerDate}>
-                      End Date:{" "}
-                      <span>{convertDateUtcToEt(bannerData?.endDate)}</span>
-                    </Text>
-                  </Flex>
-                  <Flex sx={sx.currentBannerFlex}>
-                    <Banner status={AlertTypes.INFO} bannerData={bannerData} />
-                    <Button
-                      variant="danger"
-                      sx={sx.deleteBannerButton}
-                      onClick={deleteAdminBanner as MouseEventHandler}
-                    >
-                      {bannerDeleting ? (
-                        <Spinner size="md" />
-                      ) : (
-                        "Delete Current Banner"
-                      )}
-                    </Button>
-                  </Flex>
-                </>
-              )}
+            <Collapse in={allBanners && allBanners?.length > 0}>
+              {allBanners?.map((banner) => BannerPreview(banner))}
             </Collapse>
-            {!bannerData?.key && <Text>There is no current banner</Text>}
+            {allBanners?.length === 0 && (
+              <Text>There is no current banner</Text>
+            )}
           </>
         )}
       </Box>

--- a/services/ui-src/src/constants.ts
+++ b/services/ui-src/src/constants.ts
@@ -1,6 +1,3 @@
-// BANNERS
-export const bannerId = "admin-banner-id";
-
 // HOST DOMAIN
 export const PRODUCTION_HOST_DOMAIN = "mdctmcr.cms.gov";
 

--- a/services/ui-src/src/types/banners.ts
+++ b/services/ui-src/src/types/banners.ts
@@ -11,7 +11,6 @@ export interface AdminBannerData extends BannerData {
   key: string;
   startDate: number;
   endDate: number;
-  isActive?: boolean;
 }
 
 export interface AdminBannerMethods {

--- a/services/ui-src/src/types/banners.ts
+++ b/services/ui-src/src/types/banners.ts
@@ -16,6 +16,7 @@ export interface AdminBannerData extends BannerData {
 
 export interface AdminBannerMethods {
   fetchAdminBanner: Function;
+  fetchAllBanners: Function;
   writeAdminBanner: Function;
   deleteAdminBanner: Function;
 }

--- a/services/ui-src/src/types/states.ts
+++ b/services/ui-src/src/types/states.ts
@@ -21,12 +21,14 @@ export interface McrUserState {
 // initial admin banner state
 export interface AdminBannerState {
   // INITIAL STATE
+  allBanners: AdminBannerData[] | undefined;
   bannerData: AdminBannerData | undefined;
   bannerActive: boolean;
   bannerLoading: boolean;
   bannerErrorMessage: ErrorVerbiage | undefined;
   bannerDeleting: boolean;
   // ACTIONS
+  setAllBanners: (allBanners: AdminBannerData[] | undefined) => void;
   setBannerData: (newBannerData: AdminBannerData | undefined) => void;
   clearAdminBanner: () => void;
   setBannerActive: (bannerStatus: boolean) => void;

--- a/services/ui-src/src/utils/api/requestMethods/banner.test.ts
+++ b/services/ui-src/src/utils/api/requestMethods/banner.test.ts
@@ -1,6 +1,5 @@
-import { getBanner, writeBanner, deleteBanner } from "./banner";
+import { getBanners, writeBanner, deleteBanner } from "./banner";
 // utils
-import { bannerId } from "../../../constants";
 import { mockBannerData } from "utils/testing/setupJest";
 
 const mockDelete = jest.fn();
@@ -14,12 +13,13 @@ jest.mock("utils", () => ({
 }));
 
 describe("utils/requestMethods/banner", () => {
+  const mockBannerKey = mockBannerData.key;
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  test("getBanner()", async () => {
-    await getBanner(bannerId);
+  test("getBanners()", async () => {
+    await getBanners();
     expect(mockGet).toHaveBeenCalledTimes(1);
   });
 
@@ -29,7 +29,7 @@ describe("utils/requestMethods/banner", () => {
   });
 
   test("deleteBanner()", async () => {
-    await deleteBanner(bannerId);
+    await deleteBanner(mockBannerKey);
     expect(mockDelete).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/ui-src/src/utils/api/requestMethods/banner.ts
+++ b/services/ui-src/src/utils/api/requestMethods/banner.ts
@@ -1,9 +1,9 @@
 import { AdminBannerData } from "types/banners";
 import { del, get, post } from "utils";
 
-async function getBanner(bannerKey: string) {
-  const path = `/banners/${bannerKey}`;
-  return get<AdminBannerData>(path);
+async function getBanners() {
+  const path = `/banners`;
+  return get<AdminBannerData[]>(path);
 }
 
 async function writeBanner(bannerData: AdminBannerData) {
@@ -19,4 +19,4 @@ async function deleteBanner(bannerKey: string) {
   return del(path);
 }
 
-export { getBanner, writeBanner, deleteBanner };
+export { getBanners, writeBanner, deleteBanner };

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -32,12 +32,15 @@ const userStore = (set: Function) => ({
 // ADMIN BANNER STORE
 const bannerStore = (set: Function) => ({
   // initial state
+  allBanners: undefined,
   bannerData: undefined,
   bannerActive: false,
   bannerLoading: false,
   bannerErrorMessage: undefined,
   bannerDeleting: false,
   // actions
+  setAllBanners: (allBanners: AdminBannerData[] | undefined) =>
+    set(() => ({ allBanners }), false, { type: "setAllBanners" }),
   setBannerData: (newBanner: AdminBannerData | undefined) =>
     set(() => ({ bannerData: newBanner }), false, { type: "setBannerData" }),
   clearAdminBanner: () =>

--- a/services/ui-src/src/utils/testing/mockBanner.tsx
+++ b/services/ui-src/src/utils/testing/mockBanner.tsx
@@ -1,8 +1,7 @@
 import { genericErrorContent } from "verbiage/errors";
-import { bannerId } from "../../constants";
 
 export const mockBannerData = {
-  key: bannerId,
+  key: "mock-banner-key",
   title: "Yes here I am, a banner",
   description: "I have a description too thank you very much",
   startDate: 1640995200000, // 1/1/2022 00:00:00 UTC

--- a/services/ui-src/src/utils/testing/mockZustand.tsx
+++ b/services/ui-src/src/utils/testing/mockZustand.tsx
@@ -105,6 +105,7 @@ export const mockAdminUserStore: McrUserState = {
 //  BANNER STATES / STORE
 
 export const mockBannerStore: AdminBannerState = {
+  allBanners: [mockBannerData],
   bannerData: mockBannerData,
   bannerActive: false,
   bannerLoading: false,
@@ -112,6 +113,7 @@ export const mockBannerStore: AdminBannerState = {
   bannerDeleting: false,
   setBannerData: () => {},
   clearAdminBanner: () => {},
+  setAllBanners: () => {},
   setBannerActive: () => {},
   setBannerLoading: () => {},
   setBannerErrorMessage: () => {},


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Allow multiple banners to exist at once in database
- Allow admins to view all existing banners, active and inactive
- Add logic to filter and sort banners so that most recent start date is active
- Adjust tests and api logic to fit pattern

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4180

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as an admin
- Go to `/admin`
- Create a banner
- Create another banner
- Notice they both display in a list at the top
- Experiment with creating and deleting banners
- Visit the homepage to see what banner is active
  - It should always be the banner where today's date falls within the range and with the most recent start date

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
There is still some logic to cleanup for this, like how the delete spinner shows on all the delete buttons, not just the one you clicked. Also multiple banners will have the "Active" text on the admin dashboard but only one will ever show on the homepage.

What do you think? Is this concept worth finalizing? Will admins be able to navigate this? How can we make it more clear? Is this even a use case admins really see themselves needing?

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary
---