### PR TITLE
Plan compliance PDF part 3: List plans in pdf view and add tests

### DIFF
--- a/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.tsx
@@ -1,12 +1,27 @@
 // components
-import { Box, Text } from "@chakra-ui/react";
+import { Box, Heading, Text } from "@chakra-ui/react";
 // types
-import { PlanOverlayReportPageShape } from "types";
+import { EntityShape, PlanOverlayReportPageShape } from "types";
+// utils
+import { useStore } from "utils";
 
+/*
+ * Designed originally for the plan compliance portion of the NAAAR report
+ * Expected entity is plans
+ */
 export const ExportedPlanOverlayReportSection = ({ section }: Props) => {
+  const { report } = useStore();
+
+  const plans = report?.fieldData?.plans;
+
+  if (!plans) {
+    return null;
+  }
+
   return (
     <Box data-testid="exportedPlanOverlayReportSection">
       <Text>{section.name}</Text>
+      {displayPlansList(plans)}
     </Box>
   );
 };
@@ -14,3 +29,20 @@ export const ExportedPlanOverlayReportSection = ({ section }: Props) => {
 export interface Props {
   section: PlanOverlayReportPageShape;
 }
+
+const displayPlansList = (plans: EntityShape[]) => {
+  return plans.map((plan: EntityShape) => {
+    return (
+      <Heading as="h3" sx={sx.planNameHeading} key={plan.id}>
+        {plan.name}
+      </Heading>
+    );
+  });
+};
+
+const sx = {
+  planNameHeading: {
+    fontSize: "xl",
+    paddingBottom: "1.5rem",
+  },
+};


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Pull all plans from report store
- Display each plan as an h3, per the design

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4467

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- All tests pass
- Verify plans are listed in the PDF view as h3 headings under plan compliance
- Verify if the report has no plans nothing shows up and there are no errors
- Verify if the report had plans and they were all deleted it still renders and there are no errors

| Before | After |
| ------ | ----- |
|  ![Screenshot 2025-04-15 at 10 11 21 AM](https://github.com/user-attachments/assets/fe471241-d8f1-43de-8f77-65a36828e537) | ![Screenshot 2025-04-15 at 3 08 26 PM](https://github.com/user-attachments/assets/4e3e0f9b-11a9-441b-9eea-04d9ee642ea2) |


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
Builds on https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12114

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment