### PR TITLE
[CMDCT-4504] Make EntityRow's Enter Button Disabled If No Standards

### DIFF
--- a/services/ui-src/src/components/reports/OverlayReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/OverlayReportPage.test.tsx
@@ -12,6 +12,8 @@ import {
   mockNaaarReportStore,
   mockNaaarEmptyFieldData,
   mockNaaarWithPlanCreated,
+  mockNaaarStandards,
+  mockOverlayReportPageVerbiage,
 } from "utils/testing/setupJest";
 import { UserProvider, getEntityStatus, useBreakpoint, useStore } from "utils";
 import { testA11yAct } from "utils/testing/commonTests";
@@ -46,6 +48,15 @@ const mockNaaarWithPlansStore = {
   report: {
     ...mockNaaarReportStore.report,
     fieldData: mockNaaarWithPlanCreated,
+  },
+};
+
+const mockNaaarWithPlansAndStandardsStore = {
+  ...mockEntityStore,
+  ...mockNaaarReportStore,
+  report: {
+    ...mockNaaarReportStore.report,
+    fieldData: { ...mockNaaarWithPlanCreated, standards: mockNaaarStandards },
   },
 };
 
@@ -166,6 +177,69 @@ describe("<OverlayReportPage />", () => {
       mockedUseStore.mockReturnValue({
         ...mockStateUserStore,
         ...mockNaaarWithPlansStore,
+      });
+    });
+
+    describe("<TablePage />", () => {
+      test("renders plans table with enter button disabled", async () => {
+        await act(async () => {
+          render(overlayReportPageComponent());
+        });
+        const entityTable = screen.getByRole("table");
+        const entityHeaders = screen.getByRole("row", {
+          name: `Status ${verbiage.tableHeader} Action`,
+        });
+        const entityCell = screen.getByRole("gridcell", {
+          name: `${planName} Select “Enter” to complete response.`,
+        });
+
+        expect(entityTable).toBeVisible();
+        expect(entityHeaders).toBeVisible();
+        expect(entityCell).toBeVisible();
+
+        const enterButton = screen.getByRole("button", {
+          name: mockOverlayReportPageVerbiage.enterEntityDetailsButtonText,
+        });
+        expect(enterButton).toBeVisible();
+        expect(enterButton).toBeDisabled();
+      });
+
+      test("renders plans table for mobile with enter button disabled", async () => {
+        mockUseBreakpoint.mockReturnValue({
+          isMobile: true,
+          isTablet: false,
+        });
+        await act(async () => {
+          render(overlayReportPageComponent());
+        });
+
+        const entityTable = screen.getByRole("table");
+        const entityHeaders = screen.getByRole("row", {
+          name: `Status ${verbiage.tableHeader}`,
+        });
+        const entityCell = screen.getByRole("gridcell", {
+          name: `${verbiage.tableHeader} ${planName} ${verbiage.enterEntityDetailsButtonText}`,
+        });
+
+        expect(entityTable).toBeVisible();
+        expect(entityHeaders).toBeVisible();
+        expect(entityCell).toBeVisible();
+
+        const enterButton = screen.getByRole("button", {
+          name: mockOverlayReportPageVerbiage.enterEntityDetailsButtonText,
+        });
+        expect(enterButton).toBeVisible();
+        expect(enterButton).toBeDisabled();
+      });
+    });
+  });
+
+  describe("Test OverlayReportPage (Plans And Standards Have Been Added)", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockedUseStore.mockReturnValue({
+        ...mockStateUserStore,
+        ...mockNaaarWithPlansAndStandardsStore,
       });
     });
 

