### PR TITLE
Cmdct 4298 - add captions to tables in exported reports

### DIFF
--- a/logs/todos.log
+++ b/logs/todos.log
@@ -8,6 +8,6 @@
 ./services/ui-src/src/components/reports/ModalOverlayReportPage.test.tsx:149:todo Write a test to make sure admins can't click/change details?
 ./services/ui-src/src/components/reports/OverlayReportPage.test.tsx:105:TODO: Update this when logic surrounding standards has been updated!
 ./services/ui-src/src/components/reports/OverlayReportPage.test.tsx:146:TODO: Update this when logic surrounding standards has been updated!
-./services/ui-src/src/components/reports/OverlayReportPage.tsx:95: TODO: Update this when working through the actual logic pertaining to Standards and how it'll be checked
+./services/ui-src/src/components/reports/OverlayReportPage.tsx:97: TODO: Update this when working through the actual logic pertaining to Standards and how it'll be checked
 ./services/ui-src/src/utils/autosave/autosave.ts:193: TODO: modify DynamicField hydrationValue lifecycle so we can implement a stricter check,
 ./services/ui-src/src/utils/tables/getNaaarEntityStatus.ts:4: TODO: Update to actual logic

--- a/logs/todos.log
+++ b/logs/todos.log
@@ -5,7 +5,7 @@
 ./services/ui-src/src/components/layout/Timeout.tsx:36: TODO: When autosave is implemented, set up a callback function to listen to calls to update in authLifecycle
 ./services/ui-src/src/components/overlays/EntityDetailsMultiformOverlay.tsx:173: TODO: Update with actual logic
 ./services/ui-src/src/components/overlays/EntityDetailsMultiformOverlay.tsx:80: TODO: Update with actual logic
-./services/ui-src/src/components/reports/ModalOverlayReportPage.test.tsx:149:todo Write a test to make sure admins can't click/change details?
+./services/ui-src/src/components/reports/ModalOverlayReportPage.test.tsx:170:todo Write a test to make sure admins can't click/change details?
 ./services/ui-src/src/components/reports/OverlayReportPage.test.tsx:105:TODO: Update this when logic surrounding standards has been updated!
 ./services/ui-src/src/components/reports/OverlayReportPage.test.tsx:146:TODO: Update this when logic surrounding standards has been updated!
 ./services/ui-src/src/components/reports/OverlayReportPage.tsx:97: TODO: Update this when working through the actual logic pertaining to Standards and how it'll be checked

