### PR TITLE
CMDCT-4284: Edit and Delete Functionality (NAAAR Standards)

### DIFF
--- a/services/app-api/forms/naaar.json
+++ b/services/app-api/forms/naaar.json
@@ -610,7 +610,7 @@
                   "label": "Maximum time to travel",
                   "children": [
                     {
-                      "id": "standard_standardDescription",
+                      "id": "standard_standardDescription-kIrheUXLpOwF7OEypso8Ylhs",
                       "type": "textarea",
                       "validation": {
                         "type": "text",
@@ -624,7 +624,7 @@
                       }
                     },
                     {
-                      "id": "standard_analysisMethodsUtilized",
+                      "id": "standard_analysisMethodsUtilized-kIrheUXLpOwF7OEypso8Ylhs",
                       "type": "checkbox",
                       "validation": {
                         "type": "checkbox",
@@ -645,7 +645,7 @@
                   "label": "Maximum distance to travel",
                   "children": [
                     {
-                      "id": "standard_standardDescription",
+                      "id": "standard_standardDescription-SDrVTHVxFa2YKrlBYjcqavbN",
                       "type": "textarea",
                       "validation": {
                         "type": "text",
@@ -659,7 +659,7 @@
                       }
                     },
                     {
-                      "id": "standard_analysisMethodsUtilized",
+                      "id": "standard_analysisMethodsUtilized-SDrVTHVxFa2YKrlBYjcqavbN",
                       "type": "checkbox",
                       "validation": {
                         "type": "checkbox",
@@ -680,7 +680,7 @@
                   "label": "Maximum time or distance",
                   "children": [
                     {
-                      "id": "standard_standardDescription",
+                      "id": "standard_standardDescription-fFSst8ncbSukHlX66fqV0udO",
                       "type": "textarea",
                       "validation": {
                         "type": "text",
@@ -694,7 +694,7 @@
                       }
                     },
                     {
-                      "id": "standard_analysisMethodsUtilized",
+                      "id": "standard_analysisMethodsUtilized-fFSst8ncbSukHlX66fqV0udO",
                       "type": "checkbox",
                       "validation": {
                         "type": "checkbox",
@@ -715,7 +715,7 @@
                   "label": "Ease of getting a timely appointment",
                   "children": [
                     {
-                      "id": "standard_standardDescription",
+                      "id": "standard_standardDescription-tcIQ324hNsgHwHteoDgfCh08",
                       "type": "textarea",
                       "validation": {
                         "type": "text",
@@ -729,7 +729,7 @@
                       }
                     },
                     {
-                      "id": "standard_analysisMethodsUtilized",
+                      "id": "standard_analysisMethodsUtilized-tcIQ324hNsgHwHteoDgfCh08",
                       "type": "checkbox",
                       "validation": {
                         "type": "checkbox",
@@ -750,7 +750,7 @@
                   "label": "Appointment wait time",
                   "children": [
                     {
-                      "id": "standard_standardDescription",
+                      "id": "standard_standardDescription-lG0CeH7LIO5iGxjpaKE8v37C",
                       "type": "textarea",
                       "validation": {
                         "type": "text",
@@ -764,7 +764,7 @@
                       }
                     },
                     {
-                      "id": "standard_analysisMethodsUtilized",
+                      "id": "standard_analysisMethodsUtilized-lG0CeH7LIO5iGxjpaKE8v37C",
                       "type": "checkbox",
                       "validation": {
                         "type": "checkbox",
@@ -785,7 +785,7 @@
                   "label": "Hours of operation",
                   "children": [
                     {
-                      "id": "standard_standardDescription",
+                      "id": "standard_standardDescription-EuccyPRHBiaTVhF1HMHnkUcR",
                       "type": "textarea",
                       "validation": {
                         "type": "text",
@@ -799,7 +799,7 @@
                       }
                     },
                     {
-                      "id": "standard_analysisMethodsUtilized",
+                      "id": "standard_analysisMethodsUtilized-EuccyPRHBiaTVhF1HMHnkUcR",
                       "type": "checkbox",
                       "validation": {
                         "type": "checkbox",
@@ -820,7 +820,7 @@
                   "label": "Provider to enrollee ratios",
                   "children": [
                     {
-                      "id": "standard_standardDescription",
+                      "id": "standard_standardDescription-vGdzNKCsiudeNeUJZgU5qhdz",
                       "type": "textarea",
                       "validation": {
                         "type": "text",
@@ -834,7 +834,7 @@
                       }
                     },
                     {
-                      "id": "standard_analysisMethodsUtilized",
+                      "id": "standard_analysisMethodsUtilized-vGdzNKCsiudeNeUJZgU5qhdz",
                       "type": "checkbox",
                       "validation": {
                         "type": "checkbox",
@@ -855,7 +855,7 @@
                   "label": "Minimum number of network providers",
                   "children": [
                     {
-                      "id": "standard_standardDescription",
+                      "id": "standard_standardDescription-hdz3tEHdEBvRIIdgaovgEjaa",
                       "type": "textarea",
                       "validation": {
                         "type": "text",
@@ -869,7 +869,7 @@
                       }
                     },
                     {
-                      "id": "standard_analysisMethodsUtilized",
+                      "id": "standard_analysisMethodsUtilized-hdz3tEHdEBvRIIdgaovgEjaa",
                       "type": "checkbox",
                       "validation": {
                         "type": "checkbox",
@@ -890,7 +890,7 @@
                   "label": "Service fulfillment",
                   "children": [
                     {
-                      "id": "standard_standardDescription",
+                      "id": "standard_standardDescription-9eion8H8PNrCP0AeiikpsKbx",
                       "type": "textarea",
                       "validation": {
                         "type": "text",
@@ -904,7 +904,7 @@
                       }
                     },
                     {
-                      "id": "standard_analysisMethodsUtilized",
+                      "id": "standard_analysisMethodsUtilized-9eion8H8PNrCP0AeiikpsKbx",
                       "type": "checkbox",
                       "validation": {
                         "type": "checkbox",
@@ -935,7 +935,7 @@
                       }
                     },
                     {
-                      "id": "standard_standardDescription",
+                      "id": "standard_standardDescription-Uil8wXl6t3aBsI4W8pQZlO5P",
                       "type": "textarea",
                       "validation": {
                         "type": "text",
@@ -949,7 +949,7 @@
                       }
                     },
                     {
-                      "id": "standard_analysisMethodsUtilized",
+                      "id": "standard_analysisMethodsUtilized-Uil8wXl6t3aBsI4W8pQZlO5P",
                       "type": "checkbox",
                       "validation": {
                         "type": "checkbox",

--- a/services/app-api/forms/naaar.json
+++ b/services/app-api/forms/naaar.json
@@ -524,6 +524,10 @@
         "dashboardTitle": "Standard total count: ",
         "countEntitiesInTitle": true,
         "addEntityButtonText": "Add standard",
+        "deleteEntityButtonAltText": "Delete standard",
+        "deleteModalTitle": "Are you sure you want to delete this standard?",
+        "deleteModalConfirmButtonText": "Yes, delete standard",
+        "deleteModalWarning": "Are you sure you want to proceed? You will lose all information entered for this standard in the NAAAR. The method will remain in previously submitted NAAAR reports if applicable.",
         "drawerTitle": "Add access and network adequacy standard for ",
         "missingEntityMessage": [
           {
@@ -1180,11 +1184,7 @@
             },
             "table": {
               "bodyRows": [
-                [
-                  "",
-                  "Provide plan compliance details for 438.206",
-                  ""
-                ]
+                ["", "Provide plan compliance details for 438.206", ""]
               ],
               "headRow": [
                 { "hiddenName": "Status" },

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -254,7 +254,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
 
   const addStandardsButton = (
     <Button
-      sx={sx.addEntityButton}
+      sx={sx.addStandardButton}
       leftIcon={<Image sx={sx.buttonIcons} src={addIconWhite} alt="Add" />}
       onClick={() => openRowDrawer()}
       disabled={!hasProviderTypes || !completedAnalysisMethods()}
@@ -289,7 +289,11 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
             {addStandardsButton}
             <Heading sx={sx.dashboardTitle}>{dashTitle}</Heading>
             {existingStandards && (
-              <SortableNaaarStandardsTable entities={entities} />
+              <SortableNaaarStandardsTable
+                entities={entities}
+                openRowDrawer={openRowDrawer}
+                openDeleteEntityModal={openDeleteEntityModal}
+              />
             )}
             {entities.length > 0 && addStandardsButton}
           </Box>
@@ -428,11 +432,15 @@ const sx = {
     paddingBottom: "1rem",
   },
   addEntityButton: {
-    marginBottom: "0",
+    marginBottom: "2rem",
     marginTop: "2rem",
-    "&:first-of-type": {
-      marginBottom: "2rem",
-      marginTop: "0",
+  },
+  addStandardButton: {
+    marginBottom: "2rem",
+    marginTop: "0",
+    "&:nth-of-type(2)": {
+      marginBottom: "0",
+      marginTop: "2rem",
     },
   },
 };

--- a/services/ui-src/src/components/tables/SortableNaaarStandardsTable.test.tsx
+++ b/services/ui-src/src/components/tables/SortableNaaarStandardsTable.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 // components
 import { SortableNaaarStandardsTable } from "components";
 // utils
@@ -16,6 +17,9 @@ mockedUseStore.mockReturnValue({
   ...mockStateUserStore,
   ...mockNaaarReportStore,
 });
+
+const mockOpenDeleteEntityModal = jest.fn();
+const mockOpenRowDrawer = jest.fn();
 
 const mockStandards = [
   {
@@ -40,14 +44,32 @@ const mockStandards = [
 
 const sortableTableComponent = (
   <RouterWrappedComponent>
-    <SortableNaaarStandardsTable entities={mockStandards} />
+    <SortableNaaarStandardsTable
+      entities={mockStandards}
+      openRowDrawer={mockOpenRowDrawer}
+      openDeleteEntityModal={mockOpenDeleteEntityModal}
+    />
   </RouterWrappedComponent>
 );
 
 describe("Test SortableNaaarStandardsTable component", () => {
-  test("Check that NAAAR table view renders", async () => {
+  beforeEach(() => {
     render(sortableTableComponent);
+  });
+  test("Check that NAAAR table view renders", async () => {
     expect(screen.getByText("mock-population")).toBeVisible;
+  });
+
+  test("SortableNaaarStandardsTable opens the drawer upon clicking Edit", async () => {
+    const editButton = screen.getByTestId("edit-entity");
+    await userEvent.click(editButton);
+    expect(mockOpenRowDrawer).toBeCalledTimes(1);
+  });
+
+  test("SortableNaaarStandardsTable opens the delete modal on click", async () => {
+    const deleteButton = screen.getByTestId("delete-entity");
+    await userEvent.click(deleteButton);
+    expect(mockOpenDeleteEntityModal).toBeCalledTimes(1);
   });
 
   testA11y(sortableTableComponent);

--- a/services/ui-src/src/components/tables/SortableNaaarStandardsTable.test.tsx
+++ b/services/ui-src/src/components/tables/SortableNaaarStandardsTable.test.tsx
@@ -61,7 +61,7 @@ describe("Test SortableNaaarStandardsTable component", () => {
   });
 
   test("SortableNaaarStandardsTable opens the drawer upon clicking Edit", async () => {
-    const editButton = screen.getByRole("button", { name: "edit" });
+    const editButton = screen.getByRole("button", { name: "Edit" });
     await userEvent.click(editButton);
     expect(mockOpenRowDrawer).toBeCalledTimes(1);
   });

--- a/services/ui-src/src/components/tables/SortableNaaarStandardsTable.test.tsx
+++ b/services/ui-src/src/components/tables/SortableNaaarStandardsTable.test.tsx
@@ -61,13 +61,13 @@ describe("Test SortableNaaarStandardsTable component", () => {
   });
 
   test("SortableNaaarStandardsTable opens the drawer upon clicking Edit", async () => {
-    const editButton = screen.getByTestId("edit-entity");
+    const editButton = screen.getByRole("button", { name: "edit" });
     await userEvent.click(editButton);
     expect(mockOpenRowDrawer).toBeCalledTimes(1);
   });
 
   test("SortableNaaarStandardsTable opens the delete modal on click", async () => {
-    const deleteButton = screen.getByTestId("delete-entity");
+    const deleteButton = screen.getByRole("button", { name: "delete" });
     await userEvent.click(deleteButton);
     expect(mockOpenDeleteEntityModal).toBeCalledTimes(1);
   });

--- a/services/ui-src/src/components/tables/SortableNaaarStandardsTable.tsx
+++ b/services/ui-src/src/components/tables/SortableNaaarStandardsTable.tsx
@@ -5,7 +5,11 @@ import { generateColumns, SortableTable } from "components";
 import deleteIcon from "assets/icons/icon_cancel_x_circle.png";
 import { EntityShape } from "types";
 
-export const SortableNaaarStandardsTable = ({ entities }: Props) => {
+export const SortableNaaarStandardsTable = ({
+  entities,
+  openRowDrawer,
+  openDeleteEntityModal,
+}: Props) => {
   const actualData = useMemo(() => {
     return entities.map((entity: any, index: number) => {
       const {
@@ -55,25 +59,37 @@ export const SortableNaaarStandardsTable = ({ entities }: Props) => {
         analysisMethods: extractMethods(standard_analysisMethodsUtilized),
         population: standardPopulation,
         region: standardRegion,
+        entity,
       };
     });
   }, [entities]);
 
   const customCells = (
     headKey: keyof DrawerReportPageTableShape,
-    value: any
+    value: any,
+    originalRowData: DrawerReportPageTableShape
   ) => {
+    const { entity } = originalRowData;
     switch (headKey) {
       case "edit": {
         return (
-          <Button variant="link" id={value}>
+          <Button
+            variant="link"
+            id={value}
+            onClick={() => openRowDrawer(entity)}
+          >
             Edit
           </Button>
         );
       }
       case "delete": {
         return (
-          <Button sx={sx.deleteButton} id={value}>
+          <Button
+            sx={sx.deleteButton}
+            id={value}
+            data-testid="delete-entity"
+            onClick={() => openDeleteEntityModal(entity)}
+          >
             <Image src={deleteIcon} alt="delete" boxSize="2xl" />
           </Button>
         );
@@ -137,6 +153,8 @@ const sx = {
 
 interface Props {
   entities: EntityShape[];
+  openRowDrawer: Function;
+  openDeleteEntityModal: Function;
 }
 
 interface DrawerReportPageTableShape {
@@ -147,6 +165,7 @@ interface DrawerReportPageTableShape {
   analysisMethods: string;
   population: string;
   region: string;
+  entity: EntityShape;
   edit?: null;
   delete?: null;
 }

--- a/services/ui-src/src/components/tables/SortableNaaarStandardsTable.tsx
+++ b/services/ui-src/src/components/tables/SortableNaaarStandardsTable.tsx
@@ -76,6 +76,7 @@ export const SortableNaaarStandardsTable = ({
           <Button
             variant="link"
             id={value}
+            data-testid="edit-entity"
             onClick={() => openRowDrawer(entity)}
           >
             Edit

--- a/services/ui-src/src/components/tables/SortableNaaarStandardsTable.tsx
+++ b/services/ui-src/src/components/tables/SortableNaaarStandardsTable.tsx
@@ -25,12 +25,14 @@ export const SortableNaaarStandardsTable = ({
       });
 
       // extract corresponding standard choice id
-      const standardId = standardDescription?.substring(
-        standardDescription.indexOf("-")
-      );
+      const standardId = standardDescription?.includes("-")
+        ? standardDescription?.substring(standardDescription.indexOf("-"))
+        : "";
 
       // use the id to extract analysis method attribute
-      const analysisMethodsUtilized = `standard_analysisMethodsUtilized${standardId}`;
+      const analysisMethodsUtilized = standardId
+        ? `standard_analysisMethodsUtilized${standardId}`
+        : "";
 
       const coreProviderType = entity[
         "standard_coreProviderTypeCoveredByStandard-otherText"
@@ -87,7 +89,6 @@ export const SortableNaaarStandardsTable = ({
           <Button
             variant="link"
             id={value}
-            data-testid="edit-entity"
             onClick={() => openRowDrawer(entity)}
           >
             Edit
@@ -99,7 +100,6 @@ export const SortableNaaarStandardsTable = ({
           <Button
             sx={sx.deleteButton}
             id={value}
-            data-testid="delete-entity"
             onClick={() => openDeleteEntityModal(entity)}
           >
             <Image src={deleteIcon} alt="delete" boxSize="2xl" />

--- a/services/ui-src/src/components/tables/SortableNaaarStandardsTable.tsx
+++ b/services/ui-src/src/components/tables/SortableNaaarStandardsTable.tsx
@@ -89,6 +89,7 @@ export const SortableNaaarStandardsTable = ({
           <Button
             variant="link"
             id={value}
+            name="edit"
             onClick={() => openRowDrawer(entity)}
           >
             Edit
@@ -100,6 +101,7 @@ export const SortableNaaarStandardsTable = ({
           <Button
             sx={sx.deleteButton}
             id={value}
+            name="delete"
             onClick={() => openDeleteEntityModal(entity)}
           >
             <Image src={deleteIcon} alt="delete" boxSize="2xl" />

--- a/services/ui-src/src/components/tables/SortableNaaarStandardsTable.tsx
+++ b/services/ui-src/src/components/tables/SortableNaaarStandardsTable.tsx
@@ -14,12 +14,23 @@ export const SortableNaaarStandardsTable = ({
     return entities.map((entity: any, index: number) => {
       const {
         standard_coreProviderTypeCoveredByStandard,
-        standard_standardType,
-        standard_standardDescription,
-        standard_analysisMethodsUtilized,
         standard_populationCoveredByStandard,
         standard_applicableRegion,
+        standard_standardType,
       } = entity;
+
+      // extract the standard description attribute
+      const standardDescription = Object.keys(entity).find((key: string) => {
+        return key.startsWith("standard_standardDescription");
+      });
+
+      // extract corresponding standard choice id
+      const standardId = standardDescription?.substring(
+        standardDescription.indexOf("-")
+      );
+
+      // use the id to extract analysis method attribute
+      const analysisMethodsUtilized = `standard_analysisMethodsUtilized${standardId}`;
 
       const coreProviderType = entity[
         "standard_coreProviderTypeCoveredByStandard-otherText"
@@ -43,10 +54,8 @@ export const SortableNaaarStandardsTable = ({
           : standard_applicableRegion[0].value;
 
       // there are 7 analysis methods checkboxes
-      function extractMethods(
-        standard_analysisMethodsUtilized: { value: any }[]
-      ) {
-        return standard_analysisMethodsUtilized
+      function extractMethods(analysisMethodsUtilized: { value: any }[]) {
+        return analysisMethodsUtilized
           ?.map((method) => method.value)
           .join(", ");
       }
@@ -55,8 +64,10 @@ export const SortableNaaarStandardsTable = ({
         count: index + 1,
         provider: coreProviderType,
         standardType: standardType,
-        standardDescription: standard_standardDescription,
-        analysisMethods: extractMethods(standard_analysisMethodsUtilized),
+        standardDescription: entity[standardDescription as keyof EntityShape],
+        analysisMethods: extractMethods(
+          entity[analysisMethodsUtilized as keyof EntityShape]
+        ),
         population: standardPopulation,
         region: standardRegion,
         entity,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Adding the Edit and Delete functionality to the NAAAR standards page.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4284

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a NAAAR report
- Add a plan
- Fill in the Analysis Methods
- Create a new standard here: `naaar/program-level-access-and-network-adequacy-standards`
- Click on the "Edit" button
- Verify that the fields are populated with previous data and that you can edit the standard
- Click on the "Delete" icon
- Verify that a modal pops up and that you're able to delete the standard

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
