### PR TITLE
cmdct-4300 replace header with text component

### DIFF
--- a/services/ui-src/src/components/menus/Sidebar.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.tsx
@@ -1,15 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Link as RouterLink, useLocation } from "react-router-dom";
 // components
-import {
-  Box,
-  Collapse,
-  Flex,
-  Image,
-  Heading,
-  Link,
-  Text,
-} from "@chakra-ui/react";
+import { Box, Collapse, Flex, Image, Link, Text } from "@chakra-ui/react";
 import { SkipNav } from "components";
 // utils
 import { useBreakpoint, useStore } from "utils";
@@ -65,9 +57,7 @@ export const Sidebar = ({ isHidden }: SidebarProps) => {
               />
             </Box>
             <Box id="sidebar-title-box" sx={sx.topBox}>
-              <Heading as="h1" sx={sx.title}>
-                {reportJson.name}
-              </Heading>
+              <Text sx={sx.title}>{reportJson.name}</Text>
             </Box>
             <Box sx={sx.navSectionsBox} className="nav-sections-box">
               {reportJson.routes.map((section) => (
@@ -211,6 +201,7 @@ const sx = {
   title: {
     fontSize: "xl",
     fontWeight: "bold",
+    lineHeight: "1.33",
     width: "15rem",
     padding: "1rem 1rem",
     ".desktop &": {

--- a/services/ui-src/src/components/menus/Sidebar.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.tsx
@@ -65,7 +65,9 @@ export const Sidebar = ({ isHidden }: SidebarProps) => {
               />
             </Box>
             <Box id="sidebar-title-box" sx={sx.topBox}>
-              <Heading sx={sx.title}>{reportJson.name}</Heading>
+              <Heading as="h1" sx={sx.title}>
+                {reportJson.name}
+              </Heading>
             </Box>
             <Box sx={sx.navSectionsBox} className="nav-sections-box">
               {reportJson.routes.map((section) => (


### PR DESCRIPTION
### Description
There is an `<h2>` in the sidebar that will always be out of order from any `<h1>` added to page content. 

I double checked that all of the pages start with an `<h1>` header already.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4300

---
### How to test
check that the sidebar header is set as `<Text/>`


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