--- a/services/ui-src/src/components/reports/OverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayReportPage.tsx
@@ -67,6 +67,7 @@ export const OverlayReportPage = ({
   const TablePage = () => {
     const entityData = report?.fieldData[entityType] || [];
     const standardEntities = report?.fieldData["standards"] || [];
+    const hasStandards = standardEntities.length > 0;
 
     const tableHeaders = () => {
       if (isTablet || isMobile) {
@@ -98,7 +99,7 @@ export const OverlayReportPage = ({
             {parseCustomHtml(errorMessage || "")}
           </Box>
         );
-      } else if (standardEntities.length === 0) {
+      } else if (!hasStandards) {
         return (
           <Box sx={sx.missingEntityMessage}>
             {parseCustomHtml(verbiage.requiredMessages.standards || "")}
@@ -134,7 +135,7 @@ export const OverlayReportPage = ({
                   entityType={entityType as EntityType}
                   key={entity.id}
                   locked={undefined}
-                  requiresMoreData={!standardEntities.length}
+                  hasStandards={hasStandards}
                   openOverlayOrDrawer={() => toggleOverlay(entity)}
                   verbiage={verbiage}
                 />

--- a/services/ui-src/src/components/reports/OverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayReportPage.tsx
@@ -134,6 +134,7 @@ export const OverlayReportPage = ({
                   entityType={entityType as EntityType}
                   key={entity.id}
                   locked={undefined}
+                  requiresMoreData={!standardEntities.length}
                   openOverlayOrDrawer={() => toggleOverlay(entity)}
                   verbiage={verbiage}
                 />

--- a/services/ui-src/src/components/tables/EntityRow.test.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.test.tsx
@@ -169,7 +169,7 @@ describe("<EntityRow />", () => {
       entity,
       entityType,
       verbiage: mockOverlayReportPageVerbiage,
-      requiresMoreData: false,
+      hasStandards: false,
     };
 
     test("Edit button opens the AddEditEntityModal", async () => {
@@ -182,8 +182,8 @@ describe("<EntityRow />", () => {
       });
     });
 
-    test("Enter button should be disabled if there is an entity but requiresMoreData is passed", async () => {
-      render(completeRowComponent({ ...setupData, requiresMoreData: true }));
+    test("Enter button should be disabled if there is an entity but hasStandards is passed", async () => {
+      render(completeRowComponent({ ...setupData, hasStandards: true }));
       const enterButton = screen.getByRole("button", {
         name: mockOverlayReportPageVerbiage.enterEntityDetailsButtonText,
       });
@@ -191,7 +191,7 @@ describe("<EntityRow />", () => {
       expect(enterButton).toBeDisabled();
     });
 
-    test("Enter button should not disabled if there is an entity and requiresMoreData is false", () => {
+    test("Enter button should not disabled if there is an entity and hasStandards is false", () => {
       render(completeRowComponent(setupData));
       const enterButton = screen.getByRole("button", {
         name: mockOverlayReportPageVerbiage.enterEntityDetailsButtonText,
@@ -218,7 +218,7 @@ describe("<EntityRow />", () => {
       entity,
       entityType,
       verbiage: mockDrawerReportPageJson.verbiage,
-      requiresMoreData: false,
+      hasStandards: false,
     };
 
     test("MCPAR Enter Details button opens the Drawer", async () => {

--- a/services/ui-src/src/components/tables/EntityRow.test.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.test.tsx
@@ -169,7 +169,6 @@ describe("<EntityRow />", () => {
       entity,
       entityType,
       verbiage: mockOverlayReportPageVerbiage,
-      hasStandards: false,
     };
 
     test("Edit button opens the AddEditEntityModal", async () => {
@@ -182,8 +181,8 @@ describe("<EntityRow />", () => {
       });
     });
 
-    test("Enter button should be disabled if there is an entity but hasStandards is passed", async () => {
-      render(completeRowComponent({ ...setupData, hasStandards: true }));
+    test("Enter button should be disabled if there is an entity but does not have a standard", async () => {
+      render(completeRowComponent({ ...setupData, hasStandards: false }));
       const enterButton = screen.getByRole("button", {
         name: mockOverlayReportPageVerbiage.enterEntityDetailsButtonText,
       });
@@ -191,7 +190,16 @@ describe("<EntityRow />", () => {
       expect(enterButton).toBeDisabled();
     });
 
-    test("Enter button should not disabled if there is an entity and hasStandards is false", () => {
+    test("Enter button should not disabled if there is an entity and hasStandards", () => {
+      render(completeRowComponent({ ...setupData, hasStandards: true }));
+      const enterButton = screen.getByRole("button", {
+        name: mockOverlayReportPageVerbiage.enterEntityDetailsButtonText,
+      });
+      expect(enterButton).toBeVisible();
+      expect(enterButton).not.toBeDisabled();
+    });
+
+    test("Enter button should not disabled if there is an entity and hasStandards is not defined", () => {
       render(completeRowComponent(setupData));
       const enterButton = screen.getByRole("button", {
         name: mockOverlayReportPageVerbiage.enterEntityDetailsButtonText,
@@ -218,7 +226,6 @@ describe("<EntityRow />", () => {
       entity,
       entityType,
       verbiage: mockDrawerReportPageJson.verbiage,
-      hasStandards: false,
     };
 
     test("MCPAR Enter Details button opens the Drawer", async () => {

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -90,7 +90,7 @@ export const EntityRow = ({
               onClick={() => openOverlayOrDrawer(entity)}
               variant="outline"
               size="sm"
-              disabled={!hasStandards}
+              disabled={!hasStandards && hasStandards !== undefined}
             >
               {entering ? <Spinner size="md" /> : enterDetailsText()}
             </Button>

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -14,6 +14,7 @@ export const EntityRow = ({
   entityType,
   verbiage,
   locked,
+  requiresMoreData,
   entering,
   openAddEditEntityModal,
   openDeleteEntityModal,
@@ -89,6 +90,7 @@ export const EntityRow = ({
               onClick={() => openOverlayOrDrawer(entity)}
               variant="outline"
               size="sm"
+              disabled={requiresMoreData}
             >
               {entering ? <Spinner size="md" /> : enterDetailsText()}
             </Button>
@@ -115,6 +117,7 @@ export interface EntityRowProps {
   verbiage: AnyObject;
   locked?: boolean;
   entering?: boolean;
+  requiresMoreData?: boolean;
   openAddEditEntityModal?: Function;
   openDeleteEntityModal?: Function;
   openOverlayOrDrawer?: Function;

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -14,7 +14,7 @@ export const EntityRow = ({
   entityType,
   verbiage,
   locked,
-  requiresMoreData,
+  hasStandards,
   entering,
   openAddEditEntityModal,
   openDeleteEntityModal,
@@ -90,7 +90,7 @@ export const EntityRow = ({
               onClick={() => openOverlayOrDrawer(entity)}
               variant="outline"
               size="sm"
-              disabled={requiresMoreData}
+              disabled={!hasStandards}
             >
               {entering ? <Spinner size="md" /> : enterDetailsText()}
             </Button>
@@ -117,7 +117,7 @@ export interface EntityRowProps {
   verbiage: AnyObject;
   locked?: boolean;
   entering?: boolean;
-  requiresMoreData?: boolean;
+  hasStandards?: boolean;
   openAddEditEntityModal?: Function;
   openDeleteEntityModal?: Function;
   openOverlayOrDrawer?: Function;

--- a/services/ui-src/src/components/tables/MobileEntityRow.test.tsx
+++ b/services/ui-src/src/components/tables/MobileEntityRow.test.tsx
@@ -181,8 +181,8 @@ describe("<MobileEntityRow />", () => {
       });
     });
 
-    test("Enter button should be disabled if there is an entity but requiresMoreData is passed", async () => {
-      render(completeRowComponent({ ...setupData, requiresMoreData: true }));
+    test("Enter button should be disabled if there is an entity but hasStandards is passed", async () => {
+      render(completeRowComponent({ ...setupData, hasStandards: true }));
       const enterButton = screen.getByRole("button", {
         name: mockOverlayReportPageVerbiage.enterEntityDetailsButtonText,
       });
@@ -190,7 +190,7 @@ describe("<MobileEntityRow />", () => {
       expect(enterButton).toBeDisabled();
     });
 
-    test("Enter button should not disabled if there is an entity and requiresMoreData is false", () => {
+    test("Enter button should not disabled if there is an entity and hasStandards is false", () => {
       render(completeRowComponent(setupData));
       const enterButton = screen.getByRole("button", {
         name: mockOverlayReportPageVerbiage.enterEntityDetailsButtonText,

--- a/services/ui-src/src/components/tables/MobileEntityRow.test.tsx
+++ b/services/ui-src/src/components/tables/MobileEntityRow.test.tsx
@@ -3,9 +3,10 @@ import { render, screen, waitFor } from "@testing-library/react";
 // components
 import { ReportContext } from "components/reports/ReportProvider";
 import { MobileEntityRow } from "./MobileEntityRow";
+import { EntityRowProps } from "./EntityRow";
 import { Table } from "./Table";
 // types
-import { EntityType } from "types";
+import { EntityShape, EntityType } from "types";
 // utils
 import {
   mockMlrReportContext,
@@ -13,12 +14,12 @@ import {
   mockNaaarReportStore,
   mockNaaarReportContext,
   mockStateUserStore,
-  mockVerbiageIntro,
   RouterWrappedComponent,
   mockMcparReportStore,
   mockMcparReportContext,
   mockAdminUserStore,
   mockNoUserStore,
+  mockOverlayReportPageVerbiage,
 } from "utils/testing/setupJest";
 import userEvent from "@testing-library/user-event";
 import { getEntityStatus, useStore } from "utils";
@@ -38,16 +39,12 @@ const mockedGetEntityStatus = getEntityStatus as jest.MockedFunction<
   typeof getEntityStatus
 >;
 
-const completeRowComponent = (
-  context: any = mockMlrReportContext,
-  entity: EntityType = EntityType.PROGRAM
-) => (
+const completeRowComponent = (props: EntityRowProps) => (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={context}>
+    <ReportContext.Provider value={props.context}>
       <Table content={{}}>
         <MobileEntityRow
-          entity={context.report.fieldData[entity][0]}
-          verbiage={mockVerbiageIntro}
+          {...props}
           entering={mockEntering}
           openAddEditEntityModal={openAddEditEntityModal}
           openDeleteEntityModal={openDeleteEntityModal}
@@ -71,13 +68,23 @@ describe("<MobileEntityRow />", () => {
       });
     });
 
+    const entityType = EntityType.PROGRAM;
+    const entity: EntityShape =
+      mockMlrReportContext.report.fieldData[entityType][0];
+    const setupData = {
+      context: mockMlrReportContext,
+      entity,
+      entityType,
+      verbiage: mockOverlayReportPageVerbiage,
+    };
+
     test("render error if entity is incomplete", () => {
       mockedUseStore.mockReturnValue({
         ...mockNoUserStore,
         ...mockMlrReportStore,
       });
       mockedGetEntityStatus.mockReturnValue(false);
-      render(completeRowComponent(mockMlrReportContext));
+      render(completeRowComponent(setupData));
       const errorMessage = screen.getByText(
         "Select “Enter MLR” to complete this report."
       );
@@ -86,7 +93,7 @@ describe("<MobileEntityRow />", () => {
 
     test("don't render error if entity is complete", () => {
       mockedGetEntityStatus.mockReturnValue(true);
-      render(completeRowComponent(mockMlrReportContext));
+      render(completeRowComponent(setupData));
       const errorMessage = screen.queryByText(
         "Select “Enter MLR” to complete this report."
       );
@@ -94,7 +101,7 @@ describe("<MobileEntityRow />", () => {
     });
 
     test("Edit button opens the AddEditEntityModal", async () => {
-      render(completeRowComponent());
+      render(completeRowComponent(setupData));
       const addReportButton = screen.getByRole("button", { name: "Edit" });
       expect(addReportButton).toBeVisible();
       await userEvent.click(addReportButton);
@@ -104,7 +111,7 @@ describe("<MobileEntityRow />", () => {
     });
 
     test("Enter Details button opens the Drawer", async () => {
-      render(completeRowComponent());
+      render(completeRowComponent(setupData));
       const enterDetailsButton = screen.getByRole("button", {
         name: "Enter Details",
       });
@@ -116,7 +123,7 @@ describe("<MobileEntityRow />", () => {
     });
 
     test("Delete button opens the DeleteEntityModal", async () => {
-      render(completeRowComponent());
+      render(completeRowComponent(setupData));
       const deleteButton = screen.getByRole("button", { name: "delete icon" });
       expect(deleteButton).toBeVisible();
       await userEvent.click(deleteButton);
@@ -130,18 +137,20 @@ describe("<MobileEntityRow />", () => {
         ...mockAdminUserStore,
         ...mockMlrReportStore,
       });
-      render(completeRowComponent());
+      render(completeRowComponent(setupData));
       const deleteButton = screen.getByRole("button", { name: "delete icon" });
       expect(deleteButton).toBeDisabled();
     });
 
     test("render Spinner when entering", () => {
       mockEntering = true;
-      render(completeRowComponent(mockMlrReportContext));
+      render(completeRowComponent(setupData));
       const loading = screen.getByRole("button", { name: "Loading..." });
       expect(loading).toBeVisible();
       mockEntering = false;
     });
+
+    testA11y(completeRowComponent(setupData));
   });
 
   describe("NAAAR", () => {
@@ -152,8 +161,18 @@ describe("<MobileEntityRow />", () => {
       });
     });
 
+    const entityType = EntityType.PLANS;
+    const entity: EntityShape =
+      mockNaaarReportContext.report.fieldData[entityType][0];
+    const setupData = {
+      context: mockNaaarReportContext,
+      entity,
+      entityType,
+      verbiage: mockOverlayReportPageVerbiage,
+    };
+
     test("Edit button opens the AddEditEntityModal", async () => {
-      render(completeRowComponent(mockNaaarReportContext, EntityType.PLANS));
+      render(completeRowComponent(setupData));
       const editButton = screen.getByRole("button", { name: "Edit" });
       expect(editButton).toBeVisible();
       await userEvent.click(editButton);
@@ -161,6 +180,26 @@ describe("<MobileEntityRow />", () => {
         expect(openAddEditEntityModal).toBeCalledTimes(1);
       });
     });
+
+    test("Enter button should be disabled if there is an entity but requiresMoreData is passed", async () => {
+      render(completeRowComponent({ ...setupData, requiresMoreData: true }));
+      const enterButton = screen.getByRole("button", {
+        name: mockOverlayReportPageVerbiage.enterEntityDetailsButtonText,
+      });
+      expect(enterButton).toBeVisible();
+      expect(enterButton).toBeDisabled();
+    });
+
+    test("Enter button should not disabled if there is an entity and requiresMoreData is false", () => {
+      render(completeRowComponent(setupData));
+      const enterButton = screen.getByRole("button", {
+        name: mockOverlayReportPageVerbiage.enterEntityDetailsButtonText,
+      });
+      expect(enterButton).toBeVisible();
+      expect(enterButton).not.toBeDisabled();
+    });
+
+    testA11y(completeRowComponent(setupData));
   });
 
   describe("MCPAR", () => {
@@ -171,8 +210,18 @@ describe("<MobileEntityRow />", () => {
       });
     });
 
+    const entityType = EntityType.PLANS;
+    const entity: EntityShape =
+      mockMcparReportContext.report.fieldData[entityType][0];
+    const setupData = {
+      context: mockMcparReportContext,
+      entity,
+      entityType,
+      verbiage: mockOverlayReportPageVerbiage,
+    };
+
     test("MCPAR Enter Details button opens the Drawer", async () => {
-      render(completeRowComponent(mockMcparReportContext, EntityType.PLANS));
+      render(completeRowComponent(setupData));
       const enterButton = screen.getByRole("button", { name: "Enter" });
       expect(enterButton).toBeVisible();
       await userEvent.click(enterButton);
@@ -180,7 +229,7 @@ describe("<MobileEntityRow />", () => {
         expect(mockOpenDrawer).toBeCalledTimes(1);
       });
     });
-  });
 
-  testA11y(completeRowComponent());
+    testA11y(completeRowComponent(setupData));
+  });
 });

--- a/services/ui-src/src/components/tables/MobileEntityRow.test.tsx
+++ b/services/ui-src/src/components/tables/MobileEntityRow.test.tsx
@@ -181,8 +181,8 @@ describe("<MobileEntityRow />", () => {
       });
     });
 
-    test("Enter button should be disabled if there is an entity but hasStandards is passed", async () => {
-      render(completeRowComponent({ ...setupData, hasStandards: true }));
+    test("Enter button should be disabled if there is an entity but does not have a standard", async () => {
+      render(completeRowComponent({ ...setupData, hasStandards: false }));
       const enterButton = screen.getByRole("button", {
         name: mockOverlayReportPageVerbiage.enterEntityDetailsButtonText,
       });
@@ -190,7 +190,16 @@ describe("<MobileEntityRow />", () => {
       expect(enterButton).toBeDisabled();
     });
 
-    test("Enter button should not disabled if there is an entity and hasStandards is false", () => {
+    test("Enter button should not disabled if there is an entity and hasStandards", () => {
+      render(completeRowComponent({ ...setupData, hasStandards: true }));
+      const enterButton = screen.getByRole("button", {
+        name: mockOverlayReportPageVerbiage.enterEntityDetailsButtonText,
+      });
+      expect(enterButton).toBeVisible();
+      expect(enterButton).not.toBeDisabled();
+    });
+
+    test("Enter button should not disabled if there is an entity and hasStandards is not defined", () => {
       render(completeRowComponent(setupData));
       const enterButton = screen.getByRole("button", {
         name: mockOverlayReportPageVerbiage.enterEntityDetailsButtonText,

--- a/services/ui-src/src/components/tables/MobileEntityRow.tsx
+++ b/services/ui-src/src/components/tables/MobileEntityRow.tsx
@@ -29,6 +29,7 @@ export const MobileEntityRow = ({
   entityType,
   verbiage,
   locked,
+  requiresMoreData,
   entering,
   openAddEditEntityModal,
   openDeleteEntityModal,
@@ -106,6 +107,7 @@ export const MobileEntityRow = ({
               variant="outline"
               onClick={() => openOverlayOrDrawer(entity)}
               size="sm"
+              disabled={requiresMoreData}
               sx={sx.enterButton}
             >
               {entering ? <Spinner size="md" /> : enterDetailsText()}

--- a/services/ui-src/src/components/tables/MobileEntityRow.tsx
+++ b/services/ui-src/src/components/tables/MobileEntityRow.tsx
@@ -107,7 +107,7 @@ export const MobileEntityRow = ({
               variant="outline"
               onClick={() => openOverlayOrDrawer(entity)}
               size="sm"
-              disabled={!hasStandards}
+              disabled={!hasStandards && hasStandards !== undefined}
               sx={sx.enterButton}
             >
               {entering ? <Spinner size="md" /> : enterDetailsText()}

--- a/services/ui-src/src/components/tables/MobileEntityRow.tsx
+++ b/services/ui-src/src/components/tables/MobileEntityRow.tsx
@@ -29,7 +29,7 @@ export const MobileEntityRow = ({
   entityType,
   verbiage,
   locked,
-  requiresMoreData,
+  hasStandards,
   entering,
   openAddEditEntityModal,
   openDeleteEntityModal,
@@ -107,7 +107,7 @@ export const MobileEntityRow = ({
               variant="outline"
               onClick={() => openOverlayOrDrawer(entity)}
               size="sm"
-              disabled={requiresMoreData}
+              disabled={!hasStandards}
               sx={sx.enterButton}
             >
               {entering ? <Spinner size="md" /> : enterDetailsText()}

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -252,7 +252,8 @@ export interface OverlayReportPageVerbiage extends ReportPageVerbiage {
   tableHeader: string;
   emptyDashboardText: string;
   editEntityButtonText: string;
-  enterEntityDetailsButtonText: string;
+  enterReportText?: string;
+  enterEntityDetailsButtonText?: string;
 }
 
 export interface PlanOverlayReportPageVerbiage extends ReportPageVerbiage {

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -251,6 +251,7 @@ export interface OverlayReportPageVerbiage extends ReportPageVerbiage {
   };
   tableHeader: string;
   emptyDashboardText: string;
+  editEntityButtonText: string;
   enterEntityDetailsButtonText: string;
 }
 

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -237,6 +237,7 @@ export const mockDrawerReportPageJson = {
     intro: mockVerbiageIntro,
     dashboardTitle: "Mock dashboard title",
     drawerTitle: "Mock drawer title",
+    editEntityButtonText: "Edit",
   },
   drawerForm: mockDrawerForm,
 };
@@ -635,6 +636,8 @@ export const mockOverlayReportPageVerbiage: OverlayReportPageVerbiage = {
   },
   tableHeader: "Mock table header",
   emptyDashboardText: "No entities found",
+  enterReportText: "Enter Details",
+  editEntityButtonText: "Edit",
   enterEntityDetailsButtonText: "Mock Enter Button Text",
 };
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
If you make a plan but don't add a standard, you'll now no longer be able to enter the plan compliance section for that plan until you add a standard.

https://github.com/user-attachments/assets/e6f4108e-7e7e-4d3c-88b4-8cde54b2bcc1


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4504

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Create a NAAAR Report
Add a plan name
Navigate to the Section 3 Plan Compliance
See that the enter button is disabled on both mobile and desktop
Go through the process of creating a Standard
Check back on Section 3's Plan Compliance page and see that the enter button is enabled on both mobile and desktop

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary
