### PR TITLE
Plan compliance PDF part 1: Add planOverlay types

### DIFF
--- a/services/app-api/forms/naaar.json
+++ b/services/app-api/forms/naaar.json
@@ -1207,6 +1207,7 @@
               "bodyRows": [
                 ["", "Provide plan compliance details for 438.206", ""]
               ],
+              "caption": "",
               "headRow": [
                 { "hiddenName": "Status" },
                 { "hiddenName": "Report section" },

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -55,7 +55,8 @@ export type ReportRouteWithForm =
   | DrawerReportPageShape
   | ModalDrawerReportPageShape
   | ModalOverlayReportPageShape
-  | OverlayReportPageShape;
+  | OverlayReportPageShape
+  | PlanOverlayReportPageShape;
 
 export interface ReportPageShapeBase extends ReportRouteBase {
   children?: never;
@@ -147,6 +148,39 @@ export interface OverlayReportPageShape extends ReportPageShapeBase {
   };
 }
 
+export interface PlanOverlayReportPageShape extends ReportPageShapeBase {
+  entityType: EntityType;
+  verbiage: PlanOverlayReportPageVerbiage;
+  overlayForm?: never;
+  modalForm?: never;
+  drawerForm?: never;
+  form?: never;
+  details: {
+    childForms: EntityDetailsChildFormShape[];
+    forms: PlanOverlayDetailsMultiformShape[];
+    verbiage: EntityDetailsMultiformVerbiage;
+  };
+}
+
+export interface PlanOverlayDetailsMultiformShape {
+  form: FormJson;
+  table: {
+    caption: string;
+    bodyRows: string[][];
+    headRow: Array<string | ScreenReaderCustomHeaderName>;
+  };
+  verbiage: PlanOverlayMultiformVerbiage;
+}
+
+export interface PlanOverlayMultiformVerbiage extends ReportPageVerbiage {
+  heading: string;
+  hint: string;
+  accordion?: {
+    buttonLabel: string;
+    text: string;
+  };
+}
+
 export interface ReportRouteWithoutForm extends ReportRouteBase {
   children?: ReportRoute[];
   pageType?: string;
@@ -217,6 +251,14 @@ export interface OverlayReportPageVerbiage extends ReportPageVerbiage {
   };
   tableHeader: string;
   emptyDashboardText: string;
+  enterEntityDetailsButtonText: string;
+}
+
+export interface PlanOverlayReportPageVerbiage extends ReportPageVerbiage {
+  requiredMessages: {
+    [key: string]: CustomHtmlElement[] | undefined;
+  };
+  tableHeader: string;
   enterEntityDetailsButtonText: string;
 }
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Add types to match naaar.json for `planOverlay` page type
- Add caption to table object in naaar.json to align with type
- No running code/user-facing changes

These types will be used in following PRs to define the expected shape of the planOverlay page for PDF view

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4467 pt. 1

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Compare type to naaar.json for `planOverlay` page and verify it lines up
  - I've added comments in this PR comparing each part
- All tests pass

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment