### PR TITLE
MCPAR ETL for Entities (qualityMeasures)

### DIFF
--- a/services/database/scripts/fix-entities-mcpar-data.js
+++ b/services/database/scripts/fix-entities-mcpar-data.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-console */
 /*
  * Local:
- *    `DYNAMODB_URL="http://localhost:8000" S3_LOCAL_ENDPOINT="http://localhost:4569" node services/database/scripts/fix-entities-mcpar-data.js`
+ *    `DYNAMODB_URL="http://localhost:8000" S3_LOCAL_ENDPOINT="http://localhost:4569" node services/database/scripts/fix-entities-mcpar-data.js` {{state}} {{fieldDataId}}
  *  Branch:
- *    branchPrefix="YOUR BRANCH NAME" node services/database/scripts/fix-entities-mcpar-data.js
+ *    branchPrefix="YOUR BRANCH NAME" node services/database/scripts/fix-entities-mcpar-data.js {{state}} {{fieldDataId}}
  */
 
 const { buildS3Client, getObject, list, putObject } = require("./utils/s3.js");
@@ -13,6 +13,9 @@ const isLocal = !!process.env.DYNAMODB_URL;
 const mcparBucketName = isLocal
   ? "local-mcpar-form"
   : "database-" + process.env.branchPrefix + "-mcpar";
