### PR TITLE
Make export page header static at 200+% zoom

### DIFF
--- a/services/ui-src/src/components/export/ExportedReportBanner.tsx
+++ b/services/ui-src/src/components/export/ExportedReportBanner.tsx
@@ -67,6 +67,9 @@ const sx = {
     ".mobile &": {
       padding: "2rem 1rem",
     },
+    ".tablet &, .mobile &": {
+      position: "static",
+    },
     "@media print": {
       display: "none",
     },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Add styling condition to export page header such that it only remains sticky at zooms below ~200%
  - (using mobile & tablet sizing as condition)

Applies to all export pages, regardless of report type

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4297

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a MCPAR report
- Go to Review & Submit page and open the PDF
- At desktop width scroll up and down
- Zoom in (`Cmd` + `+`) and test at various sizes
- Banner should become fixed to top of page at around 200% zoom

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
This just happens to be the functionality with mobile & tablet as the condition. We may be able to tweak further if needed, but this meets the requirements of the ticket and I think is a pretty reasonable breakpoint visually.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
~- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary~
~- [ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
---