### PR TITLE
Plan compliance PDF part 2: Add plan overlay export page

### DIFF
--- a/services/app-api/forms/naaar.json
+++ b/services/app-api/forms/naaar.json
@@ -1207,6 +1207,7 @@
               "bodyRows": [
                 ["", "Provide plan compliance details for 438.206", ""]
               ],
+              "caption": "",
               "headRow": [
                 { "hiddenName": "Status" },
                 { "hiddenName": "Report section" },

--- a/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.test.tsx
+++ b/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.test.tsx
@@ -1,0 +1,26 @@
+import { screen, render } from "@testing-library/react";
+// components
+import { ReportContext } from "components";
+import { ExportedPlanOverlayReportSection } from "./ExportedPlanOverlayReportSection";
+// utils
+import { mockNaaarPlanCompliancePageJson } from "utils/testing/mockForm";
+import { mockNaaarReportContext } from "utils/testing/mockReport";
+import { testA11y } from "utils/testing/commonTests";
+
+const exportedPlanOverlaySectionComponent = (
+  <ReportContext.Provider value={mockNaaarReportContext}>
+    <ExportedPlanOverlayReportSection
+      section={mockNaaarPlanCompliancePageJson}
+    />
+  </ReportContext.Provider>
+);
+
+describe("<ExportedPlanOverlayReportSection />", () => {
+  test("ExportedPlanOverlayReportSection renders", () => {
+    const sectionName = mockNaaarPlanCompliancePageJson.name;
+    render(exportedPlanOverlaySectionComponent);
+    expect(screen.getByText(sectionName)).toBeInTheDocument();
+  });
+
+  testA11y(exportedPlanOverlaySectionComponent);
+});

--- a/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.tsx
@@ -1,12 +1,27 @@
 // components
-import { Box, Text } from "@chakra-ui/react";
+import { Box, Heading, Text } from "@chakra-ui/react";
 // types
-import { PlanOverlayReportPageShape } from "types";
+import { EntityShape, PlanOverlayReportPageShape } from "types";
+// utils
+import { useStore } from "utils";
 
+/*
+ * Designed originally for the plan compliance portion of the NAAAR report
+ * Expected entity is plans
+ */
 export const ExportedPlanOverlayReportSection = ({ section }: Props) => {
+  const { report } = useStore();
+
+  const plans = report?.fieldData?.plans;
+
+  if (!plans) {
+    return null;
+  }
+
   return (
     <Box data-testid="exportedPlanOverlayReportSection">
       <Text>{section.name}</Text>
+      {displayPlansList(plans)}
     </Box>
   );
 };
@@ -14,3 +29,20 @@ export const ExportedPlanOverlayReportSection = ({ section }: Props) => {
 export interface Props {
   section: PlanOverlayReportPageShape;
 }
+
+const displayPlansList = (plans: EntityShape[]) => {
+  return plans.map((plan: EntityShape) => {
+    return (
+      <Heading as="h3" sx={sx.planNameHeading} key={plan.id}>
+        {plan.name}
+      </Heading>
+    );
+  });
+};
+
+const sx = {
+  planNameHeading: {
+    fontSize: "xl",
+    paddingBottom: "1.5rem",
+  },
+};

--- a/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.tsx
@@ -1,0 +1,16 @@
+// components
+import { Box, Text } from "@chakra-ui/react";
+// types
+import { PlanOverlayReportPageShape } from "types";
+
+export const ExportedPlanOverlayReportSection = ({ section }: Props) => {
+  return (
+    <Box data-testid="exportedPlanOverlayReportSection">
+      <Text>{section.name}</Text>
+    </Box>
+  );
+};
+
+export interface Props {
+  section: PlanOverlayReportPageShape;
+}

--- a/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
@@ -13,6 +13,7 @@ import {
   mockNaaarStandardsPageJson,
   mockNaaarReportStore,
   mockMcparReportStore,
+  mockNaaarPlanCompliancePageJson,
 } from "utils/testing/setupJest";
 import { testA11y } from "utils/testing/commonTests";
 import { useStore } from "utils";
@@ -53,6 +54,12 @@ const exportedModalDrawerReportWrapperComponent = (
 const standardEntityReportWrapperComponent = (
   <ReportContext.Provider value={mockNaaarReportContext}>
     <ExportedReportWrapper section={mockNaaarStandardsPageJson} />
+  </ReportContext.Provider>
+);
+
+const exportedPlanOverlayReportWrapperComponent = (
+  <ReportContext.Provider value={mockNaaarReportContext}>
+    <ExportedReportWrapper section={mockNaaarPlanCompliancePageJson} />
   </ReportContext.Provider>
 );
 
@@ -101,6 +108,14 @@ describe("<ExportedReportWrapper />", () => {
     render(standardEntityReportWrapperComponent);
     expect(
       screen.getByTestId("exportedModalOverlayReportSection")
+    ).toBeInTheDocument();
+  });
+
+  test("Standards Entity renders ModalOverlay page in export", () => {
+    mockedUseStore.mockReturnValue(mockNaaarReportStore);
+    render(exportedPlanOverlayReportWrapperComponent);
+    expect(
+      screen.getByTestId("exportedPlanOverlayReportSection")
     ).toBeInTheDocument();
   });
 

--- a/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
@@ -111,7 +111,7 @@ describe("<ExportedReportWrapper />", () => {
     ).toBeInTheDocument();
   });
 
-  test("Standards Entity renders ModalOverlay page in export", () => {
+  test("ExportedPlanOverlayReportSection renders", () => {
     mockedUseStore.mockReturnValue(mockNaaarReportStore);
     render(exportedPlanOverlayReportWrapperComponent);
     expect(

--- a/services/ui-src/src/components/export/ExportedReportWrapper.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.tsx
@@ -5,6 +5,7 @@ import {
   ExportedReportFieldTable,
   ExportedEntityDetailsOverlaySection,
   ExportedModalOverlayReportSection,
+  ExportedPlanOverlayReportSection,
 } from "components";
 // types
 import {
@@ -13,6 +14,7 @@ import {
   ModalDrawerReportPageShape,
   ModalOverlayReportPageShape,
   PageTypes,
+  PlanOverlayReportPageShape,
   ReportRouteWithForm,
   StandardReportPageShape,
 } from "types";
@@ -61,7 +63,11 @@ export const ExportedReportWrapper = ({ section }: Props) => {
         </>
       );
     case PageTypes.PLAN_OVERLAY:
-      return <></>;
+      return (
+        <ExportedPlanOverlayReportSection
+          section={section as PlanOverlayReportPageShape}
+        />
+      );
     default:
       return <></>;
   }

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -47,6 +47,7 @@ export { ExportedModalOverlayReportSection } from "./export/ExportedModalOverlay
 export { ExportedEntityDetailsOverlaySection } from "./export/ExportedEntityDetailsOverlaySection";
 export { ExportedEntityDetailsTable } from "./export/ExportedEntityDetailsTable";
 export { ExportedEntityDetailsTableRow } from "./export/ExportedEntityDetailsTableRow";
+export { ExportedPlanOverlayReportSection } from "./export/ExportedPlanOverlayReportSection";
 // fields
 export { CheckboxField } from "./fields/CheckboxField";
 export { ChoiceField } from "./fields/ChoiceField";

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -55,7 +55,8 @@ export type ReportRouteWithForm =
   | DrawerReportPageShape
   | ModalDrawerReportPageShape
   | ModalOverlayReportPageShape
-  | OverlayReportPageShape;
+  | OverlayReportPageShape
+  | PlanOverlayReportPageShape;
 
 export interface ReportPageShapeBase extends ReportRouteBase {
   children?: never;
@@ -147,6 +148,39 @@ export interface OverlayReportPageShape extends ReportPageShapeBase {
   };
 }
 
+export interface PlanOverlayReportPageShape extends ReportPageShapeBase {
+  entityType: EntityType;
+  verbiage: PlanOverlayReportPageVerbiage;
+  overlayForm?: never;
+  modalForm?: never;
+  drawerForm?: never;
+  form?: never;
+  details: {
+    childForms: EntityDetailsChildFormShape[];
+    forms: PlanOverlayDetailsMultiformShape[];
+    verbiage: EntityDetailsMultiformVerbiage;
+  };
+}
+
+export interface PlanOverlayDetailsMultiformShape {
+  form: FormJson;
+  table: {
+    caption: string;
+    bodyRows: string[][];
+    headRow: Array<string | ScreenReaderCustomHeaderName>;
+  };
+  verbiage: PlanOverlayMultiformVerbiage;
+}
+
+export interface PlanOverlayMultiformVerbiage extends ReportPageVerbiage {
+  heading: string;
+  hint: string;
+  accordion?: {
+    buttonLabel: string;
+    text: string;
+  };
+}
+
 export interface ReportRouteWithoutForm extends ReportRouteBase {
   children?: ReportRoute[];
   pageType?: string;
@@ -217,6 +251,14 @@ export interface OverlayReportPageVerbiage extends ReportPageVerbiage {
   };
   tableHeader: string;
   emptyDashboardText: string;
+  enterEntityDetailsButtonText: string;
+}
+
+export interface PlanOverlayReportPageVerbiage extends ReportPageVerbiage {
+  requiredMessages: {
+    [key: string]: CustomHtmlElement[] | undefined;
+  };
+  tableHeader: string;
   enterEntityDetailsButtonText: string;
 }
 

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -570,6 +570,92 @@ export const mockNaaarStandardsPageJson = {
   },
 };
 
+export const mockNaaarPlanCompliancePageJson = {
+  name: "mock-route",
+  path: "/naaar/plan-compliance",
+  pageType: "planOverlay",
+  entityType: EntityType.PLANS,
+  verbiage: {
+    intro: mockVerbiageIntro,
+    requiredMessages: {
+      plans: [
+        {
+          type: "p",
+          content: "plans are required",
+        },
+      ],
+      standards: [
+        {
+          type: "p",
+          content: "standards are required",
+        },
+      ],
+    },
+    tableHeader: "Plan Name",
+    enterEntityDetailsButtonText: "Enter",
+  },
+  details: {
+    verbiage: {
+      intro: {
+        section: "mock section",
+      },
+    },
+    forms: [
+      {
+        form: {
+          id: "planComplianceMockForm1",
+          fields: [
+            {
+              id: "mockComplianceQuestion1",
+              type: "radio",
+              validation: "radio",
+              props: {
+                choices: [
+                  {
+                    id: "mockComplianceOption1",
+                    label: "Yes, is compliant",
+                  },
+                  {
+                    id: "mockComplianceOption2",
+                    label: "No, is not compliant",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        table: {
+          bodyRows: [["Mock body row"]],
+          caption: "",
+          headRow: ["Mock head row"],
+        },
+        verbiage: {
+          heading: "mock plan compliance heading",
+          hint: "mock plan compliance hint",
+          intro: {
+            section: "",
+          },
+        },
+      },
+    ],
+    childForms: [
+      {
+        parentForm: "mockParentFormId",
+        form: {
+          id: "mockChildFormId1",
+          fields: [
+            {
+              id: "mockChildFormFieldId1",
+              type: "textarea",
+              validation: "text",
+            },
+          ],
+        },
+      },
+    ],
+  },
+};
+
 export const mockModalDrawerReportPageVerbiage = {
   intro: mockVerbiageIntro,
   dashboardTitle: "Mock dashboard title",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Building on https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12113

- Add `ExportedPlanOverlayReportSection` component with basic output and tests
- Add above component to export wrapper return path and add tests

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4467 pt. 2

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- All tests pass
- If you want to, run the app, create a NAAAR, and view plan compliance in the PDF
  - Verify the new text shows up, meaning we are displaying the correct component
  - We will continue to build out this component in future PRs

| Before | After |
| ------ | ----- |
| ![Screenshot 2025-04-15 at 10 11 27 AM](https://github.com/user-attachments/assets/5b09c55c-49a4-4346-b6f4-2df1dbe8bd94) | ![Screenshot 2025-04-15 at 10 11 21 AM](https://github.com/user-attachments/assets/1118a2b1-fc80-48e0-9edb-a707b3664d79) |

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment