### PR TITLE
cmdct-4380 add or edit in title for modal drawer and drawer report page

### DIFF
--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -1224,7 +1224,7 @@
                 "entityUnfinishedMessage": "Complete the remaining indicators for this access measure by entering details.",
                 "enterEntityDetailsButtonText": "Enter details",
                 "editEntityDetailsButtonText": "Edit details",
-                "drawerTitle": "details for access measure"
+                "drawerTitle": "{{action}} details for access measure"
               },
               "modalForm": {
                 "id": "cam-modal",

--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -3313,7 +3313,7 @@
             "enterEntityDetailsButtonText": "Enter measure results",
             "editEntityDetailsButtonText": "Edit measure results",
             "drawerEyebrowTitle": "D2.VII.9a and D2.VII.9b",
-            "drawerTitle": "plan-level measure results",
+            "drawerTitle": "{{action}} plan-level measure results",
             "drawerNoFormMessage": "No plans added. To enter measure results, add all plans in A: Program Information - Add plans."
           },
           "modalForm": {
@@ -3578,7 +3578,7 @@
             "entityUnfinishedMessage": "Complete the remaining indicators for this plan sanction by selecting “Enter sanction details”.",
             "enterEntityDetailsButtonText": "Enter sanction details",
             "editEntityDetailsButtonText": "Edit sanction details",
-            "drawerTitle": "details for sanction",
+            "drawerTitle": "{{action}} details for sanction",
             "missingEntityMessage": [
               {
                 "type": "p",

--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -1224,7 +1224,7 @@
                 "entityUnfinishedMessage": "Complete the remaining indicators for this access measure by entering details.",
                 "enterEntityDetailsButtonText": "Enter details",
                 "editEntityDetailsButtonText": "Edit details",
-                "drawerTitle": "Add details for access measure"
+                "drawerTitle": "details for access measure"
               },
               "modalForm": {
                 "id": "cam-modal",
@@ -3313,7 +3313,7 @@
             "enterEntityDetailsButtonText": "Enter measure results",
             "editEntityDetailsButtonText": "Edit measure results",
             "drawerEyebrowTitle": "D2.VII.9a and D2.VII.9b",
-            "drawerTitle": "Add plan-level measure results",
+            "drawerTitle": "plan-level measure results",
             "drawerNoFormMessage": "No plans added. To enter measure results, add all plans in A: Program Information - Add plans."
           },
           "modalForm": {
@@ -3578,7 +3578,7 @@
             "entityUnfinishedMessage": "Complete the remaining indicators for this plan sanction by selecting “Enter sanction details”.",
             "enterEntityDetailsButtonText": "Enter sanction details",
             "editEntityDetailsButtonText": "Edit sanction details",
-            "drawerTitle": "Add details for sanction",
+            "drawerTitle": "details for sanction",
             "missingEntityMessage": [
               {
                 "type": "p",

--- a/services/app-api/forms/naaar.json
+++ b/services/app-api/forms/naaar.json
@@ -549,7 +549,7 @@
         "deleteModalTitle": "Are you sure you want to delete this standard?",
         "deleteModalConfirmButtonText": "Yes, delete standard",
         "deleteModalWarning": "Are you sure you want to proceed? You will lose all information entered for this standard in the NAAAR. The method will remain in previously submitted NAAAR reports if applicable.",
-        "drawerTitle": "Add access and network adequacy standard for ",
+        "drawerTitle": "access and network adequacy standard for ",
         "missingEntityMessage": [
           {
             "type": "p",
@@ -1345,7 +1345,7 @@
                       {
                         "id": "yCleNTI4lSJCwNhuq59KmU",
                         "label": "Does not adhere to applicability date"
-                      },                      
+                      },
                       {
                         "id": "mrCzwGVdpvl81r5P0JDTSr",
                         "label": "Other, specify",

--- a/services/app-api/forms/naaar.json
+++ b/services/app-api/forms/naaar.json
@@ -315,7 +315,7 @@
             "deleteModalTitle": "Are you sure you want to delete this analysis method?",
             "deleteModalConfirmButtonText": "Yes, delete method",
             "deleteModalWarning": "Are you sure you want to proceed? You will lose all information entered for this analysis method in the NAAAR. The method will remain in previously submitted NAAAR reports if applicable.",
-            "drawerTitle": "Analysis method: ",
+            "drawerTitle": "Analysis method: {{name}}",
             "missingEntityMessage": [
               {
                 "type": "p",
@@ -549,7 +549,7 @@
         "deleteModalTitle": "Are you sure you want to delete this standard?",
         "deleteModalConfirmButtonText": "Yes, delete standard",
         "deleteModalWarning": "Are you sure you want to proceed? You will lose all information entered for this standard in the NAAAR. The method will remain in previously submitted NAAAR reports if applicable.",
-        "drawerTitle": "access and network adequacy standard for ",
+        "drawerTitle": "{{action}} access and network adequacy standard for {{name}}",
         "missingEntityMessage": [
           {
             "type": "p",

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -222,7 +222,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
       selectedEntity?.custom_analysis_method_name ||
       "Add other";
     if (isReportingOnStandards && report) {
-      addOrEdit = selectedEntity ? "Edit " : "Add ";
+      addOrEdit = selectedEntity ? "Edit" : "Add";
       name = report?.programName;
     }
     return translate(verbiage.drawerTitle, {

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -215,14 +215,16 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
   };
 
   const getDrawerTitle = () => {
+    let addOrEdit = "";
     let name =
       selectedEntity?.name ||
       selectedEntity?.custom_analysis_method_name ||
       "Add other";
     if (isReportingOnStandards && report) {
+      addOrEdit = selectedEntity ? "Edit " : "Add ";
       name = report?.programName;
     }
-    return `${verbiage.drawerTitle} ${name}`;
+    return `${addOrEdit}${verbiage.drawerTitle} ${name}`;
   };
 
   const displayErrorMessages = () => {

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -34,6 +34,7 @@ import {
   getForm,
   parseCustomHtml,
   setClearedEntriesToDefaultValue,
+  translate,
   useStore,
 } from "utils";
 
@@ -224,7 +225,10 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
       addOrEdit = selectedEntity ? "Edit " : "Add ";
       name = report?.programName;
     }
-    return `${addOrEdit}${verbiage.drawerTitle} ${name}`;
+    return translate(verbiage.drawerTitle, {
+      action: addOrEdit,
+      name,
+    });
   };
 
   const displayErrorMessages = () => {

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
@@ -132,9 +132,6 @@ describe("<ModalDrawerReportPage />", () => {
       const saveAndCloseButton = screen.getByText(saveAndCloseText);
       await userEvent.click(saveAndCloseButton);
       expect(mockMcparReportContext.updateReport).toHaveBeenCalledTimes(1);
-
-      await userEvent.click(launchDrawerButton);
-      expect(screen.getByRole("dialog")).toBeVisible();
     });
 
     test("Submit sidedrawer doesn't autosave if no change was made by State User", async () => {

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
@@ -135,7 +135,6 @@ describe("<ModalDrawerReportPage />", () => {
 
       await userEvent.click(launchDrawerButton);
       expect(screen.getByRole("dialog")).toBeVisible();
-      expect(screen.getByText("Edit Mock drawer title")).toBeVisible();
     });
 
     test("Submit sidedrawer doesn't autosave if no change was made by State User", async () => {

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
@@ -119,6 +119,7 @@ describe("<ModalDrawerReportPage />", () => {
       const enterDetailsButton = screen.getByText(enterEntityDetailsButtonText);
       await userEvent.click(enterDetailsButton);
       expect(screen.getByRole("dialog")).toBeVisible();
+      expect(screen.getByText("Add Mock drawer title")).toBeVisible();
     });
 
     test("ModalDrawerReportPage sidedrawer opens and saves for state user", async () => {
@@ -131,6 +132,10 @@ describe("<ModalDrawerReportPage />", () => {
       const saveAndCloseButton = screen.getByText(saveAndCloseText);
       await userEvent.click(saveAndCloseButton);
       expect(mockMcparReportContext.updateReport).toHaveBeenCalledTimes(1);
+
+      await userEvent.click(launchDrawerButton);
+      expect(screen.getByRole("dialog")).toBeVisible();
+      expect(screen.getByText("Edit Mock drawer title")).toBeVisible();
     });
 
     test("Submit sidedrawer doesn't autosave if no change was made by State User", async () => {

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -51,6 +51,13 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
     undefined
   );
 
+  const formattedEntityData = getFormattedEntityData(
+    entityType,
+    selectedEntity,
+    report?.fieldData
+  );
+  const addEditDrawerText = formattedEntityData.assessmentDate ? "Edit" : "Add";
+  const addEditDrawerTitle = addEditDrawerText + verbiage.drawerTitle;
   const { updateReport } = useContext(ReportContext);
   const reportFieldDataEntities = report?.fieldData[entityType] || [];
 
@@ -258,6 +265,7 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
           selectedEntity={selectedEntity!}
           verbiage={{
             ...verbiage,
+            drawerTitle: addEditDrawerTitle,
             drawerDetails: getFormattedEntityData(
               entityType,
               selectedEntity,

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -36,6 +36,7 @@ import {
   resetClearProp,
   parseCustomHtml,
   useBreakpoint,
+  getAddEditDrawerText,
 } from "utils";
 // assets
 import addIcon from "assets/icons/icon_add.png";
@@ -57,28 +58,6 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
     report?.fieldData
   );
 
-  let addEditDrawerText = "Add ";
-  switch (entityType) {
-    case EntityType.ACCESS_MEASURES:
-      if (formattedEntityData.provider) {
-        addEditDrawerText = "Edit ";
-      }
-      break;
-    case EntityType.QUALITY_MEASURES:
-      if (formattedEntityData.perPlanResponses) {
-        addEditDrawerText = "Edit ";
-      }
-      break;
-    case EntityType.SANCTIONS:
-      if (formattedEntityData.assessmentDate) {
-        addEditDrawerText = "Edit ";
-      }
-      break;
-    default:
-      break;
-  }
-
-  const addEditDrawerTitle = addEditDrawerText + verbiage.drawerTitle;
   const { updateReport } = useContext(ReportContext);
   const reportFieldDataEntities = report?.fieldData[entityType] || [];
 
@@ -286,7 +265,11 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
           selectedEntity={selectedEntity!}
           verbiage={{
             ...verbiage,
-            drawerTitle: addEditDrawerTitle,
+            drawerTitle: getAddEditDrawerText(
+              entityType,
+              formattedEntityData,
+              verbiage
+            ),
             drawerDetails: getFormattedEntityData(
               entityType,
               selectedEntity,

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -56,7 +56,28 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
     selectedEntity,
     report?.fieldData
   );
-  const addEditDrawerText = formattedEntityData.assessmentDate ? "Edit" : "Add";
+
+  let addEditDrawerText = "Add ";
+  switch (entityType) {
+    case EntityType.ACCESS_MEASURES:
+      if (formattedEntityData.provider) {
+        addEditDrawerText = "Edit ";
+      }
+      break;
+    case EntityType.QUALITY_MEASURES:
+      if (formattedEntityData.perPlanResponses) {
+        addEditDrawerText = "Edit ";
+      }
+      break;
+    case EntityType.SANCTIONS:
+      if (formattedEntityData.assessmentDate) {
+        addEditDrawerText = "Edit ";
+      }
+      break;
+    default:
+      break;
+  }
+
   const addEditDrawerTitle = addEditDrawerText + verbiage.drawerTitle;
   const { updateReport } = useContext(ReportContext);
   const reportFieldDataEntities = report?.fieldData[entityType] || [];

--- a/services/ui-src/src/utils/reports/entities.test.ts
+++ b/services/ui-src/src/utils/reports/entities.test.ts
@@ -1,4 +1,4 @@
-import { getFormattedEntityData } from "./entities";
+import { getAddEditDrawerText, getFormattedEntityData } from "./entities";
 import { EntityType } from "types";
 import {
   mockAccessMeasuresEntity,
@@ -12,6 +12,7 @@ import {
   mockReportFieldData,
   mockQualityMeasuresEntityMissingDetails,
   mockQualityMeasuresFormattedEntityDataMissingDetails,
+  mockModalDrawerReportPageVerbiage,
 } from "utils/testing/setupJest";
 
 describe("Test getFormattedEntityData", () => {
@@ -70,5 +71,43 @@ describe("Test getFormattedEntityData", () => {
       mockReportFieldData
     );
     expect(entityData).toEqual({});
+  });
+});
+
+describe("Test getFormattedEntityData", () => {
+  test("returns 'Add' when no conditions are met", () => {
+    const result = getAddEditDrawerText(
+      EntityType.ACCESS_MEASURES,
+      { provider: false },
+      mockModalDrawerReportPageVerbiage
+    );
+    expect(result).toBe("Add Mock drawer title");
+  });
+
+  test("returns 'Edit' when provider exists for ACCESS_MEASURES", () => {
+    const result = getAddEditDrawerText(
+      EntityType.ACCESS_MEASURES,
+      { provider: true },
+      mockModalDrawerReportPageVerbiage
+    );
+    expect(result).toBe("Edit Mock drawer title");
+  });
+
+  test("returns 'Edit' when perPlanResponses exists for QUALITY_MEASURES", () => {
+    const result = getAddEditDrawerText(
+      EntityType.QUALITY_MEASURES,
+      { perPlanResponses: true },
+      mockModalDrawerReportPageVerbiage
+    );
+    expect(result).toBe("Edit Mock drawer title");
+  });
+
+  test("returns 'Edit' when assessmentDate exists for SANCTIONS", () => {
+    const result = getAddEditDrawerText(
+      EntityType.SANCTIONS,
+      { assessmentDate: true },
+      mockModalDrawerReportPageVerbiage
+    );
+    expect(result).toBe("Edit Mock drawer title");
   });
 });

--- a/services/ui-src/src/utils/reports/entities.test.ts
+++ b/services/ui-src/src/utils/reports/entities.test.ts
@@ -96,7 +96,7 @@ describe("Test getFormattedEntityData", () => {
   test("returns 'Edit' when perPlanResponses exists for QUALITY_MEASURES", () => {
     const result = getAddEditDrawerText(
       EntityType.QUALITY_MEASURES,
-      { perPlanResponses: true },
+      { perPlanResponses: [{ name: "plan 1", response: "n/a" }] },
       mockModalDrawerReportPageVerbiage
     );
     expect(result).toBe("Edit Mock drawer title");

--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -1,6 +1,11 @@
 // utils
-import { AnyObject, EntityShape, EntityType } from "types";
-import { compareText, maskResponseData, otherSpecify } from "utils";
+import {
+  AnyObject,
+  EntityShape,
+  EntityType,
+  ModalDrawerReportPageVerbiage,
+} from "types";
+import { compareText, maskResponseData, otherSpecify, translate } from "utils";
 
 const getRadioValue = (entity: EntityShape | undefined, label: string) => {
   return otherSpecify(
@@ -113,3 +118,31 @@ export const entityWasUpdated = (
   originalEntity: EntityShape,
   newEntity: AnyObject
 ) => JSON.stringify(originalEntity) !== JSON.stringify(newEntity);
+
+export const getAddEditDrawerText = (
+  entityType: EntityType,
+  formattedEntityData: AnyObject,
+  verbiage: ModalDrawerReportPageVerbiage
+) => {
+  let addEditDrawerText = "Add";
+  switch (entityType) {
+    case EntityType.ACCESS_MEASURES:
+      if (formattedEntityData.provider) {
+        addEditDrawerText = "Edit";
+      }
+      break;
+    case EntityType.QUALITY_MEASURES:
+      if (formattedEntityData.perPlanResponses) {
+        addEditDrawerText = "Edit";
+      }
+      break;
+    case EntityType.SANCTIONS:
+      if (formattedEntityData.assessmentDate) {
+        addEditDrawerText = "Edit";
+      }
+      break;
+    default:
+      break;
+  }
+  return translate(verbiage.drawerTitle, { action: addEditDrawerText });
+};

--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -132,7 +132,7 @@ export const getAddEditDrawerText = (
       }
       break;
     case EntityType.QUALITY_MEASURES:
-      if (formattedEntityData.perPlanResponses) {
+      if (formattedEntityData.perPlanResponses[0].response) {
         addEditDrawerText = "Edit";
       }
       break;

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -586,7 +586,7 @@ export const mockModalDrawerReportPageVerbiage = {
   entityUnfinishedMessage: "Mock entity unfinished messsage",
   enterEntityDetailsButtonText: "Mock enter entity details button text",
   editEntityDetailsButtonText: "Mock edit entity details button text",
-  drawerTitle: "Mock drawer title",
+  drawerTitle: "{{action}} Mock drawer title",
   drawerNoFormMessage: "Mock no form fields here",
   tableHeader: "Mock table header",
 };


### PR DESCRIPTION
### Description
`Add` in the title of Modal Drawers and Drawer Reports was hardcoded so it was potentially confusing for users when editing an existing entity. New modal drawers and drawer reports should display `Add` in the title, while existing entities should display `Edit`.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4380

---
### How to test

MCPAR - adding/edit Access Measures, Quality Measures, Sanctions
NAAAR - Adding/editing Standards


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
