### PR TITLE
prevent display of undefined date

### DIFF
--- a/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.tsx
@@ -14,6 +14,8 @@ export const EntityCardBottomSection = ({
       Not answered
     </Text>
   );
+
+  console.log("completed", formattedEntityData?.remediationCompleted);
   switch (entityType) {
     case EntityType.ACCESS_MEASURES:
       return (
@@ -128,9 +130,10 @@ export const EntityCardBottomSection = ({
                   }Remediation date non-compliance was corrected`}
                 </Text>
                 <Text sx={sx.subtext}>
-                  {formattedEntityData?.remediationDate ||
-                  formattedEntityData?.remediationCompleted
-                    ? `${formattedEntityData?.remediationCompleted} ${formattedEntityData?.remediationDate}`
+                  {formattedEntityData?.remediationCompleted
+                    ? `${formattedEntityData?.remediationCompleted} ${
+                        formattedEntityData?.remediationDate ?? ""
+                      }`
                     : printVersion && notAnswered}
                 </Text>
               </Box>

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.tsx
@@ -15,7 +15,6 @@ export const EntityCardBottomSection = ({
     </Text>
   );
 
-  console.log("completed", formattedEntityData?.remediationCompleted);
   switch (entityType) {
     case EntityType.ACCESS_MEASURES:
       return (
@@ -130,11 +129,11 @@ export const EntityCardBottomSection = ({
                   }Remediation date non-compliance was corrected`}
                 </Text>
                 <Text sx={sx.subtext}>
-                  {formattedEntityData?.remediationCompleted
-                    ? `${formattedEntityData?.remediationCompleted} ${
-                        formattedEntityData?.remediationDate ?? ""
-                      }`
-                    : printVersion && notAnswered}
+                  {[
+                    formattedEntityData?.remediationCompleted,
+                    formattedEntityData?.remediationDate,
+                  ].join(" ") ||
+                    (printVersion && notAnswered)}
                 </Text>
               </Box>
             </Flex>


### PR DESCRIPTION
### Description
I noticed that in the `EntityCardBottom` section for `sanctions` the remediation date was displaying regardless of whether it was valid or undefined. This fix only displays the date if it's not undefined.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
no related ticket

---
### How to test
create a MCPAR report, go to /mcpar/plan-level-indicators/sanctions, add a sanction, edit the bottom section, verify that the remediation date displays if `yes` has been selected, otherwise no date (nor `undefined` text) should display

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
