### PR TITLE
Add compareText util

### DIFF
--- a/logs/launchdarkly-flags.log
+++ b/logs/launchdarkly-flags.log
@@ -4,7 +4,7 @@
 ./services/ui-src/src/components/app/AppRoutes.tsx:30:useFlags()?.naaarReport;
 ./services/ui-src/src/components/cards/TemplateCard.tsx:34:useFlags()?.naaarReport;
 ./services/ui-src/src/components/forms/AdminDashSelector.tsx:40:useFlags()?.naaarReport;
-./services/ui-src/src/components/modals/AddEditReportModal.tsx:43:useFlags()?.naaarReport;
+./services/ui-src/src/components/modals/AddEditReportModal.tsx:44:useFlags()?.naaarReport;
 ./services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx:213:useFlags()?.sortableDashboardTable;
 
 # LaunchDarkly flags in tests

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -22,6 +22,7 @@ import {
   calculateDueDate,
   convertDateEtToUtc,
   convertDateUtcToEt,
+  otherSpecify,
   useStore,
 } from "utils";
 
@@ -154,10 +155,11 @@ export const AddEditReportModal = ({
       formData["reportingPeriodEndDate"]
     );
     const planTypeIncludedInProgram = formData["planTypeIncludedInProgram"];
-    const planTypeOtherText =
-      planTypeIncludedInProgram[0].value === "Other, specify"
-        ? formData["planTypeIncludedInProgram-otherText"]
-        : null;
+    const planTypeOtherText = otherSpecify(
+      planTypeIncludedInProgram[0].value,
+      formData["planTypeIncludedInProgram-otherText"],
+      null
+    );
 
     return {
       metadata: {

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -3,6 +3,7 @@ import { Button, Td, Tr, Spinner } from "@chakra-ui/react";
 import { Table } from "components";
 // types
 import { ReportMetadataShape, ReportType } from "types";
+import { otherSpecify } from "utils";
 // utils
 import {
   AdminArchiveButton,
@@ -50,9 +51,10 @@ export const DashboardTable = ({
         {/* Plan type (NAAAR only) */}
         {report.reportType === ReportType.NAAAR && (
           <Td>
-            {report["planTypeIncludedInProgram"]?.[0].value === "Other, specify"
-              ? report["planTypeIncludedInProgram-otherText"]
-              : report.planTypeIncludedInProgram?.[0].value}
+            {otherSpecify(
+              report["planTypeIncludedInProgram"]?.[0].value,
+              report["planTypeIncludedInProgram-otherText"]
+            )}
           </Td>
         )}
         {/* Date Fields */}

--- a/services/ui-src/src/components/pages/Dashboard/SortableDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/SortableDashboardTable.tsx
@@ -5,7 +5,7 @@ import { SortableTable } from "components";
 // types
 import { ReportMetadataShape, ReportStatus } from "types";
 // utils
-import { convertDateUtcToEt } from "utils";
+import { convertDateUtcToEt, otherSpecify } from "utils";
 import {
   AdminArchiveButton,
   AdminReleaseButton,
@@ -50,10 +50,10 @@ export const SortableDashboardTable = ({
           dueDate,
           lastAltered,
           editedBy: lastAlteredBy || "-",
-          planType:
-            report["planTypeIncludedInProgram"]?.[0].value === "Other, specify"
-              ? report["planTypeIncludedInProgram-otherText"]
-              : report.planTypeIncludedInProgram?.[0].value,
+          planType: otherSpecify(
+            report.planTypeIncludedInProgram?.[0].value,
+            report["planTypeIncludedInProgram-otherText"]
+          ),
           status: getStatus(status, report.archived, submissionCount),
           submissionCount: submissionCount === 0 ? 1 : submissionCount,
           // Original report shape to pass to cell buttons

--- a/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
@@ -10,7 +10,7 @@ import { AnyObject } from "yup/lib/types";
 import unfinishedIcon from "assets/icons/icon_error_circle_bright.png";
 import deleteIcon from "assets/icons/icon_cancel_x_circle.png";
 import completedIcon from "assets/icons/icon_check_circle.png";
-import { getForm, isIlosCompleted, useStore } from "utils";
+import { getForm, isIlosCompleted, otherSpecify, useStore } from "utils";
 import { getDefaultAnalysisMethodIds } from "../../constants";
 
 export const DrawerReportPageEntityRows = ({
@@ -109,10 +109,10 @@ export const DrawerReportPageEntityRows = ({
 
         if (plans) {
           const frequencyVal = entity.analysis_method_frequency[0].value;
-          const frequency =
-            frequencyVal === "Other, specify"
-              ? entity["analysis_method_frequency-otherText"]
-              : frequencyVal;
+          const frequency = otherSpecify(
+            frequencyVal,
+            entity["analysis_method_frequency-otherText"]
+          );
           const utilizedPlans = plans
             .map((entity: AnyObject) => entity.value)
             .join(", ");

--- a/services/ui-src/src/components/tables/SortableNaaarStandardsTable.tsx
+++ b/services/ui-src/src/components/tables/SortableNaaarStandardsTable.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { generateColumns, SortableTable } from "components";
 import deleteIcon from "assets/icons/icon_cancel_x_circle.png";
 import { EntityShape } from "types";
+import { otherSpecify } from "utils";
 
 export const SortableNaaarStandardsTable = ({
   entities,
@@ -34,26 +35,27 @@ export const SortableNaaarStandardsTable = ({
         ? `standard_analysisMethodsUtilized${standardId}`
         : "";
 
-      const coreProviderType = entity[
-        "standard_coreProviderTypeCoveredByStandard-otherText"
-      ]
-        ? `${standard_coreProviderTypeCoveredByStandard[0].value}; ${entity["standard_coreProviderTypeCoveredByStandard-otherText"]}`
-        : standard_coreProviderTypeCoveredByStandard[0].value;
+      const coreProviderTypeOther =
+        entity["standard_coreProviderTypeCoveredByStandard-otherText"];
+      const coreProviderTypeValue =
+        standard_coreProviderTypeCoveredByStandard[0].value;
 
-      const standardType =
-        standard_standardType[0].value === "Other, specify"
-          ? entity["standard_standardType-otherText"]
-          : standard_standardType[0].value;
+      const coreProviderType = coreProviderTypeOther
+        ? `${coreProviderTypeValue}; ${coreProviderTypeOther}`
+        : coreProviderTypeValue;
 
-      const standardPopulation =
-        standard_populationCoveredByStandard[0].value === "Other, specify"
-          ? entity["standard_populationCoveredByStandard-otherText"]
-          : standard_populationCoveredByStandard[0].value;
-
-      const standardRegion =
-        standard_applicableRegion[0].value === "Other, specify"
-          ? entity["standard_applicableRegion-otherText"]
-          : standard_applicableRegion[0].value;
+      const standardType = otherSpecify(
+        standard_standardType[0].value,
+        entity["standard_standardType-otherText"]
+      );
+      const standardPopulation = otherSpecify(
+        standard_populationCoveredByStandard[0].value,
+        entity["standard_populationCoveredByStandard-otherText"]
+      );
+      const standardRegion = otherSpecify(
+        standard_applicableRegion[0].value,
+        entity["standard_applicableRegion-otherText"]
+      );
 
       // there are 7 analysis methods checkboxes
       function extractMethods(analysisMethodsUtilized: { value: any }[]) {

--- a/services/ui-src/src/utils/index.ts
+++ b/services/ui-src/src/utils/index.ts
@@ -43,4 +43,5 @@ export * from "./other/typing";
 // state management (zustand)
 export * from "./state/useStore";
 // text
+export * from "./text/compareText";
 export * from "./text/translate";

--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -16,18 +16,22 @@ const getCheckboxValues = (entity: EntityShape | undefined, label: string) => {
 };
 
 const getReportingRateType = (entity: EntityShape | undefined) => {
-  const matchText = `Cross-program rate: ${entity?.qualityMeasure_crossProgramReportingRateProgramList}`;
+  const textToMatch = "Cross-program rate";
+  const matchText = `${textToMatch}: ${entity?.qualityMeasure_crossProgramReportingRateProgramList}`;
+
   return compareText(
-    "Cross-program rate",
+    textToMatch,
     entity?.qualityMeasure_reportingRateType?.[0]?.value,
     matchText
   );
 };
 
 const getReportingPeriod = (entity: EntityShape | undefined) => {
-  const matchText = `No, ${entity?.qualityMeasure_reportingPeriodStartDate} - ${entity?.qualityMeasure_reportingPeriodEndDate}`;
+  const textToMatch = "No";
+  const matchText = `${textToMatch}, ${entity?.qualityMeasure_reportingPeriodStartDate} - ${entity?.qualityMeasure_reportingPeriodEndDate}`;
+
   return compareText(
-    "No",
+    textToMatch,
     entity?.qualityMeasure_reportingPeriod?.[0]?.value,
     matchText
   );

--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -1,33 +1,36 @@
 // utils
 import { AnyObject, EntityShape, EntityType } from "types";
-import { maskResponseData } from "utils";
+import { compareText, maskResponseData, otherSpecify } from "utils";
 
 const getRadioValue = (entity: EntityShape | undefined, label: string) => {
-  return entity?.[label]?.[0].value !== "Other, specify"
-    ? entity?.[label]?.[0].value
-    : entity?.[label + "-otherText"];
+  return otherSpecify(
+    entity?.[label]?.[0].value,
+    entity?.[`${label}-otherText`]
+  );
 };
 
 const getCheckboxValues = (entity: EntityShape | undefined, label: string) => {
   return entity?.[label]?.map((method: AnyObject) =>
-    method.value === "Other, specify"
-      ? entity?.[label + "-otherText"]
-      : method.value
+    otherSpecify(method.value, entity?.[`${label}-otherText`])
   );
 };
 
 const getReportingRateType = (entity: EntityShape | undefined) => {
-  return entity?.qualityMeasure_reportingRateType?.[0]?.value ===
-    "Cross-program rate"
-    ? "Cross-program rate: " +
-        entity?.qualityMeasure_crossProgramReportingRateProgramList
-    : entity?.qualityMeasure_reportingRateType?.[0]?.value;
+  const matchText = `Cross-program rate: ${entity?.qualityMeasure_crossProgramReportingRateProgramList}`;
+  return compareText(
+    "Cross-program rate",
+    entity?.qualityMeasure_reportingRateType?.[0]?.value,
+    matchText
+  );
 };
 
 const getReportingPeriod = (entity: EntityShape | undefined) => {
-  return entity?.qualityMeasure_reportingPeriod?.[0]?.value === "No"
-    ? `No, ${entity?.qualityMeasure_reportingPeriodStartDate} - ${entity?.qualityMeasure_reportingPeriodEndDate}`
-    : entity?.qualityMeasure_reportingPeriod?.[0]?.value;
+  const matchText = `No, ${entity?.qualityMeasure_reportingPeriodStartDate} - ${entity?.qualityMeasure_reportingPeriodEndDate}`;
+  return compareText(
+    "No",
+    entity?.qualityMeasure_reportingPeriod?.[0]?.value,
+    matchText
+  );
 };
 
 // returns an array of { planName: string, response: string } or undefined

--- a/services/ui-src/src/utils/text/compareText.test.ts
+++ b/services/ui-src/src/utils/text/compareText.test.ts
@@ -1,0 +1,82 @@
+import { compareText, otherSpecify } from "./compareText";
+
+describe("utils/text/otherText", () => {
+  describe("otherSpecify()", () => {
+    test("returns matchText for textToCompare: Other, specify", () => {
+      const result = otherSpecify("Other, specify", "Matched", "Not Matched");
+      expect(result).toBe("Matched");
+    });
+
+    test("returns nonMatchText for textToCompare: Test", () => {
+      const result = otherSpecify("Test", "Matched", "Not Matched");
+      expect(result).toBe("Not Matched");
+    });
+
+    test("returns nonMatchText for textToCompare: null", () => {
+      const result = otherSpecify(null, "Matched", "Not Matched");
+      expect(result).toBe("Not Matched");
+    });
+
+    test("returns nonMatchText for textToCompare: undefined", () => {
+      const result = otherSpecify(undefined, "Matched", "Not Matched");
+      expect(result).toBe("Not Matched");
+    });
+
+    test("returns null for matchText", () => {
+      const result = otherSpecify("Other, specify", null, "Not Matched");
+      expect(result).toBeNull();
+    });
+
+    test("returns null for nonMatchText", () => {
+      const result = otherSpecify("Test", "Matched", null);
+      expect(result).toBeNull();
+    });
+
+    test("returns textToCompare for undefined nonMatchText", () => {
+      const result = otherSpecify("Test", "Matched");
+      expect(result).toBe("Test");
+    });
+  });
+
+  describe("compareText()", () => {
+    test("returns matchText for textToMatch: Other, specify", () => {
+      const result = compareText(
+        "Other, specify",
+        "Other, specify",
+        "Matched",
+        "Not Matched"
+      );
+      expect(result).toBe("Matched");
+    });
+
+    test("returns nonMatchText for textToMatch: Test", () => {
+      const result = compareText(
+        "Test",
+        "Other, specify",
+        "Matched",
+        "Not Matched"
+      );
+      expect(result).toBe("Not Matched");
+    });
+
+    test("returns null for textToCompare: Other, specify", () => {
+      const result = compareText(
+        "Other, specify",
+        "Other, specify",
+        null,
+        "Not Matched"
+      );
+      expect(result).toBeNull();
+    });
+
+    test("returns null for textToCompare: Text", () => {
+      const result = compareText("Other, specify", "Test", "Matched", null);
+      expect(result).toBeNull();
+    });
+
+    test("returns textToCompare for undefined nonMatchText", () => {
+      const result = compareText("Other, specify", "Test", "Matched");
+      expect(result).toBe("Test");
+    });
+  });
+});

--- a/services/ui-src/src/utils/text/compareText.test.ts
+++ b/services/ui-src/src/utils/text/compareText.test.ts
@@ -1,82 +1,100 @@
 import { compareText, otherSpecify } from "./compareText";
 
 describe("utils/text/otherText", () => {
+  const otherSpecifyText = "Other, specify";
+  const testText = "Test";
+  const matchText = "Matched";
+  const nonMatchText = "Not Matched";
+
   describe("otherSpecify()", () => {
-    test("returns matchText for textToCompare: Other, specify", () => {
-      const result = otherSpecify("Other, specify", "Matched", "Not Matched");
-      expect(result).toBe("Matched");
+    describe("matches", () => {
+      test("returns matchText", () => {
+        const result = otherSpecify(otherSpecifyText, matchText, nonMatchText);
+        expect(result).toBe(matchText);
+      });
+
+      test("returns null matchText", () => {
+        const result = otherSpecify(otherSpecifyText, null, nonMatchText);
+        expect(result).toBeNull();
+      });
     });
 
-    test("returns nonMatchText for textToCompare: Test", () => {
-      const result = otherSpecify("Test", "Matched", "Not Matched");
-      expect(result).toBe("Not Matched");
-    });
+    describe("non-matches", () => {
+      test("returns nonMatchText", () => {
+        const result = otherSpecify(testText, matchText, nonMatchText);
+        expect(result).toBe(nonMatchText);
+      });
 
-    test("returns nonMatchText for textToCompare: null", () => {
-      const result = otherSpecify(null, "Matched", "Not Matched");
-      expect(result).toBe("Not Matched");
-    });
+      test("returns null nonMatchText", () => {
+        const result = otherSpecify(testText, matchText, null);
+        expect(result).toBeNull();
+      });
 
-    test("returns nonMatchText for textToCompare: undefined", () => {
-      const result = otherSpecify(undefined, "Matched", "Not Matched");
-      expect(result).toBe("Not Matched");
-    });
+      test("returns textToCompare for undefined nonMatchText", () => {
+        const result = otherSpecify(testText, matchText);
+        expect(result).toBe(testText);
+      });
 
-    test("returns null for matchText", () => {
-      const result = otherSpecify("Other, specify", null, "Not Matched");
-      expect(result).toBeNull();
-    });
+      test("returns nonMatchText for null textToCompare", () => {
+        const result = otherSpecify(null, matchText, nonMatchText);
+        expect(result).toBe(nonMatchText);
+      });
 
-    test("returns null for nonMatchText", () => {
-      const result = otherSpecify("Test", "Matched", null);
-      expect(result).toBeNull();
-    });
-
-    test("returns textToCompare for undefined nonMatchText", () => {
-      const result = otherSpecify("Test", "Matched");
-      expect(result).toBe("Test");
+      test("returns nonMatchText for undefined textToCompare", () => {
+        const result = otherSpecify(undefined, matchText, nonMatchText);
+        expect(result).toBe(nonMatchText);
+      });
     });
   });
 
   describe("compareText()", () => {
-    test("returns matchText for textToMatch: Other, specify", () => {
-      const result = compareText(
-        "Other, specify",
-        "Other, specify",
-        "Matched",
-        "Not Matched"
-      );
-      expect(result).toBe("Matched");
+    describe("matches", () => {
+      test("returns ≈", () => {
+        const result = compareText(testText, testText, matchText, nonMatchText);
+        expect(result).toBe(matchText);
+      });
+
+      test("returns null matchText", () => {
+        const result = compareText(testText, testText, null, nonMatchText);
+        expect(result).toBeNull();
+      });
     });
 
-    test("returns nonMatchText for textToMatch: Test", () => {
-      const result = compareText(
-        "Test",
-        "Other, specify",
-        "Matched",
-        "Not Matched"
-      );
-      expect(result).toBe("Not Matched");
-    });
+    describe("non-matches", () => {
+      test("returns nonMatchText", () => {
+        const result = compareText(
+          testText,
+          otherSpecifyText,
+          matchText,
+          nonMatchText
+        );
+        expect(result).toBe(nonMatchText);
+      });
 
-    test("returns null for textToCompare: Other, specify", () => {
-      const result = compareText(
-        "Other, specify",
-        "Other, specify",
-        null,
-        "Not Matched"
-      );
-      expect(result).toBeNull();
-    });
+      test("returns null nonMatchText", () => {
+        const result = compareText(testText, otherSpecifyText, matchText, null);
+        expect(result).toBeNull();
+      });
 
-    test("returns null for textToCompare: Text", () => {
-      const result = compareText("Other, specify", "Test", "Matched", null);
-      expect(result).toBeNull();
-    });
+      test("returns textToCompare for undefined nonMatchText", () => {
+        const result = compareText(testText, otherSpecifyText, matchText);
+        expect(result).toBe(otherSpecifyText);
+      });
 
-    test("returns textToCompare for undefined nonMatchText", () => {
-      const result = compareText("Other, specify", "Test", "Matched");
-      expect(result).toBe("Test");
+      test("returns nonMatchText for undefined textToCompare", () => {
+        const result = compareText(
+          testText,
+          undefined,
+          matchText,
+          nonMatchText
+        );
+        expect(result).toBe(nonMatchText);
+      });
+
+      test("returns undefined nonMatchText for undefined textToCompare", () => {
+        const result = compareText(testText, undefined, matchText);
+        expect(result).toBe(undefined);
+      });
     });
   });
 });

--- a/services/ui-src/src/utils/text/compareText.test.ts
+++ b/services/ui-src/src/utils/text/compareText.test.ts
@@ -14,8 +14,13 @@ describe("utils/text/compareText", () => {
       });
 
       test("returns null matchText", () => {
-        const result = compareText(testText, testText, null, nonMatchText);
+        const result = compareText(testText, testText, null);
         expect(result).toBeNull();
+      });
+
+      test("returns undefined matchText", () => {
+        const result = compareText(testText, testText);
+        expect(result).toBeUndefined();
       });
     });
 
@@ -52,7 +57,7 @@ describe("utils/text/compareText", () => {
 
       test("returns undefined nonMatchText for undefined textToCompare", () => {
         const result = compareText(testText, undefined, matchText);
-        expect(result).toBe(undefined);
+        expect(result).toBeUndefined();
       });
     });
   });
@@ -65,8 +70,13 @@ describe("utils/text/compareText", () => {
       });
 
       test("returns null matchText", () => {
-        const result = otherSpecify(otherSpecifyText, null, nonMatchText);
+        const result = otherSpecify(otherSpecifyText, null);
         expect(result).toBeNull();
+      });
+
+      test("returns undefined matchText", () => {
+        const result = otherSpecify(otherSpecifyText);
+        expect(result).toBeUndefined();
       });
     });
 

--- a/services/ui-src/src/utils/text/compareText.test.ts
+++ b/services/ui-src/src/utils/text/compareText.test.ts
@@ -1,55 +1,14 @@
 import { compareText, otherSpecify } from "./compareText";
 
-describe("utils/text/otherText", () => {
+describe("utils/text/compareText", () => {
   const otherSpecifyText = "Other, specify";
   const testText = "Test";
   const matchText = "Matched";
   const nonMatchText = "Not Matched";
 
-  describe("otherSpecify()", () => {
-    describe("matches", () => {
-      test("returns matchText", () => {
-        const result = otherSpecify(otherSpecifyText, matchText, nonMatchText);
-        expect(result).toBe(matchText);
-      });
-
-      test("returns null matchText", () => {
-        const result = otherSpecify(otherSpecifyText, null, nonMatchText);
-        expect(result).toBeNull();
-      });
-    });
-
-    describe("non-matches", () => {
-      test("returns nonMatchText", () => {
-        const result = otherSpecify(testText, matchText, nonMatchText);
-        expect(result).toBe(nonMatchText);
-      });
-
-      test("returns null nonMatchText", () => {
-        const result = otherSpecify(testText, matchText, null);
-        expect(result).toBeNull();
-      });
-
-      test("returns textToCompare for undefined nonMatchText", () => {
-        const result = otherSpecify(testText, matchText);
-        expect(result).toBe(testText);
-      });
-
-      test("returns nonMatchText for null textToCompare", () => {
-        const result = otherSpecify(null, matchText, nonMatchText);
-        expect(result).toBe(nonMatchText);
-      });
-
-      test("returns nonMatchText for undefined textToCompare", () => {
-        const result = otherSpecify(undefined, matchText, nonMatchText);
-        expect(result).toBe(nonMatchText);
-      });
-    });
-  });
-
   describe("compareText()", () => {
     describe("matches", () => {
-      test("returns ≈", () => {
+      test("returns matchText", () => {
         const result = compareText(testText, testText, matchText, nonMatchText);
         expect(result).toBe(matchText);
       });
@@ -94,6 +53,47 @@ describe("utils/text/otherText", () => {
       test("returns undefined nonMatchText for undefined textToCompare", () => {
         const result = compareText(testText, undefined, matchText);
         expect(result).toBe(undefined);
+      });
+    });
+  });
+
+  describe("otherSpecify()", () => {
+    describe("matches", () => {
+      test("returns matchText", () => {
+        const result = otherSpecify(otherSpecifyText, matchText, nonMatchText);
+        expect(result).toBe(matchText);
+      });
+
+      test("returns null matchText", () => {
+        const result = otherSpecify(otherSpecifyText, null, nonMatchText);
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("non-matches", () => {
+      test("returns nonMatchText", () => {
+        const result = otherSpecify(testText, matchText, nonMatchText);
+        expect(result).toBe(nonMatchText);
+      });
+
+      test("returns null nonMatchText", () => {
+        const result = otherSpecify(testText, matchText, null);
+        expect(result).toBeNull();
+      });
+
+      test("returns textToCompare for undefined nonMatchText", () => {
+        const result = otherSpecify(testText, matchText);
+        expect(result).toBe(testText);
+      });
+
+      test("returns nonMatchText for null textToCompare", () => {
+        const result = otherSpecify(null, matchText, nonMatchText);
+        expect(result).toBe(nonMatchText);
+      });
+
+      test("returns nonMatchText for undefined textToCompare", () => {
+        const result = otherSpecify(undefined, matchText, nonMatchText);
+        expect(result).toBe(nonMatchText);
       });
     });
   });

--- a/services/ui-src/src/utils/text/compareText.ts
+++ b/services/ui-src/src/utils/text/compareText.ts
@@ -1,26 +1,26 @@
-export function otherSpecify(
-  textToCompare?: string | null,
-  matchText?: string | null,
-  nonMatchText?: string | null
-) {
-  return compareText("Other, specify", textToCompare, matchText, nonMatchText);
-}
-
 export function compareText(
   textToMatch: string | boolean | null,
   textToCompare?: string | boolean | null,
   matchText?: string | null,
   nonMatchText?: string | null
 ) {
-  // textToMatch is required, so early return no match
+  // textToMatch is required, so early return non-match
   if (textToCompare === undefined) {
     return nonMatchText;
   }
 
   return textToCompare === textToMatch
     ? matchText
-    : // return textToCompare only if undefined nonMatchText to allow null nonMatchText
+    : // return textToCompare only with undefined nonMatchText to allow null nonMatchText
     nonMatchText !== undefined
     ? nonMatchText
     : textToCompare;
+}
+
+export function otherSpecify(
+  textToCompare?: string | null,
+  matchText?: string | null,
+  nonMatchText?: string | null
+) {
+  return compareText("Other, specify", textToCompare, matchText, nonMatchText);
 }

--- a/services/ui-src/src/utils/text/compareText.ts
+++ b/services/ui-src/src/utils/text/compareText.ts
@@ -1,0 +1,26 @@
+export function otherSpecify(
+  textToCompare?: string | null,
+  matchText?: string | null,
+  nonMatchText?: string | null
+) {
+  return compareText("Other, specify", textToCompare, matchText, nonMatchText);
+}
+
+export function compareText(
+  textToMatch: string | boolean | null,
+  textToCompare?: string | boolean | null,
+  matchText?: string | null,
+  nonMatchText?: string | null
+) {
+  // textToMatch is required, so early return no match
+  if (textToCompare === undefined) {
+    return nonMatchText;
+  }
+
+  return textToCompare === textToMatch
+    ? matchText
+    : // return textToCompare only if undefined nonMatchText to allow null nonMatchText
+    nonMatchText !== undefined
+    ? nonMatchText
+    : textToCompare;
+}

--- a/services/ui-src/src/utils/text/compareText.ts
+++ b/services/ui-src/src/utils/text/compareText.ts
@@ -4,17 +4,11 @@ export function compareText(
   matchText?: string | null,
   nonMatchText?: string | null
 ) {
-  // textToMatch is required, so early return non-match
-  if (textToCompare === undefined) {
-    return nonMatchText;
-  }
-
-  return textToCompare === textToMatch
-    ? matchText
-    : // return textToCompare only with undefined nonMatchText to allow null nonMatchText
-    nonMatchText !== undefined
-    ? nonMatchText
-    : textToCompare;
+  if (textToMatch === textToCompare) return matchText;
+  // Allow null nonMatchText
+  if (nonMatchText !== undefined) return nonMatchText;
+  // nonMatchText undefined
+  return textToCompare;
 }
 
 export function otherSpecify(


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Add `otherSpecify` util because it's a pattern we use often
- Add `compareText` util as what `otherSpecify` uses under the hood
- Limiting this PR to `otherSpecify` uses and a couple of nearby cases where `compareText` seems useful

<!-- ### Related ticket(s) -->
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
<!-- CMDCT- -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. `yarn test` in `ui-src`
2. All previous tests plus new `compareText` tests should pass

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

<!-- --- -->
<!-- ### Pre-merge checklist -->
<!-- Complete the following steps before merging -->

<!-- #### Review -->
<!-- - [ ] Design: This work has been reviewed and approved by design, if necessary -->
<!-- - [ ] Product: This work has been reviewed and approved by product owner, if necessary -->

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
