### PR TITLE
CMDCT-4530: Disable "Add standards" button

### DIFF
--- a/services/app-api/forms/naaar.json
+++ b/services/app-api/forms/naaar.json
@@ -531,13 +531,24 @@
             "children": [
               {
                 "type": "html",
-                "content": "This program is missing required information. You won’t be able to complete this section until you’ve completed all the required questions in section "
+                "content": "This program is missing required information. You won’t be able to complete this section until you’ve completed all the required questions in section I. State and program information. Report on "
               },
               {
                 "type": "internalLink",
-                "content": "I. State and program information",
+                "content": "Provider type coverage",
                 "props": {
                   "to": "/naaar/state-and-program-information/provider-type-coverage"
+                }
+              },
+              {
+                "type": "html",
+                "content": " and "
+              },
+              {
+                "type": "internalLink",
+                "content": "Analysis methods",
+                "props": {
+                  "to": "/naaar/state-and-program-information/analysis-methods"
                 }
               },
               {
@@ -1089,7 +1100,7 @@
       "details": {
         "verbiage": {
           "backButton": "Return to plan compliance dashboard",
-          "intro" : {
+          "intro": {
             "info": "States should use this section to report on plan compliance with the state’s 42 C.F.R. § 438.68 and 42 C.F.R. § 438.206 standards for the plan listed above.",
             "section": "",
             "subsection": "III. Plan compliance data for {{planName}}"
@@ -1183,7 +1194,7 @@
               "accordion": {
                 "buttonLabel": "Assurance of 42 C.F.R. § 438.206",
                 "text": "<p>(b) <b>Delivery network.</b> The State must ensure, through its contracts, that each MCO, PIHP and PAHP, consistent with the scope of its contracted services, meets the following requirements:</p><p>(1) Maintains and monitors a network of appropriate providers that is supported by written agreements and is sufficient to provide adequate access to all services covered under the contract for all enrollees, including those with limited English proficiency or physical or mental disabilities.</p><p>(2) Provides female enrollees with direct access to a women’s health specialist within the provider network for covered care necessary to provide women’s routine and preventive health care services. This is in addition to the enrollee’s designated source of primary care if that source is not a women’s health specialist.</p><p>(3) Provides for a second opinion from a network provider, or arranges for the enrollee to obtain one outside the network, at no cost to the enrollee.</p><p>(4) If the provider network is unable to provide necessary services, covered under the contract, to a particular enrollee, the MCO, PIHP, or PAHP must adequately and timely cover these services out of network for the enrollee, for as long as the MCO, PIHP, or PAHP’s provider network is unable to provide them.</p><p>(5) Requires out-of-network providers to coordinate with the MCO, PIHP, or PAHP for payment and ensures the cost to the enrollee is no greater than it would be if the services were furnished within the network.</p><p>(6) Demonstrates that its network providers are credentialed as required by § 438.214.</p><p>(7) Demonstrates that its network includes sufficient family planning providers to ensure timely access to covered services.</p><p>(c) <b>Furnishing of services.</b> The State must ensure that each contract with a MCO, PIHP, and PAHP complies with the following requirements.</p><p>(1) <b>Timely access.</b> Each MCO, PIHP, and PAHP must do the following:</p><p>(i) Meet and require its network providers to meet State standards for timely access to care and services taking into account the urgency of the need for services, as well as appointment wait times specified in § 438.68(e).</p><p>(ii) Ensure that the network providers offer hours of operation that are no less than the hours of operation offered to commercial enrollees or comparable to Medicaid FFS, if the provider serves only Medicaid enrollees.</p><p>(iii) Make services included in the contract available 24 hours a day, 7 days a week, when medically necessary.</p><p>(iv) Establish mechanisms to ensure compliance by network providers.</p><p>(v) Monitor network providers regularly to determine compliance.</p><p>(vi) Take corrective action if there is a failure to comply by a network provider.</p><p>(2) Access and cultural considerations. Each MCO, PIHP, and PAHP participates in the State’s efforts to promote the delivery of services in a culturally competent manner to all enrollees, including those with limited English proficiency and diverse cultural and ethnic backgrounds, disabilities, and regardless of sex which includes sex characteristics, including intersex traits; pregnancy or related conditions; sexual orientation; gender identity and sex stereotypes.</p><p>(3) Accessibility considerations. Each MCO, PIHP, and PAHP must ensure that network providers provide physical access, reasonable accommodations, and accessible equipment for Medicaid enrollees with physical or mental disabilities.</p><p>(d) Applicability date. States will not be held out of compliance with the requirements of paragraphs (c)(1)(i) of this section prior to the first rating period that begins on or after 3 years after July 9, 2024, so long as they comply with the corresponding standard(s) codified in 42 CFR 438.2</p>"
-              },        
+              },
               "heading": "Assurance of plan compliance for 438.206",
               "hint": "Indicate whether the state assures that the plan complies with the state’s network adequacy standards based on each analysis the state conducted for the plan during the reporting period."
             }

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -74,7 +74,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
         return analysisMethod.analysis_applicable && analysisMethod.isRequired;
       }
     );
-    return result.length === 7;
+    return result && result.length === 7;
   };
 
   const formParams = {

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -11,7 +11,10 @@ import {
   DeleteEntityModal,
 } from "components";
 // constants
-import { getDefaultAnalysisMethodIds } from "../../constants";
+import {
+  DEFAULT_ANALYSIS_METHODS,
+  getDefaultAnalysisMethodIds,
+} from "../../constants";
 // types
 import {
   AnyObject,
@@ -74,7 +77,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
         return analysisMethod.analysis_applicable && analysisMethod.isRequired;
       }
     );
-    return result && result.length === 7;
+    return result?.length === DEFAULT_ANALYSIS_METHODS.length;
   };
 
   const formParams = {

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -69,7 +69,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
   const hasProviderTypes = report?.fieldData?.["providerTypes"]?.length > 0;
 
   const completedAnalysisMethods = () => {
-    const result = report?.fieldData["analysisMethods"].filter(
+    const result = report?.fieldData["analysisMethods"]?.filter(
       (analysisMethod: AnyObject) => {
         return analysisMethod.analysis_applicable && analysisMethod.isRequired;
       }

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -68,6 +68,15 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
     route.path === "/naaar/program-level-access-and-network-adequacy-standards";
   const hasProviderTypes = report?.fieldData?.["providerTypes"]?.length > 0;
 
+  const completedAnalysisMethods = () => {
+    const result = report?.fieldData["analysisMethods"].filter(
+      (analysisMethod: AnyObject) => {
+        return analysisMethod.analysis_applicable && analysisMethod.isRequired;
+      }
+    );
+    return result.length === 7;
+  };
+
   const formParams = {
     route,
     report,
@@ -218,6 +227,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
       );
     } else if (
       (isAnalysisMethodsPage && !hasPlans) ||
+      (isReportingOnStandards && !completedAnalysisMethods()) ||
       (isReportingOnStandards && !hasProviderTypes)
     ) {
       return (
@@ -234,7 +244,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
       sx={sx.bottomAddEntityButton}
       leftIcon={<Image sx={sx.buttonIcons} src={addIconWhite} alt="Add" />}
       onClick={() => openRowDrawer()}
-      disabled={!hasProviderTypes}
+      disabled={!hasProviderTypes || !completedAnalysisMethods()}
     >
       {verbiage.addEntityButtonText}
     </Button>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
For NAAAR, if a user has not completed all of the default Analysis Methods, they should not be able to add standards. 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4350

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a NAAAR
- Navigate to `/naaar/program-level-access-and-network-adequacy-standards`
- Verify that the "Add standards" button is disabled
- Click on the alert banner to navigate to the appropriate links and finish those sections
- Navigate back and add standards

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
