### PR TITLE
Fix "Analysis methods" page error message

### DIFF
--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -64,13 +64,14 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
   const isAnalysisMethodsPage = route.path.includes("analysis-methods");
   const reportingOnIlos = route.path === "/mcpar/plan-level-indicators/ilos";
   const ilos = report?.fieldData?.["ilos"];
-  const hasIlos = ilos?.length;
+  const hasIlos = ilos?.length > 0;
   const plans = report?.fieldData?.["plans"];
-  const hasPlans = plans?.length;
+  const hasPlans = plans?.length > 0;
   const isReportingOnStandards =
     route.path === "/naaar/program-level-access-and-network-adequacy-standards";
   const hasProviderTypes = report?.fieldData?.["providerTypes"]?.length > 0;
 
+  // check if user has completed default analysis methods (NAAAR)
   const completedAnalysisMethods = () => {
     const result = report?.fieldData["analysisMethods"]?.filter(
       (analysisMethod: AnyObject) => {
@@ -222,7 +223,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
 
   const displayErrorMessages = () => {
     // if there are no ILOS but there are plans added, display this message
-    if (!hasIlos && entities.length > 0) {
+    if (reportingOnIlos && !hasIlos && entities.length > 0) {
       return (
         <Box sx={sx.missingEntity}>
           {parseCustomHtml(verbiage.missingIlosMessage || "")}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The error message for whenever a user is trying to enter Analysis methods without adding plans first was not showing on the form page (shoutout to @gmrabian for pointing that out ✨ )

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a NAAAR
- Navigate to `/naaar/state-and-program-information/analysis-methods`

You should see an error message pointing you to the "Add plans" page

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
