### PR TITLE
Fix skip-nav in export page

### DIFF
--- a/services/ui-src/src/components/app/MainSkipNav.test.tsx
+++ b/services/ui-src/src/components/app/MainSkipNav.test.tsx
@@ -6,6 +6,11 @@ import { ReportContextShape } from "types";
 // utils
 import { testA11y } from "utils/testing/commonTests";
 
+const mockUseLocation = jest.fn();
+jest.mock("react-router-dom", () => ({
+  useLocation: () => mockUseLocation(),
+}));
+
 const mainSkipNavOutsideReport = (
   <ReportContext.Provider
     value={
@@ -32,6 +37,7 @@ const mainSkipNavInsideReport = (
 
 describe("<MainSkipNav />", () => {
   test("should be visible and focusable", async () => {
+    mockUseLocation.mockReturnValue({ pathname: "/home" });
     render(mainSkipNavOutsideReport);
     const skipNav = document.getElementById("skip-nav-main")!;
     skipNav.focus();
@@ -42,11 +48,23 @@ describe("<MainSkipNav />", () => {
   });
 
   test("should skip to report content when on a report page", async () => {
+    mockUseLocation.mockReturnValue({ pathname: "/report-page" });
     render(mainSkipNavInsideReport);
     const skipNav = document.getElementById("skip-nav-main")!;
     skipNav.focus();
 
     const skipNavLink = screen.getByText("Skip to report sidebar");
+    await expect(skipNavLink).toHaveFocus();
+    await expect(skipNavLink).toBeVisible();
+  });
+
+  test("should skip to main content when on an export page", async () => {
+    mockUseLocation.mockReturnValue({ pathname: "/export" });
+    render(mainSkipNavInsideReport);
+    const skipNav = document.getElementById("skip-nav-main")!;
+    skipNav.focus();
+
+    const skipNavLink = screen.getByText("Skip to main content");
     await expect(skipNavLink).toHaveFocus();
     await expect(skipNavLink).toBeVisible();
   });

--- a/services/ui-src/src/components/app/MainSkipNav.tsx
+++ b/services/ui-src/src/components/app/MainSkipNav.tsx
@@ -1,11 +1,12 @@
 import { useContext } from "react";
+import { useLocation } from "react-router-dom";
 // components
 import { ReportContext, SkipNav } from "components";
 
 /**
  * The app's main skip nav changes its target, if we are on a report route.
  *
- * Note this this behavior might not actually matter. It seeems that when
+ * Note this this behavior might not actually matter. It seems that when
  * there are multiple SkipNav components on the page, the last one takes
  * priority. And when we are on a report page, there will be a second SkipNav,
  * in the sidebar.
@@ -16,12 +17,16 @@ import { ReportContext, SkipNav } from "components";
  */
 export const MainSkipNav = () => {
   const { isReportPage } = useContext(ReportContext);
+  const { pathname } = useLocation();
+  const isExportPage = pathname.includes("/export");
+
+  const skipSidebarNav = isReportPage && !isExportPage;
 
   return (
     <SkipNav
       id="skip-nav-main"
-      href={isReportPage ? "#skip-nav-sidebar" : "#main-content"}
-      text={`Skip to ${isReportPage ? "report sidebar" : "main content"}`}
+      href={skipSidebarNav ? "#skip-nav-sidebar" : "#main-content"}
+      text={`Skip to ${skipSidebarNav ? "report sidebar" : "main content"}`}
       sxOverride={sx.skipnav}
     />
   );


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Fix skip nav on export page so it navigates to main content instead of the (nonexistent) sidebar.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4299

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a MCPAR report
- Go to the Review and Submit page and click the "Review PDF"
- `Tab` to the "Skip to main content" text and hit `Return` on your keyboard
- When you hit `tab` again it should focus one of the links to a legal clause
  - It skips over the "Download PDF" button
- If you tab backwards to the top and tab through, you'll notice it tabs over the download button before going to main content

By skipping this button, you have been sent to main content!

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Accessibility: This work has been reviewed and approved by the accessibility team, if necessary
---