--- a/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
@@ -30,8 +30,6 @@ export const ExportedEntityDetailsOverlaySection = ({
   const { report } = useStore();
   const entityType = section.entityType;
 
-  // console.log(section.verbiage.intro);
-
   return (
     <Box sx={sx.sectionHeading} {...props}>
       <ExportedSectionHeading

--- a/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
@@ -30,6 +30,8 @@ export const ExportedEntityDetailsOverlaySection = ({
   const { report } = useStore();
   const entityType = section.entityType;
 
+  // console.log(section.verbiage.intro);
+
   return (
     <Box sx={sx.sectionHeading} {...props}>
       <ExportedSectionHeading
@@ -146,6 +148,7 @@ export function getEntityTableComponents(
                 fields={filteredFields.slice(1) as FormField[]}
                 entity={entity}
                 showHintText={false}
+                caption={header.props?.content}
               />
             </Fragment>
           );

--- a/services/ui-src/src/components/export/ExportedEntityDetailsTable.test.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTable.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 // components
 import { ExportedEntityDetailsTable } from "components";
 // utils
@@ -6,6 +6,7 @@ import {
   mockMlrReportContext,
   mockMlrReportStore,
   mockModalOverlayReportPageWithOverlayJson,
+  mockUseStore,
 } from "utils/testing/setupJest";
 import { useStore } from "utils";
 import { testA11y } from "utils/testing/commonTests";
@@ -15,6 +16,10 @@ const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 mockedUseStore.mockReturnValue({
   ...mockMlrReportStore,
 });
+jest.mock("./ExportedEntityDetailsTable", () => ({
+  ...jest.requireActual("./ExportedEntityDetailsTable"),
+  renderFieldRow: jest.fn(),
+}));
 
 const exportedEntityDetailsTableComponent = () => (
   <ExportedEntityDetailsTable
@@ -43,7 +48,58 @@ describe("<ExportedEntityDetailsTable />", () => {
         expect(element).toBeVisible();
       }
     }
+    expect(screen.getByText("header content")).toBeVisible();
   });
 
   testA11y(exportedEntityDetailsTableComponent());
+});
+
+describe("new test", () => {
+  test("new test", () => {
+    const mockField = {
+      id: "1",
+      type: "text",
+      validation: "text",
+      props: {
+        choices: [
+          {
+            id: "choice-1",
+            children: [
+              {
+                id: "nested-1",
+                type: "text",
+                props: { content: "Nested Field 1" },
+              },
+              {
+                id: "nested-2",
+                type: "text",
+                props: { content: "Nested Field 2" },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    jest.mock("utils/state/useStore");
+    const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+    mockedUseStore.mockReturnValue({
+      ...mockMlrReportStore,
+    });
+
+    render(
+      <ExportedEntityDetailsTable
+        caption="Test Table"
+        fields={[mockField]}
+        entity={mockMlrReportContext.report.fieldData.program[0]}
+        showHintText={false}
+      />
+    );
+
+    const nestedField1 = screen.getByText("Nested Field 1");
+    const nestedField2 = screen.getByText("Nested Field 2");
+
+    expect(nestedField1).toBeInTheDocument();
+    expect(nestedField2).toBeInTheDocument();
+  });
 });

--- a/services/ui-src/src/components/export/ExportedEntityDetailsTable.test.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTable.test.tsx
@@ -21,6 +21,7 @@ const exportedEntityDetailsTableComponent = () => (
     fields={mockModalOverlayReportPageWithOverlayJson.overlayForm.fields}
     entity={mockMlrReportContext.report.fieldData.program[0]}
     data-testid="exportedEntityDetailsTable"
+    caption={"header content"}
   ></ExportedEntityDetailsTable>
 );
 describe("<ExportedEntityDetailsTable />", () => {

--- a/services/ui-src/src/components/export/ExportedEntityDetailsTable.test.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTable.test.tsx
@@ -6,7 +6,6 @@ import {
   mockMlrReportContext,
   mockMlrReportStore,
   mockModalOverlayReportPageWithOverlayJson,
-  mockUseStore,
 } from "utils/testing/setupJest";
 import { useStore } from "utils";
 import { testA11y } from "utils/testing/commonTests";
@@ -52,54 +51,4 @@ describe("<ExportedEntityDetailsTable />", () => {
   });
 
   testA11y(exportedEntityDetailsTableComponent());
-});
-
-describe("new test", () => {
-  test("new test", () => {
-    const mockField = {
-      id: "1",
-      type: "text",
-      validation: "text",
-      props: {
-        choices: [
-          {
-            id: "choice-1",
-            children: [
-              {
-                id: "nested-1",
-                type: "text",
-                props: { content: "Nested Field 1" },
-              },
-              {
-                id: "nested-2",
-                type: "text",
-                props: { content: "Nested Field 2" },
-              },
-            ],
-          },
-        ],
-      },
-    };
-
-    jest.mock("utils/state/useStore");
-    const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
-    mockedUseStore.mockReturnValue({
-      ...mockMlrReportStore,
-    });
-
-    render(
-      <ExportedEntityDetailsTable
-        caption="Test Table"
-        fields={[mockField]}
-        entity={mockMlrReportContext.report.fieldData.program[0]}
-        showHintText={false}
-      />
-    );
-
-    const nestedField1 = screen.getByText("Nested Field 1");
-    const nestedField2 = screen.getByText("Nested Field 2");
-
-    expect(nestedField1).toBeInTheDocument();
-    expect(nestedField2).toBeInTheDocument();
-  });
 });

--- a/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
@@ -44,7 +44,7 @@ export const ExportedEntityDetailsTable = ({
       {...props}
       sx={sx.root}
       content={{
-        caption: caption,
+        caption,
         headRow: threeColumnHeaderItems,
       }}
     >

--- a/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
@@ -18,6 +18,7 @@ import { useStore } from "utils";
 import verbiage from "verbiage/pages/mlr/mlr-export";
 
 export const ExportedEntityDetailsTable = ({
+  caption,
   fields,
   entity,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -43,6 +44,7 @@ export const ExportedEntityDetailsTable = ({
       {...props}
       sx={sx.root}
       content={{
+        caption: caption,
         headRow: threeColumnHeaderItems,
       }}
     >
@@ -122,6 +124,7 @@ export const renderFieldTableBody = (
 };
 
 export interface Props {
+  caption: string;
   fields: FormField[];
   entity: EntityShape;
   showHintText?: boolean;

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -35,6 +35,7 @@ export const ExportedModalOverlayReportSection = ({ section }: Props) => {
       <Table
         sx={sx.root}
         content={{
+          caption: "Reporting Overview",
           headRow: headerLabels,
         }}
         data-testid="exportTable"

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
@@ -104,6 +104,7 @@ export const ExportedReportFieldTable = ({ section }: Props) => {
           sx={sx.root}
           className={formHasOnlyDynamicFields ? "two-column" : ""}
           content={{
+            caption: section.name,
             headRow: headRowItems,
           }}
           data-testid="exportTable"

--- a/services/ui-src/src/components/export/ExportedReportMetadataTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportMetadataTable.tsx
@@ -15,6 +15,7 @@ export const ExportedReportMetadataTable = ({
       data-testid="exportedReportMetadataTable"
       sx={sx.metadataTable}
       content={{
+        caption: "Report Submission Information",
         headRow: headerRowLabels(reportType, verbiage),
         bodyRows: bodyRowContent(reportType, report),
       }}

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -65,6 +65,7 @@ export const ExportedReportPage = () => {
               sx={sx.combinedDataTable}
               className="short"
               content={{
+                caption: "MCPAR CHIP Exclusion Indicator",
                 headRow: [tableHeaders.indicator, tableHeaders.response],
               }}
             >

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
@@ -190,6 +190,7 @@ describe("<ModalDrawerReportPage />", () => {
       render(modalDrawerReportPageComponentWithEntities(naaarRoute));
 
       const entityTable = screen.getByRole("table");
+      const entityCaption = entityTable.querySelector("caption");
       const entityHeader = screen.getByRole("columnheader", {
         name: "Mock table header",
       });
@@ -198,6 +199,7 @@ describe("<ModalDrawerReportPage />", () => {
       });
 
       expect(entityTable).toBeVisible();
+      expect(entityCaption).toHaveTextContent("Mock table header");
       expect(entityHeader).toBeVisible();
       expect(entityCell).toBeVisible();
     });
@@ -214,12 +216,14 @@ describe("<ModalDrawerReportPage />", () => {
       render(modalDrawerReportPageComponentWithEntities(naaarRoute));
 
       const entityTable = screen.getByRole("table");
+      const entityCaption = entityTable.querySelector("caption");
       const entityHeader = screen.queryByRole("columnheader", {
         name: "Mock table header",
       });
       const entityCell = screen.getByText("plan 1");
 
       expect(entityTable).toBeVisible();
+      expect(entityCaption).toHaveTextContent("Mock table header");
       expect(entityHeader).toBeNull();
       expect(entityCell).toBeVisible();
     });

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -304,10 +304,17 @@ const entityTable = (
   const { isTablet, isMobile } = useBreakpoint();
   const tableHeaders = () => {
     if (isTablet || isMobile)
-      return { caption: verbiage.tableHeader, headRow: ["", ""] };
+      return {
+        caption: verbiage.tableHeader,
+        headRow: [{ hiddenName: "Status" }, { hiddenName: "Content" }],
+      };
     return {
       caption: verbiage.tableHeader,
-      headRow: ["", verbiage.tableHeader!, ""],
+      headRow: [
+        { hiddenName: "Status" },
+        verbiage.tableHeader!,
+        { hiddenName: "Action" },
+      ],
     };
   };
   return (

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -303,8 +303,12 @@ const entityTable = (
 ) => {
   const { isTablet, isMobile } = useBreakpoint();
   const tableHeaders = () => {
-    if (isTablet || isMobile) return { headRow: ["", ""] };
-    return { headRow: ["", verbiage.tableHeader!, ""] };
+    if (isTablet || isMobile)
+      return { caption: verbiage.tableHeader, headRow: ["", ""] };
+    return {
+      caption: verbiage.tableHeader,
+      headRow: ["", verbiage.tableHeader!, ""],
+    };
   };
   return (
     <Table sx={sx.table} content={tableHeaders()}>

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.test.tsx
@@ -14,7 +14,12 @@ import {
   mockEmptyReportStore,
   mockEntityStore,
 } from "utils/testing/setupJest";
-import { UserProvider, useStore } from "utils";
+import {
+  makeMediaQueryClasses,
+  useBreakpoint,
+  UserProvider,
+  useStore,
+} from "utils";
 import { testA11yAct } from "utils/testing/commonTests";
 // verbiage
 import accordionVerbiage from "verbiage/pages/accordion";
@@ -29,6 +34,14 @@ const mockMlrEntityStartedStore = {
     fieldData: mockMLRReportEntityStartedFieldData,
   },
 };
+
+jest.mock("utils/other/useBreakpoint");
+const mockUseBreakpoint = useBreakpoint as jest.MockedFunction<
+  typeof useBreakpoint
+>;
+const mockMakeMediaQueryClasses = makeMediaQueryClasses as jest.MockedFunction<
+  typeof makeMediaQueryClasses
+>;
 
 const mockSetSidebarHidden = jest.fn();
 
@@ -46,6 +59,14 @@ const modalOverlayReportPageComponent = (
 );
 
 describe("<ModalOverlayReportPage />", () => {
+  beforeEach(() => {
+    mockUseBreakpoint.mockReturnValue({
+      isMobile: false,
+      isTablet: false,
+    });
+    mockMakeMediaQueryClasses.mockReturnValue("desktop");
+  });
+
   describe("Test ModalOverlayReportPage (empty state)", () => {
     beforeEach(() => {
       jest.clearAllMocks();
@@ -382,6 +403,34 @@ describe("<ModalOverlayReportPage />", () => {
       // And make sure we're back on the first page!
       expect(mockSetSidebarHidden).toBeCalledWith(false);
       expect(screen.getByText(dashboardTitle)).toBeVisible();
+    });
+  });
+
+  describe("mobile view", () => {
+    beforeEach(() => {
+      mockedUseStore.mockReturnValue({
+        ...mockStateUserStore,
+        ...mockMlrEntityStartedStore,
+        ...mockEntityStore,
+      });
+      mockUseBreakpoint.mockReturnValue({
+        isMobile: true,
+      });
+      mockMakeMediaQueryClasses.mockReturnValue("mobile");
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    const verbiage = mockModalOverlayReportPageWithOverlayJson.verbiage;
+
+    test("mobile view", async () => {
+      await act(async () => {
+        render(modalOverlayReportPageComponent);
+      });
+      const headerAndCaptionArray = screen.getAllByText(verbiage.tableHeader);
+      expect(headerAndCaptionArray).toHaveLength(2);
     });
   });
 

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -64,8 +64,12 @@ export const ModalOverlayReportPage = ({
   const reportFieldDataEntities = report?.fieldData[entityType] || [];
   const dashTitle = `${verbiage.dashboardTitle} ${reportFieldDataEntities.length}`;
   const tableHeaders = () => {
-    if (isTablet || isMobile) return { headRow: ["", ""] };
-    return { headRow: ["", verbiage.tableHeader, ""] };
+    if (isTablet || isMobile)
+      return { caption: verbiage.tableHeader, headRow: ["", ""] };
+    return {
+      caption: verbiage.tableHeader,
+      headRow: ["", verbiage.tableHeader, ""],
+    };
   };
 
   // Add/edit entity modal disclosure and methods

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -65,10 +65,17 @@ export const ModalOverlayReportPage = ({
   const dashTitle = `${verbiage.dashboardTitle} ${reportFieldDataEntities.length}`;
   const tableHeaders = () => {
     if (isTablet || isMobile)
-      return { caption: verbiage.tableHeader, headRow: ["", ""] };
+      return {
+        caption: verbiage.tableHeader,
+        headRow: [{ hiddenName: "Status" }, { hiddenName: "Content" }],
+      };
     return {
       caption: verbiage.tableHeader,
-      headRow: ["", verbiage.tableHeader, ""],
+      headRow: [
+        { hiddenName: "Status" },
+        verbiage.tableHeader,
+        { hiddenName: "Action" },
+      ],
     };
   };
 

--- a/services/ui-src/src/components/reports/OverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayReportPage.tsx
@@ -67,6 +67,7 @@ export const OverlayReportPage = ({
     const tableHeaders = () => {
       if (isTablet || isMobile) {
         return {
+          caption: verbiage.tableHeader,
           headRow: [
             { hiddenName: "Status" },
             { hiddenName: verbiage.tableHeader },
@@ -75,6 +76,7 @@ export const OverlayReportPage = ({
       }
 
       return {
+        caption: verbiage.tableHeader,
         headRow: [
           { hiddenName: "Status" },
           verbiage.tableHeader,

--- a/services/ui-src/src/verbiage/pages/mcpar/mcpar-get-started.ts
+++ b/services/ui-src/src/verbiage/pages/mcpar/mcpar-get-started.ts
@@ -30,7 +30,7 @@ export default {
         tableHeading:
           "Excel workbook tabs are located in these sections in the online form:",
         table: {
-          caption: "Before you begin the MCPAR online form",
+          caption: "MCPAR online form overview",
           headRow: ["Excel Workbook Tab", "Location in MCPAR online form"],
           bodyRows: [
             ["A_Program_Info", "A: Program Information"],

--- a/services/ui-src/src/verbiage/pages/mcpar/mcpar-get-started.ts
+++ b/services/ui-src/src/verbiage/pages/mcpar/mcpar-get-started.ts
@@ -30,6 +30,7 @@ export default {
         tableHeading:
           "Excel workbook tabs are located in these sections in the online form:",
         table: {
+          caption: "Before you begin the MCPAR online form",
           headRow: ["Excel Workbook Tab", "Location in MCPAR online form"],
           bodyRows: [
             ["A_Program_Info", "A: Program Information"],

--- a/services/ui-src/src/verbiage/pages/mcpar/mcpar-review-and-submit.ts
+++ b/services/ui-src/src/verbiage/pages/mcpar/mcpar-review-and-submit.ts
@@ -35,6 +35,7 @@ export default {
       ],
     },
     table: {
+      caption: "Review & Submit",
       headRow: ["Section", "Status", { hiddenName: "Actions" }],
     },
     modal: {

--- a/services/ui-src/src/verbiage/pages/mlr/mlr-review-and-submit.ts
+++ b/services/ui-src/src/verbiage/pages/mlr/mlr-review-and-submit.ts
@@ -35,6 +35,7 @@ export default {
       ],
     },
     table: {
+      caption: "Review & Submit",
       headRow: ["Section", "Status", { hiddenName: "Actions" }],
     },
     modal: {

--- a/services/ui-src/src/verbiage/pages/naaar/naaar-review-and-submit.ts
+++ b/services/ui-src/src/verbiage/pages/naaar/naaar-review-and-submit.ts
@@ -11,6 +11,7 @@ export default {
       info: "Double check that everything in your NAAAR submission is accurate. You will be able to make edits after submitting, and resubmit. Once you’ve reviewed your report, certify that it’s in compliance with CFRs.",
     },
     table: {
+      caption: "Review & Submit",
       headRow: ["Section", "Status", { hiddenName: "Actions" }],
     },
     modal: {


### PR DESCRIPTION
### Description
 Tables have empty <caption> tags, thus not getting labelled. This makes it harder for screen readers to be able to navigate to a specific table that they want

Every report now has captions (visually hidden) on the review& submit page table along with the exported tables

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4298

---
### How to test
Create a report (MLR and MCR), use the inspector to verify that tables have captions in the review & submit page and in the exported report. NAAR was also updated on the review & submit page.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