+
+const state = process.argv.slice(2, 3);
+const fieldDataId = process.argv.slice(3);
 
 async function handler() {
   try {
@@ -39,42 +42,26 @@ async function updateS3Items() {
   console.log(`Processing bucket ${mcparBucketName}`);
   const allObjects = await list({
     Bucket: mcparBucketName,
-    Prefix: "fieldData/",
+    Prefix: `fieldData/${state}/${fieldDataId}`,
   });
-  const filteredObjects = filterS3ObjectsById(allObjects);
-  await transformS3Objects(filteredObjects);
+  await transformS3Object(allObjects[0]);
   console.log(
-    `Touched ${filteredObjects.length} objects in bucket ${mcparBucketName}`
+    `Touched ${allObjects.length} objects in bucket ${mcparBucketName}`
   );
 }
 
-function filterS3ObjectsById(bucketObjects) {
-  return bucketObjects.filter((obj) =>
-    [
-      "2dxVLCY92B2LlM8DrHpEzqy4IOt", // pragma: allowlist secret
-      "2e0c9p1wDwKR7VHaC0OoA05ef7M", // pragma: allowlist secret
-      "2iQ4W9olixiQB6SfhaNlDyxPRx1", // pragma: allowlist secret
-      "2q25RuoPYKXf1tuJuVaUm1VHSVP", // pragma: allowlist secret
-      "2nkfD0lAyvuEEU4N4LqQBtcCi5H", // pragma: allowlist secret
-      "2nkg1D1PauC4yW8qGh4pENkjgJi", // pragma: allowlist secret
-    ].contains(obj.Id)
-  );
-}
-
-async function transformS3Objects(objects) {
-  for (const object of objects) {
-    const s3FieldData = await getObject({
-      Key: object.Key,
-      Bucket: mcparBucketName,
-    });
-    fixBadEntityData(s3FieldData);
-    await putObject({
-      Bucket: mcparBucketName,
-      Key: object.Key,
-      Body: JSON.stringify(s3FieldData),
-      ContentType: "application/json",
-    });
-  }
+async function transformS3Object(object) {
+  const s3FieldData = await getObject({
+    Key: object.Key,
+    Bucket: mcparBucketName,
+  });
+  fixBadEntityData(s3FieldData);
+  await putObject({
+    Bucket: mcparBucketName,
+    Key: object.Key,
+    Body: JSON.stringify(s3FieldData),
+    ContentType: "application/json",
+  });
 }
 
 // any matching "qualityMeasures" entities are set to empty arrays

--- a/services/database/scripts/fix-entities-mcpar-data.js
+++ b/services/database/scripts/fix-entities-mcpar-data.js
@@ -1,0 +1,85 @@
+/* eslint-disable no-console */
+/*
+ * Local:
+ *    `DYNAMODB_URL="http://localhost:8000" S3_LOCAL_ENDPOINT="http://localhost:4569" node services/database/scripts/fix-entities-mcpar-data.js`
+ *  Branch:
+ *    branchPrefix="YOUR BRANCH NAME" node services/database/scripts/fix-entities-mcpar-data.js
+ */
+
+const { buildS3Client, getObject, list, putObject } = require("./utils/s3.js");
+
+const isLocal = !!process.env.DYNAMODB_URL;
+
+const mcparBucketName = isLocal
+  ? "local-mcpar-form"
+  : "database-" + process.env.branchPrefix + "-mcpar";
+
+async function handler() {
+  try {
+    console.log("Searching for bad entities in report");
+    await updateS3Items();
+    console.debug("S3 data fix complete");
+
+    return {
+      statusCode: 200,
+      body: "All done!",
+    };
+  } catch (err) {
+    console.error(err);
+    return {
+      statusCode: 500,
+      body: err.message,
+    };
+  }
+}
+
+async function updateS3Items() {
+  buildS3Client();
+
+  console.log(`Processing bucket ${mcparBucketName}`);
+  const allObjects = await list({
+    Bucket: mcparBucketName,
+    Prefix: "fieldData/",
+  });
+  const filteredObjects = filterS3ObjectsById(allObjects);
+  await transformS3Objects(filteredObjects);
+  console.log(
+    `Touched ${filteredObjects.length} objects in bucket ${mcparBucketName}`
+  );
+}
+
+function filterS3ObjectsById(bucketObjects) {
+  return bucketObjects.filter((obj) =>
+    [
+      "2dxVLCY92B2LlM8DrHpEzqy4IOt", // pragma: allowlist secret
+      "2e0c9p1wDwKR7VHaC0OoA05ef7M", // pragma: allowlist secret
+      "2iQ4W9olixiQB6SfhaNlDyxPRx1", // pragma: allowlist secret
+      "2q25RuoPYKXf1tuJuVaUm1VHSVP", // pragma: allowlist secret
+      "2nkfD0lAyvuEEU4N4LqQBtcCi5H", // pragma: allowlist secret
+      "2nkg1D1PauC4yW8qGh4pENkjgJi", // pragma: allowlist secret
+    ].contains(obj.Id)
+  );
+}
+
+async function transformS3Objects(objects) {
+  for (const object of objects) {
+    const s3FieldData = await getObject({
+      Key: object.Key,
+      Bucket: mcparBucketName,
+    });
+    fixBadEntityData(s3FieldData);
+    await putObject({
+      Bucket: mcparBucketName,
+      Key: object.Key,
+      Body: JSON.stringify(s3FieldData),
+      ContentType: "application/json",
+    });
+  }
+}
+
+// any matching "qualityMeasures" entities are set to empty arrays
+function fixBadEntityData(data) {
+  for (const key in data) if (key === "qualityMeasures") data[key] = [];
+}
+
+handler();


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
DataConnect recently reported an issue with six (6) MCPAR reports in the `production` environment that have bad entity data, specifically for the `qualityMeasures` array. If a user has entered and then removed a quality measure entity, that array of objects is supposed to be empty, but these reports still contain an object with a single attribute, `id`

This script receives two (2) parameters: the state and the `fieldDataId` (which were provided to us by DataConnect) and it proceeds to set that `qualityMeasures` attribute to an empty array, as expected.

**NOTE:** This issue has since been fixed, but these reports need to be remediated.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
**To re-create the error, here is what I have done locally:**
- Run `./run local` in a new terminal 
- Run this command on a separate terminal window `DYNAMO_ENDPOINT=http://localhost:8000 dynamodb-admin` to access the DynamoDB database locally
- Create a MCPAR report
- On your `localhost:8001` tab, note the `fieldDataId` for that report

In VSCode, to modify the field data object:
- Navigate to `services/uploads/` on the sidebar
- Select the state you created a report for (e.g. `MN` if you logged in as `stateUser1`)
- Navigate to `fieldData/` and select the object that matches the `fieldDataId` you noted earlier (the one that ends with `*.json._s3rver_object`

Add the following attribute to the JSON blob:

`"qualityMeasures":[{"id":"fake-id"}]`

**To test the script:**
- Open a new terminal window
- Copy your MCR `dev` AWS credentials from CloudTamer, then paste them into that terminal window

Run the following command, replacing the `{{state}}` with your corresponding report state acronym (e.g. MN) and `{{fieldDataId}}` with the ID of the JSON object you have modified

`DYNAMODB_URL="http://localhost:8000" S3_LOCAL_ENDPOINT="http://localhost:4569" node services/database/scripts/fix-entities-mcpar-data.js {{state}} {{fieldDataId}}`

✨ et voilá ✨ 

The following message should pop up on the terminal: 

`Touched 1 objects in bucket local-mcpar-form`
`S3 data fix complete`

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
