### PR TITLE
CMDCT-4469 updating the destroy workflow

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -63,6 +63,7 @@ jobs:
         run: |
           ./run destroy --stage $branch_name --verify false --service app-api
           ./run destroy --stage $branch_name --verify false
+          serverless reconcile
 
   # Notify the integrations channel when a destroy action fails
   notify_on_destroy_failure:


### PR DESCRIPTION
### Description
Serverless needs to be prompted to remove stacks that aren't there anymore.

### Related ticket(s)
CMDCT-4469

---
### How to test
I did the test but you have to be using AWS for mcr creds and then `serverless usage` and see the stacks that you've created. Then destroy them using the github action and then do another `serverless usage` and see that they are no longer listed.


### Notes
NA

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
