### PR TITLE
Fix choicelist checkbox bug

### DIFF
--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -179,7 +179,7 @@ export const ChoiceListField = ({
   const onChangeHandler = (event: InputChangeEvent) => {
     const clickedOption = { key: event.target.id, value: event.target.value };
     const isOptionChecked = event.target.checked;
-    let selectedOptions = displayValue || [];
+    let selectedOptions = [];
 
     // handle radio
     if (type === "radio") {
@@ -189,11 +189,13 @@ export const ChoiceListField = ({
       );
       clearUncheckedNestedFields(everyOtherOption);
     }
+
     // handle checkbox
     if (type === "checkbox") {
+      selectedOptions = [...(form.getValues(name) || displayValue || [])];
+
       if (isOptionChecked) {
-        // using selectedOptions.push() here was causing tests to fail
-        selectedOptions = [...selectedOptions, clickedOption];
+        selectedOptions.push(clickedOption);
       } else {
         selectedOptions = selectedOptions.filter(
           (field) => field.key !== clickedOption.key

--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -179,7 +179,7 @@ export const ChoiceListField = ({
   const onChangeHandler = (event: InputChangeEvent) => {
     const clickedOption = { key: event.target.id, value: event.target.value };
     const isOptionChecked = event.target.checked;
-    let selectedOptions = [];
+    let selectedOptions = displayValue || [];
 
     // handle radio
     if (type === "radio") {
@@ -189,13 +189,11 @@ export const ChoiceListField = ({
       );
       clearUncheckedNestedFields(everyOtherOption);
     }
-
     // handle checkbox
     if (type === "checkbox") {
-      selectedOptions = [...(form.getValues(name) || [])];
-
       if (isOptionChecked) {
-        selectedOptions.push(clickedOption);
+        // using selectedOptions.push() here was causing tests to fail
+        selectedOptions = [...selectedOptions, clickedOption];
       } else {
         selectedOptions = selectedOptions.filter(
           (field) => field.key !== clickedOption.key


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
`form.getValues()` works best for the plan compliance overlay page
`displayValue` works best for the Provider Type Coverage checkbox list page

Guess we're using both!

`form.getValues()` is undefined on the first render, but matches `displayValue` after that. Adding `displayValue` gives us reliable behavior on standard pages, while `form.getValues()` gives us reliable behavior in overlays. More info in the How to test section.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4453

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
#### Provider Type Choices bug:
See it fail in [MCR Dev](https://mdctmcrdev.cms.gov/):
- Log in as a state user
- Create a new NAAAR report
- Check multiple Provider Type Coverage boxes
- Click on another page in the sidebar
- Go back to Provider Type Coverage and uncheck a box
- Notice all the boxes uncheck (if it doesn't happen right away, try it a few times, checking and unchecking various boxes)

See it work in local or [deployed env](https://d1svwqhsmil4sz.cloudfront.net/):
- Repeat the above steps and verify the checkboxes behave as expected

#### Provide plan compliance details for 438.206 bug (already fixed. Ensure no degradation):
See it work in local or [deployed env](https://d1svwqhsmil4sz.cloudfront.net/):
1. Run MCR
2. Create a NAAAR
3. Add a plan and provider type coverage
4. Go to `III. Plan compliance`
5. Select `Enter` for plan dashboard
6. Select `No, the plan does not comply on all standards based on all analyses and/or exceptions granted` for `Assurance of plan compliance for 438.206`
7. Select `Enter` for `Provide plan compliance details for 438.206`, checkmark should be red
8. Add compliance details, form should validate and save
9. On plan dashboard, `Provide plan compliance details for 438.206` checkmark should be green
10. Re-enter the compliance details page and verify all the checkboxes you selected are checked


#### Check for degradation in MCPAR:
- Encounter Data Report pages in Sections B and C have checkbox lists
- Section C -> Availability and Accessibility -> Access Measures has a drawer with a checkbox list


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
What happens if we have a standard page like Provider Type Coverage but with a set of choice lists with a shared groupId like we see in plan compliance details?

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment