### PR TITLE
Filter analysis methods in Add Standard view

### DIFF
--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -297,8 +297,9 @@ export const getForm = (params: getFormParams) => {
   const providerTypes = report?.fieldData?.providerTypes?.map(
     (providerType: { name: string }) => providerType
   );
-  const analysisMethods = report?.fieldData?.analysisMethods?.map(
-    (analysisMethod: { name: string }) => analysisMethod
+  const analysisMethodsUsedByPlans = report?.fieldData?.analysisMethods?.filter(
+    (analysisMethod: AnyObject) =>
+      analysisMethod.analysis_method_applicable_plans?.length > 0
   );
   const reportType = report?.reportType;
 
@@ -321,7 +322,7 @@ export const getForm = (params: getFormParams) => {
           EntityType.STANDARDS
         );
         modifiedForm.fields.splice(0, 1, providerTypeFields.fields[0]);
-        generateAnalysisMethodChoices(drawerForm, analysisMethods);
+        generateAnalysisMethodChoices(drawerForm, analysisMethodsUsedByPlans);
       }
       break;
     case ReportType.MCPAR:

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -299,7 +299,8 @@ export const getForm = (params: getFormParams) => {
   );
   const analysisMethodsUsedByPlans = report?.fieldData?.analysisMethods?.filter(
     (analysisMethod: AnyObject) =>
-      analysisMethod.analysis_method_applicable_plans?.length > 0
+      analysisMethod.analysis_applicable?.[0].value === "Yes" ||
+      analysisMethod.custom_analysis_method_name
   );
   const reportType = report?.reportType;
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Filter analysis methods shown when adding standards.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4503

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Create a NAAAR
2. Add a plan
3. Add analysis methods
    1. Select "Yes" for a few, but not all 
    2. Add a custom method
5. Add a standard
    1. Under standard type, "Analysis method(s) utilized to assess compliance for this standard for this program" should only show the analysis methods you selected "Yes" for plus custom methods

<!-- ### Notes -->
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
