### PR TITLE
Render NAAAR standards in a table in export view

### DIFF
--- a/services/app-api/utils/types/other.ts
+++ b/services/app-api/utils/types/other.ts
@@ -128,8 +128,9 @@ export enum PageTypes {
   REVIEW_SUBMIT = "reviewSubmit",
 }
 
-export interface ScreenReaderOnlyHeaderName {
+export interface ScreenReaderCustomHeaderName {
   hiddenName: string;
+  name?: string;
 }
 
 export interface SortableHeadRow {
@@ -145,7 +146,7 @@ export interface SortableHeadRow {
 
 export interface TableContentShape {
   caption?: string;
-  headRow?: Array<string | ScreenReaderOnlyHeaderName>;
+  headRow?: Array<string | ScreenReaderCustomHeaderName>;
   sortableHeadRow?: SortableHeadRow;
   bodyRows?: string[][];
 }

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -6,7 +6,7 @@ import {
   State,
   CompletionData,
   EntityType,
-  ScreenReaderOnlyHeaderName,
+  ScreenReaderCustomHeaderName,
   TableContentShape,
 } from "./index";
 
@@ -96,7 +96,7 @@ export interface EntityDetailsMultiformShape {
   table?: {
     caption: string;
     bodyRows: string[][];
-    headRow: Array<string | ScreenReaderOnlyHeaderName>;
+    headRow: Array<string | ScreenReaderCustomHeaderName>;
   };
   verbiage?: EntityDetailsMultiformVerbiage;
 }

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 // components
 import {
   ExportedModalOverlayReportSection,
@@ -208,38 +208,54 @@ describe("<ExportedModalOverlayReportSection />", () => {
 
     test("Should render data correctly for naaar", async () => {
       mockedUseStore.mockReturnValue(mockNaaarReportStore);
-      const { container, findByText } = render(exportedNaaarStandardsComponent);
+      render(exportedNaaarStandardsComponent);
 
       // All table headers are present
-      expect(container.querySelectorAll("th").length).toBe(7);
+      expect(screen.getAllByRole("columnheader").length).toBe(7);
 
       // Every entity has a row (+1 for header)
-      expect(container.querySelectorAll("tr").length).toBe(
-        mockNaaarReportStore.report?.fieldData.standards.length + 1
+      const tbody = screen.getAllByRole("rowgroup")[1];
+      const rows = within(tbody).getAllByRole("row");
+      expect(rows.length).toBe(
+        mockNaaarReportStore.report?.fieldData.standards.length
       );
 
       // index
-      expect(await findByText("1")).toBeVisible();
+      expect(screen.getByRole("gridcell", { name: "1" })).toBeVisible();
 
       // provider type
       expect(
-        await findByText("Mock Provider; mock provider details")
+        screen.getByRole("gridcell", {
+          name: "Mock Provider; mock provider details",
+        })
       ).toBeVisible();
 
       // standard type
-      expect(await findByText("mock standard type")).toBeVisible();
+      expect(
+        screen.getByRole("gridcell", { name: "mock standard type" })
+      ).toBeVisible();
 
       // description
-      expect(await findByText("description of standard")).toBeVisible();
+      expect(
+        screen.getByRole("gridcell", { name: "description of standard" })
+      ).toBeVisible();
 
       // analysis methods, joined with a comma
-      expect(await findByText("Mock am 1, Mock am 2, Mock am 3")).toBeVisible();
+      expect(
+        screen.getByRole("gridcell", {
+          name: "Mock am 1, Mock am 2, Mock am 3",
+        })
+      ).toBeVisible();
 
       // population
-      expect(await findByText("Mock population")).toBeVisible();
+      expect(
+        screen.getByRole("gridcell", { name: "Mock population" })
+      ).toBeVisible();
 
       // region
-      expect(await findByText("Mock region")).toBeVisible();
+      expect(
+        screen.getByRole("gridcell", { name: "Mock region" })
+      ).toBeVisible();
     });
 
     test("Should render message for naaar with no standards", async () => {
@@ -248,17 +264,17 @@ describe("<ExportedModalOverlayReportSection />", () => {
       };
       mockEmptyStandardsNaaarStore.report!.fieldData.standards = undefined;
       mockedUseStore.mockReturnValue(mockEmptyStandardsNaaarStore);
-      const { container, findByText } = render(exportedNaaarStandardsComponent);
+      render(exportedNaaarStandardsComponent);
 
       // No table renders
-      expect(container.querySelectorAll("table").length).toBe(0);
+      expect(screen.queryByRole("table")).toBeNull();
 
       // region
       expect(
-        await findByText(
-          "Standard total count: 0 - No access standards entered"
-        )
-      ).toBeVisible();
+        screen.getByTestId("exportedModalOverlayReportSection")
+      ).toHaveTextContent(
+        "Standard total count: 0 - No access standards entered"
+      );
     });
 
     test('Should render "other" explanations if they are filled.', async () => {

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
@@ -242,6 +242,25 @@ describe("<ExportedModalOverlayReportSection />", () => {
       expect(await findByText("Mock region")).toBeVisible();
     });
 
+    test("Should render message for naaar with no standards", async () => {
+      const mockEmptyStandardsNaaarStore = {
+        ...mockNaaarReportStore,
+      };
+      mockEmptyStandardsNaaarStore.report!.fieldData.standards = undefined;
+      mockedUseStore.mockReturnValue(mockEmptyStandardsNaaarStore);
+      const { container, findByText } = render(exportedNaaarStandardsComponent);
+
+      // No table renders
+      expect(container.querySelectorAll("table").length).toBe(0);
+
+      // region
+      expect(
+        await findByText(
+          "Standard total count: 0 - No access standards entered"
+        )
+      ).toBeVisible();
+    });
+
     test('Should render "other" explanations if they are filled.', async () => {
       mockReportContextOther.report.fieldData.program = [mockMlrProgramOther];
 

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -33,22 +33,20 @@ export const ExportedModalOverlayReportSection = ({ section }: Props) => {
 
   const verbiage = exportVerbiageMap[report?.reportType as ReportType];
 
-  const { emptyEntityMessage, modalOverlayTableHeaders } = verbiage;
+  const { modalOverlayTableHeaders } = verbiage;
 
   const headerLabels = Object.values(
     modalOverlayTableHeaders as Record<string, string>
   );
 
-  const countDisplayText =
-    entityCount > 0
-      ? entityCount
-      : emptyEntityMessage[entityType as keyof typeof emptyEntityMessage];
-
   return (
-    <Box>
+    <Box data-testid="exportedModalOverlayReportSection">
       {entityType === EntityType.STANDARDS && (
-        <Text as="span" sx={sx.standardCount} data-testid="entityMessage">
-          Standard total count: {countDisplayText}
+        <Text sx={sx.standardCount}>
+          Standard total count:{" "}
+          {entityCount > 0
+            ? entityCount
+            : verbiage.emptyEntityMessage[entityType]}
         </Text>
       )}
       <Table

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -49,22 +49,26 @@ export const ExportedModalOverlayReportSection = ({ section }: Props) => {
             : verbiage.emptyEntityMessage[entityType]}
         </Text>
       )}
-      <Table
-        sx={sx.root}
-        content={{
-          caption: "Reporting Overview",
-          headRow: headerLabels,
-        }}
-        data-testid="exportTable"
-      >
-        {entities &&
-          renderModalOverlayTableBody(
-            report?.reportType as ReportType,
-            entities
+      {entityType === EntityType.STANDARDS && !entityCount ? null : (
+        <>
+          <Table
+            sx={sx.root}
+            content={{
+              caption: "Reporting Overview",
+              headRow: headerLabels,
+            }}
+            data-testid="exportTable"
+          >
+            {entities &&
+              renderModalOverlayTableBody(
+                report?.reportType as ReportType,
+                entities
+              )}
+          </Table>
+          {(!entities || entityCount === 0) && (
+            <Text sx={sx.emptyState}> No entities found.</Text>
           )}
-      </Table>
-      {(!entities || entityCount === 0) && (
-        <Text sx={sx.emptyState}> No entities found.</Text>
+        </>
       )}
     </Box>
   );
@@ -131,6 +135,7 @@ export function renderModalOverlayTableBody(
         );
       });
     case ReportType.NAAAR:
+      // render pattern for NAAAR Standards
       return entities.map((entity, idx) => {
         const {
           provider,

--- a/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
@@ -9,8 +9,16 @@ import {
   mockNestedReportPageJson,
   mockStandardReportPageJson,
   mockMcparReportContext,
+  mockNaaarReportContext,
+  mockNaaarStandardsPageJson,
+  mockNaaarReportStore,
+  mockMcparReportStore,
 } from "utils/testing/setupJest";
 import { testA11y } from "utils/testing/commonTests";
+import { useStore } from "utils";
+
+jest.mock("utils/state/useStore");
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 
 const exportedStandardReportWrapperComponent = (
   <ReportContext.Provider value={mockMcparReportContext}>
@@ -42,7 +50,16 @@ const exportedModalDrawerReportWrapperComponent = (
   </ReportContext.Provider>
 );
 
+const standardEntityReportWrapperComponent = (
+  <ReportContext.Provider value={mockNaaarReportContext}>
+    <ExportedReportWrapper section={mockNaaarStandardsPageJson} />
+  </ReportContext.Provider>
+);
+
 describe("<ExportedReportWrapper />", () => {
+  beforeEach(() => {
+    mockedUseStore.mockReturnValue(mockMcparReportStore);
+  });
   test("ExportedStandardReportSection renders", () => {
     render(exportedStandardReportWrapperComponent);
     expect(
@@ -75,6 +92,15 @@ describe("<ExportedReportWrapper />", () => {
     render(exportedModalDrawerReportWrapperComponent);
     expect(
       screen.getByTestId("exportedModalDrawerReportSection")
+    ).toBeInTheDocument();
+  });
+
+  // this is a drawer page in the normal report, but we use a different page for the pdf
+  test("Standards Entity renders ModalOverlay page in export", () => {
+    mockedUseStore.mockReturnValue(mockNaaarReportStore);
+    render(standardEntityReportWrapperComponent);
+    expect(
+      screen.getByTestId("exportedModalOverlayReportSection")
     ).toBeInTheDocument();
   });
 

--- a/services/ui-src/src/components/export/ExportedReportWrapper.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.tsx
@@ -31,11 +31,9 @@ export const ExportedReportWrapper = ({ section }: Props) => {
       // standards uses the table pattern from the modal overlay component
       if (section.entityType === EntityType.STANDARDS) {
         return (
-          <>
-            <ExportedModalOverlayReportSection
-              section={section as ModalOverlayReportPageShape}
-            />
-          </>
+          <ExportedModalOverlayReportSection
+            section={section as ModalOverlayReportPageShape}
+          />
         );
       }
       return (

--- a/services/ui-src/src/components/export/ExportedReportWrapper.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.tsx
@@ -9,6 +9,7 @@ import {
 // types
 import {
   DrawerReportPageShape,
+  EntityType,
   ModalDrawerReportPageShape,
   ModalOverlayReportPageShape,
   PageTypes,
@@ -27,6 +28,16 @@ export const ExportedReportWrapper = ({ section }: Props) => {
         </Box>
       );
     case PageTypes.DRAWER:
+      // standards uses the table pattern from the modal overlay component
+      if (section.entityType === EntityType.STANDARDS) {
+        return (
+          <>
+            <ExportedModalOverlayReportSection
+              section={section as ModalOverlayReportPageShape}
+            />
+          </>
+        );
+      }
       return (
         <Box data-testid="exportedDrawerReportSection" mt="2rem">
           <ExportedReportFieldTable

--- a/services/ui-src/src/components/overlays/EntityDetailsMultiformOverlay.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsMultiformOverlay.tsx
@@ -37,7 +37,7 @@ import {
   EntityShape,
   EntityType,
   ReportShape,
-  ScreenReaderOnlyHeaderName,
+  ScreenReaderCustomHeaderName,
 } from "types";
 // utils
 import { translateVerbiage } from "utils";
@@ -314,7 +314,7 @@ export const EntityDetailsMultiformOverlay = ({
       text,
     }: {
       formId: string;
-      header?: string | ScreenReaderOnlyHeaderName;
+      header?: string | ScreenReaderCustomHeaderName;
       text: string;
     }) => {
       const headerName =

--- a/services/ui-src/src/components/overlays/PlanComplianceTableOverlay.tsx
+++ b/services/ui-src/src/components/overlays/PlanComplianceTableOverlay.tsx
@@ -22,7 +22,7 @@ import {
   EntityDetailsTableContentShape,
   EntityShape,
   FormJson,
-  ScreenReaderOnlyHeaderName,
+  ScreenReaderCustomHeaderName,
 } from "types";
 import { NaaarStandardsTableShape } from "components/tables/SortableNaaarStandardsTable";
 // utils
@@ -59,7 +59,7 @@ export const PlanComplianceTableOverlay = ({
     const closeEntityDetailsFormOverlay = () => {
       setSelectedStandard(null);
     };
-    let headRow = [] as ScreenReaderOnlyHeaderName[];
+    let headRow = [] as ScreenReaderCustomHeaderName[];
     const bodyRows = [];
     let formJson = structuredClone(form);
 

--- a/services/ui-src/src/components/tables/Table.tsx
+++ b/services/ui-src/src/components/tables/Table.tsx
@@ -13,7 +13,7 @@ import {
 // types
 import {
   AnyObject,
-  ScreenReaderOnlyHeaderName,
+  ScreenReaderCustomHeaderName,
   TableContentShape,
 } from "types";
 // utils
@@ -43,7 +43,7 @@ export const Table = ({
           <Tr>
             {content.headRow.map(
               (
-                headerCell: string | ScreenReaderOnlyHeaderName,
+                headerCell: string | ScreenReaderCustomHeaderName,
                 index: number
               ) => (
                 <Th
@@ -52,9 +52,12 @@ export const Table = ({
                   sx={{ ...sx.tableHeader, ...sxOverride }}
                 >
                   {typeof headerCell === "object" ? (
-                    <VisuallyHidden>
-                      {sanitizeAndParseHtml(headerCell.hiddenName)}
-                    </VisuallyHidden>
+                    <>
+                      <VisuallyHidden>
+                        {sanitizeAndParseHtml(headerCell.hiddenName)}
+                      </VisuallyHidden>
+                      {headerCell?.name ? headerCell.name : null}
+                    </>
                   ) : (
                     sanitizeAndParseHtml(headerCell)
                   )}

--- a/services/ui-src/src/types/other.ts
+++ b/services/ui-src/src/types/other.ts
@@ -59,8 +59,9 @@ export enum PageTypes {
 
 export interface InputChangeEvent extends React.ChangeEvent<HTMLInputElement> {}
 
-export interface ScreenReaderOnlyHeaderName {
+export interface ScreenReaderCustomHeaderName {
   hiddenName: string;
+  name?: string;
 }
 
 export interface SortableHeadRow {
@@ -76,7 +77,7 @@ export interface SortableHeadRow {
 
 export interface TableContentShape {
   caption?: string;
-  headRow?: Array<string | ScreenReaderOnlyHeaderName>;
+  headRow?: Array<string | ScreenReaderCustomHeaderName>;
   sortableHeadRow?: SortableHeadRow;
   bodyRows?: string[][];
 }

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -5,7 +5,7 @@ import {
   CustomHtmlElement,
   EntityType,
   FormJson,
-  ScreenReaderOnlyHeaderName,
+  ScreenReaderCustomHeaderName,
   SortableHeadRow,
   State,
   TableContentShape,
@@ -97,7 +97,7 @@ export interface EntityDetailsMultiformShape {
   table?: {
     caption: string;
     bodyRows: string[][];
-    headRow: Array<string | ScreenReaderOnlyHeaderName>;
+    headRow: Array<string | ScreenReaderCustomHeaderName>;
   };
   verbiage?: EntityDetailsMultiformVerbiage;
 }

--- a/services/ui-src/src/utils/testing/mockReport.tsx
+++ b/services/ui-src/src/utils/testing/mockReport.tsx
@@ -382,6 +382,52 @@ export const mockNaaarReportFieldData = {
       name: "provider2",
     },
   ],
+  standards: [
+    {
+      id: "mockId",
+      standard_coreProviderTypeCoveredByStandard: [
+        {
+          key: "standard_coreProviderTypeCoveredByStandard-mock-1",
+          value: "Mock Provider",
+        },
+      ],
+      standard_standardType: [
+        {
+          key: "standard_standardType-mock-1",
+          value: "mock standard type",
+        },
+      ],
+      standard_populationCoveredByStandard: [
+        {
+          key: "standard_populationCoveredByStandard-mock-1",
+          value: "Mock population",
+        },
+      ],
+      standard_applicableRegion: [
+        {
+          key: "standard_applicableRegion-mock-1",
+          value: "Mock region",
+        },
+      ],
+      "standard_coreProviderTypeCoveredByStandard-mock-1-otherText":
+        "mock provider details",
+      "standard_standardDescription-mock-1": "description of standard",
+      "standard_analysisMethodsUtilized-mock-1": [
+        {
+          key: "standard_analysisMethodsUtilized-mock-1",
+          value: "Mock am 1",
+        },
+        {
+          key: "standard_analysisMethodsUtilized-mock-2",
+          value: "Mock am 2",
+        },
+        {
+          key: "standard_analysisMethodsUtilized-mock-3",
+          value: "Mock am 3",
+        },
+      ],
+    },
+  ],
 };
 
 export const mockMcparReport = {

--- a/services/ui-src/src/verbiage/pages/naaar/naaar-export.ts
+++ b/services/ui-src/src/verbiage/pages/naaar/naaar-export.ts
@@ -22,4 +22,19 @@ export default {
     indicator: "Indicator",
     response: "Response",
   },
+  modalOverlayTableHeaders: {
+    index: "#",
+    provider: "Provider",
+    standardType: "Standard type",
+    standardDescription: "Standard description",
+    analysisMethods: "Analysis methods",
+    population: {
+      name: "Pop.",
+      hiddenName: "Population",
+    },
+    region: "Region",
+  },
+  emptyEntityMessage: {
+    standards: "0 - No access standards entered",
+  },
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
I added comments to explain the key code changes. If you review by commit you'll see the core changes in the first commit, and some type updates and tests in the rest.

- Add custom branch to render standards page using modal overlay export page type (it's the closest to what we wanted)
  - The standards page is a `drawer` page type. What do you think of this? Is it ok to render another page type for the export page logically? I thought it would save us lines of code and be more reusable. Perhaps our export types don't perfectly align with our form page types?
- Add NAAAR standards logic to `ModalOverlay` export page
- Add display name to screen reader header type and rename
- Add tests

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4464

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Open the [deployed environment](https://d6dq6fzvsiy1v.cloudfront.net/)
- Log in as `stateuser@test.com`
- Go to the existing NAAAR titled "standards"
- Go to the PDF view (Review & Submit -> Review PDF)
- View the standards table and verify it matches the [Figma](https://www.figma.com/design/QcoVlfZ2adUBnzcHiI0G0S/MDCT-MCR-NAAAR?node-id=1356-27373&t=3x4VxLNRMgWtuzKX-4)
- Verify the counter indicates the correct number of standards
- Leave this report and open the NAAAR report titled "no standards"
- Go to the PDF view (Review & Submit -> Review PDF)
- Verify the table indicates its empty, and the counter is set to 0 with a custom message

Bonus:
- Turn on VoiceOver and verify the `Pop.` column header reads out "Population" 

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
I'm not sure what the best way is to color this text mid-line so I left it all black.
Figma:
![Screenshot 2025-04-04 at 11 27 43 AM](https://github.com/user-attachments/assets/b6811903-e121-410c-8ef3-5f412afd11dc)
Deployed instance:
![Screenshot 2025-04-04 at 11 56 21 AM](https://github.com/user-attachments/assets/c66e5f2b-3f60-403c-9792-7e030d0136ce)

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary
---