### PR TITLE
fix codeowners format

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # Default repo owners
-
--       @BearHanded @jessabean @karla-vm
+*       @BearHanded @jessabean @karla-vm


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
I think our prettier messed up this file. I opened a PR (this one, for example!) and it didn't auto-assign.

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
After merging open a PR and verify the codeowners populate

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
When updating this file in the future, use the `--no-verify` flag on `git commit`!
