### PR TITLE
Updates for analysis methods page

### DIFF
--- a/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
@@ -98,26 +98,30 @@ export const DrawerReportPageEntityRows = ({
           isIlosCompleted(reportingOnIlos, entity)
         : calculateEntityCompletion();
 
-      const entityHasDetailsToDisplay =
-        entity?.analysis_method_applicable_plans;
+      const AnalysisMethodsDetails = () => {
+        if (!isEntityCompleted) {
+          const incompleteText = "Select “Enter” to complete response.";
+          return <Text sx={sx.incompleteText}>{incompleteText}</Text>;
+        }
 
-      const AnalysisMethodsDetails = isEntityCompleted ? (
-        entityHasDetailsToDisplay ? (
-          <Text>
-            {entity.analysis_method_frequency[0].value === "Other, specify"
+        const plans = entity?.analysis_method_applicable_plans;
+        let completeText = "Not utilized";
+
+        if (plans) {
+          const frequencyVal = entity.analysis_method_frequency[0].value;
+          const frequency =
+            frequencyVal === "Other, specify"
               ? entity["analysis_method_frequency-otherText"]
-              : entity.analysis_method_frequency[0].value}
-            :&nbsp;
-            {entity.analysis_method_applicable_plans
-              .map((entity: AnyObject) => entity.value)
-              .join(", ")}
-          </Text>
-        ) : (
-          <Text>Not utilized</Text>
-        )
-      ) : (
-        <Text sx={sx.incompleteText}>Select “Enter” to complete response.</Text>
-      );
+              : frequencyVal;
+          const utilizedPlans = plans
+            .map((entity: AnyObject) => entity.value)
+            .join(", ");
+
+          completeText = `${frequency}: ${utilizedPlans}`;
+        }
+
+        return <Text>{completeText}</Text>;
+      };
 
       return (
         <Flex
@@ -147,7 +151,7 @@ export const DrawerReportPageEntityRows = ({
             {entity.custom_analysis_method_description && (
               <Text>{entity.custom_analysis_method_description}</Text>
             )}
-            {isAnalysisMethodsPage ? AnalysisMethodsDetails : null}
+            {isAnalysisMethodsPage && <AnalysisMethodsDetails />}
           </Flex>
           <Box sx={buttonBoxStyling(canAddEntities)}>
             {enterButton(entity, isEntityCompleted)}

--- a/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
@@ -98,6 +98,27 @@ export const DrawerReportPageEntityRows = ({
           isIlosCompleted(reportingOnIlos, entity)
         : calculateEntityCompletion();
 
+      const entityHasDetailsToDisplay =
+        entity?.analysis_method_applicable_plans;
+
+      const AnalysisMethodsDetails = isEntityCompleted ? (
+        entityHasDetailsToDisplay ? (
+          <Text>
+            {entity.analysis_method_frequency[0].value === "Other, specify"
+              ? entity["analysis_method_frequency-otherText"]
+              : entity.analysis_method_frequency[0].value}
+            :&nbsp;
+            {entity.analysis_method_applicable_plans
+              .map((entity: AnyObject) => entity.value)
+              .join(", ")}
+          </Text>
+        ) : (
+          <Text>Not utilized</Text>
+        )
+      ) : (
+        <Text sx={sx.incompleteText}>Select “Enter” to complete response.</Text>
+      );
+
       return (
         <Flex
           key={entity.id}
@@ -119,29 +140,15 @@ export const DrawerReportPageEntityRows = ({
               />
             )
           )}
-          {isCustomEntity ? (
-            <Flex direction={"column"} sx={sx.customEntityRow}>
-              <Heading as="h4" sx={sx.customEntityName}>
-                {entity.custom_analysis_method_name}
-              </Heading>
-              {entity.custom_analysis_method_description && (
-                <Text>{entity.custom_analysis_method_description}</Text>
-              )}
-              {entity.analysis_method_frequency &&
-                entity.analysis_method_applicable_plans && (
-                  <Text>
-                    {entity.analysis_method_frequency[0].value}:&nbsp;
-                    {entity.analysis_method_applicable_plans
-                      .map((entity: AnyObject) => entity.value)
-                      .join(", ")}
-                  </Text>
-                )}
-            </Flex>
-          ) : (
+          <Flex direction={"column"} sx={sx.entityRow}>
             <Heading as="h4" sx={sx.entityName}>
-              {entity.name}
+              {entity.name ?? entity.custom_analysis_method_name}
             </Heading>
-          )}
+            {entity.custom_analysis_method_description && (
+              <Text>{entity.custom_analysis_method_description}</Text>
+            )}
+            {isAnalysisMethodsPage ? AnalysisMethodsDetails : null}
+          </Flex>
           <Box sx={buttonBoxStyling(canAddEntities)}>
             {enterButton(entity, isEntityCompleted)}
             {canAddEntities && !entity.isRequired && (
@@ -198,7 +205,7 @@ const sx = {
     height: "1.25rem",
     position: "absolute",
   },
-  customEntityRow: {
+  entityRow: {
     paddingLeft: "2.25rem",
     maxWidth: "32rem",
     gap: "4px",
@@ -207,13 +214,10 @@ const sx = {
     fontSize: "lg",
     fontWeight: "bold",
     flexGrow: 1,
-    marginLeft: "2.25rem",
-    paddingRight: "1rem",
   },
-  customEntityName: {
-    fontSize: "lg",
-    fontWeight: "bold",
-    flexGrow: 1,
+  incompleteText: {
+    color: "palette.error_dark",
+    fontSize: "sm",
   },
   missingIlos: {
     fontWeight: "bold",

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -254,7 +254,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
 
   const addStandardsButton = (
     <Button
-      sx={sx.addEntityButton}
+      sx={sx.addStandardsButton}
       leftIcon={<Image sx={sx.buttonIcons} src={addIconWhite} alt="Add" />}
       onClick={() => openRowDrawer()}
       disabled={!hasProviderTypes || !completedAnalysisMethods()}
@@ -428,6 +428,10 @@ const sx = {
     paddingBottom: "1rem",
   },
   addEntityButton: {
+    marginBottom: "0",
+    marginTop: "2rem",
+  },
+  addStandardsButton: {
     marginBottom: "0",
     marginTop: "2rem",
     "&:first-of-type": {

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -378,7 +378,7 @@ export const mockNaaarAnalysisMethodsPageJson = {
     id: "am_custom",
     fields: [
       {
-        id: "mock_custom_analysis_method_name",
+        id: "custom_analysis_method_name",
         type: "text",
         validation: "text",
         props: {
@@ -386,7 +386,7 @@ export const mockNaaarAnalysisMethodsPageJson = {
         },
       },
       {
-        id: "mock_custom_analysis_method_description",
+        id: "custom_analysis_method_description",
         type: "textarea",
         validation: "textarea",
         props: {
@@ -394,7 +394,7 @@ export const mockNaaarAnalysisMethodsPageJson = {
         },
       },
       {
-        id: "mock_analysis_method_frequency",
+        id: "analysis_method_frequency",
         type: "radio",
         props: {
           label: "Frequency of analysis",
@@ -405,7 +405,7 @@ export const mockNaaarAnalysisMethodsPageJson = {
         },
       },
       {
-        id: "mock_analysis_method_applicable_plans",
+        id: "analysis_method_applicable_plans",
         type: "checkbox",
         props: {
           label: "Plans utilizing this method",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Add red text when analysis method is incomplete: `Select "Enter" to complete response`
- Display selected frequency and plan under all analysis methods, not just custom ones
- Display Other, specify textbox contents instead of radio option when selected

Open to code re-organization

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4351
CMDCT-4352
CMDCT-4353

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a NAAAR report
- Enter the NAAAR report and add a plan
- Go to the Analysis Methods page
- Verify:
  - All methods have red text under their names indicating they need to be completed
  - When you complete a method and select "No" to the utilization question, it displays "Not utilized" beneath the name in the table
  - When you select "Yes" and fill out the nested fields, the values of the nested fields are displayed below the name in the table
  - When you select "Yes" and then "Other, specify" for the frequency, the contents of that nested text box are displayed in the place of the frequency
  - The display behavior is the same for default and custom analysis methods


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary
---
