### PR TITLE
[CMDCT-4521] Make sure child choices are validating on render

### DIFF
--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -122,6 +122,7 @@ export const ChoiceListField = ({
           disabled: shouldDisableChildFields,
           nested: isNested,
           autosave,
+          validateOnRender,
         });
         choiceObject.checkedChildren = formattedChildren;
       }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Children of choices never validated on render. While beneficial in some scenarios, this isn't helpful when trying to find what you haven't filled out after clicking review on the review and submit page!

https://github.com/user-attachments/assets/30849b7e-e774-48a9-b87c-ece0112e1478

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4521

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Open up NAAAR and create a report
Add some info (Or don't), making sure you at least check Scenario 3 so that the child fields are showing (Don't fill these out yet!)
Go to the review and submit page
Click on review for Page 1
See that theres an error for every field you didn't fill out!

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

#### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary
