### PR TITLE
cmdct-4266 add Plan Provider Directory Review children to plan compliance

### DIFF
--- a/services/ui-src/src/constants.ts
+++ b/services/ui-src/src/constants.ts
@@ -438,7 +438,7 @@ export const PlanProviderChildJson = [
                         validation: "numberOptional",
                         props: {
                           label: "Q1 (optional)",
-                          mask: "percentage",
+                          mask: "comma-separated",
                           decimalPlacesToRoundTo: 0,
                         },
                       },
@@ -448,7 +448,7 @@ export const PlanProviderChildJson = [
                         validation: "numberOptional",
                         props: {
                           label: "Q2 (optional)",
-                          mask: "percentage",
+                          mask: "comma-separated",
                           decimalPlacesToRoundTo: 0,
                         },
                       },
@@ -458,7 +458,7 @@ export const PlanProviderChildJson = [
                         validation: "numberOptional",
                         props: {
                           label: "Q3 (optional)",
-                          mask: "percentage",
+                          mask: "comma-separated",
                           decimalPlacesToRoundTo: 0,
                         },
                       },
@@ -468,7 +468,7 @@ export const PlanProviderChildJson = [
                         validation: "numberOptional",
                         props: {
                           label: "Q4 (optional)",
-                          mask: "percentage",
+                          mask: "comma-separated",
                           decimalPlacesToRoundTo: 0,
                         },
                       },
@@ -530,14 +530,14 @@ export const PlanProviderChildJson = [
           label: "Report results annually",
           children: [
             {
-              id: "ppdaReportResultsAnnually",
+              id: "ppdrReportResultsAnnually",
               type: "radio",
               validation: "radioOptional",
               props: {
                 choices: [
                   {
                     id: "j4ch2jWhesE7SHQZYQmvJV",
-                    label: "Minimum number of Network Providers",
+                    label: "Minimum number of network providers",
                     children: [
                       {
                         id: "ppdrAnnualMinimumNumberOfNetworkProviders",
@@ -572,7 +572,7 @@ export const PlanProviderChildJson = [
                         validation: "numberOptional",
                         props: {
                           label: "Annual (optional)",
-                          mask: "comma-separated",
+                          mask: "percentage",
                           decimalPlacesToRoundTo: 0,
                         },
                       },

--- a/services/ui-src/src/constants.ts
+++ b/services/ui-src/src/constants.ts
@@ -164,7 +164,7 @@ export const GeomappingChildJson = [
           label: "Report results by quarter",
           children: [
             {
-              id: "geoEnrolleesMeetingStandard",
+              id: "enrolleesMeetingStandard",
               type: "radio",
               validation: "radioOptional",
               props: {
@@ -174,7 +174,7 @@ export const GeomappingChildJson = [
                     label: "Percent of enrollees that met the standard",
                     children: [
                       {
-                        id: "geoQ1PercentMetStandard",
+                        id: "q1PercentMetStandard",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -184,7 +184,7 @@ export const GeomappingChildJson = [
                         },
                       },
                       {
-                        id: "geoQ2PercentMetStandard",
+                        id: "q2PercentMetStandard",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -194,7 +194,7 @@ export const GeomappingChildJson = [
                         },
                       },
                       {
-                        id: "geoQ3PercentMetStandard",
+                        id: "q3PercentMetStandard",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -204,7 +204,7 @@ export const GeomappingChildJson = [
                         },
                       },
                       {
-                        id: "geoQ4PercentMetStandard",
+                        id: "q4PercentMetStandard",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -220,7 +220,7 @@ export const GeomappingChildJson = [
                     label: "Actual maximum time",
                     children: [
                       {
-                        id: "geoQ1ActualMaxTime",
+                        id: "q1ActualMaxTime",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -230,7 +230,7 @@ export const GeomappingChildJson = [
                         },
                       },
                       {
-                        id: "geoQ2ActualMaxTime",
+                        id: "q2ActualMaxTime",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -240,7 +240,7 @@ export const GeomappingChildJson = [
                         },
                       },
                       {
-                        id: "geoQ3ActualMaxTime",
+                        id: "q3ActualMaxTime",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -250,7 +250,7 @@ export const GeomappingChildJson = [
                         },
                       },
                       {
-                        id: "geoQ4ActualMaxTime",
+                        id: "q4ActualMaxTime",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -266,7 +266,7 @@ export const GeomappingChildJson = [
                     label: "Actual maximum distance",
                     children: [
                       {
-                        id: "geoQ1ActualMaxDist",
+                        id: "q1ActualMaxDist",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -276,7 +276,7 @@ export const GeomappingChildJson = [
                         },
                       },
                       {
-                        id: "geoQ2ActualMaxDist",
+                        id: "q2ActualMaxDist",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -286,7 +286,7 @@ export const GeomappingChildJson = [
                         },
                       },
                       {
-                        id: "geoQ3ActualMaxDist",
+                        id: "q3ActualMaxDist",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -296,7 +296,7 @@ export const GeomappingChildJson = [
                         },
                       },
                       {
-                        id: "geoQ4ActualMaxDist",
+                        id: "q4ActualMaxDist",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -317,7 +317,7 @@ export const GeomappingChildJson = [
           label: "Report results annually",
           children: [
             {
-              id: "geoReportResultsAnnually",
+              id: "reportResultsAnnually",
               type: "radio",
               validation: "radioOptional",
               props: {
@@ -327,7 +327,7 @@ export const GeomappingChildJson = [
                     label: "Percent of enrollees that met the standard",
                     children: [
                       {
-                        id: "geoAnnualPercentMetStandard",
+                        id: "annualPercentMetStandard",
                         type: "numberOptional",
                         validation: "numberOptional",
                         props: {
@@ -337,7 +337,7 @@ export const GeomappingChildJson = [
                         },
                       },
                       {
-                        id: "geoAnnualPercentMetStandardDate",
+                        id: "annualPercentMetStandardDate",
                         type: "date",
                         validation: "dateOptional",
                         props: {
@@ -352,7 +352,7 @@ export const GeomappingChildJson = [
                     label: "Actual maximum time",
                     children: [
                       {
-                        id: "geoAnnualMaxTime",
+                        id: "annualMaxTime",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -362,7 +362,7 @@ export const GeomappingChildJson = [
                         },
                       },
                       {
-                        id: "geoAnnualMaxTimeDate",
+                        id: "annualMaxTimeDate",
                         type: "date",
                         validation: {
                           type: "dateOptional",
@@ -379,7 +379,7 @@ export const GeomappingChildJson = [
                     label: "Actual maximum distance",
                     children: [
                       {
-                        id: "geoActualMaxDistance",
+                        id: "actualMaxDistance",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -389,7 +389,7 @@ export const GeomappingChildJson = [
                         },
                       },
                       {
-                        id: "geoActualMaxDistanceDate",
+                        id: "actualMaxDistanceDate",
                         type: "date",
                         validation: "dateOptional",
                         props: {
@@ -423,7 +423,7 @@ export const PlanProviderChildJson = [
           label: "Report results by quarter",
           children: [
             {
-              id: "ppdrEnrolleesMeetingStandard",
+              id: "enrolleesMeetingStandard",
               type: "radio",
               validation: "radioOptional",
               props: {
@@ -433,7 +433,7 @@ export const PlanProviderChildJson = [
                     label: "Minimum number of network providers",
                     children: [
                       {
-                        id: "ppdrQ1NumberOfNetworkProviders",
+                        id: "q1NumberOfNetworkProviders",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -443,7 +443,7 @@ export const PlanProviderChildJson = [
                         },
                       },
                       {
-                        id: "ppdrQ2NumberOfNetworkProviders",
+                        id: "q2NumberOfNetworkProviders",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -453,7 +453,7 @@ export const PlanProviderChildJson = [
                         },
                       },
                       {
-                        id: "ppdrQ3NumberOfNetworkProviders",
+                        id: "q3NumberOfNetworkProviders",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -463,7 +463,7 @@ export const PlanProviderChildJson = [
                         },
                       },
                       {
-                        id: "ppdrQ4NumberOfNetworkProviders",
+                        id: "q4NumberOfNetworkProviders",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -479,7 +479,7 @@ export const PlanProviderChildJson = [
                     label: "Provider to enrollee ratio",
                     children: [
                       {
-                        id: "ppdrQ1ProviderToEnrolleeRatio",
+                        id: "q1ProviderToEnrolleeRatio",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -489,7 +489,7 @@ export const PlanProviderChildJson = [
                         },
                       },
                       {
-                        id: "ppdrQ2ProviderToEnrolleeRatio",
+                        id: "q2ProviderToEnrolleeRatio",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -499,7 +499,7 @@ export const PlanProviderChildJson = [
                         },
                       },
                       {
-                        id: "ppdrQ3ProviderToEnrolleeRatio",
+                        id: "q3ProviderToEnrolleeRatio",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -509,7 +509,7 @@ export const PlanProviderChildJson = [
                         },
                       },
                       {
-                        id: "ppdrQ4ProviderToEnrolleeRatio",
+                        id: "q4ProviderToEnrolleeRatio",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -530,7 +530,7 @@ export const PlanProviderChildJson = [
           label: "Report results annually",
           children: [
             {
-              id: "ppdrReportResultsAnnually",
+              id: "reportResultsAnnually",
               type: "radio",
               validation: "radioOptional",
               props: {
@@ -540,7 +540,7 @@ export const PlanProviderChildJson = [
                     label: "Minimum number of network providers",
                     children: [
                       {
-                        id: "ppdrAnnualMinimumNumberOfNetworkProviders",
+                        id: "annualMinimumNumberOfNetworkProviders",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -550,11 +550,9 @@ export const PlanProviderChildJson = [
                         },
                       },
                       {
-                        id: "ppdrAnnualMinimumNumberOfNetworkProvidersDate",
+                        id: "annualMinimumNumberOfNetworkProvidersDate",
                         type: "date",
-                        validation: {
-                          type: "dateOptional",
-                        },
+                        validation: "dateOptional",
                         props: {
                           label:
                             "Date of analysis of annual snapshot (optional)",
@@ -567,7 +565,7 @@ export const PlanProviderChildJson = [
                     label: "Provider to enrollee ratio",
                     children: [
                       {
-                        id: "ppdrAnnualProvidertoEnrolleeRatio",
+                        id: "annualProvidertoEnrolleeRatio",
                         type: "number",
                         validation: "numberOptional",
                         props: {
@@ -577,7 +575,7 @@ export const PlanProviderChildJson = [
                         },
                       },
                       {
-                        id: "ppdrAnnualProvidertoEnrolleeRatioDate",
+                        id: "annualProvidertoEnrolleeRatioDate",
                         type: "date",
                         validation: "dateOptional",
                         props: {
@@ -611,7 +609,7 @@ export const SecretShopperAppointmentAvailabilityChildJson = [
           label: "Report results by quarter",
           children: [
             {
-              id: "ssaaQ1PercentMetStandard",
+              id: "q1PercentMetStandard",
               type: "number",
               validation: "numberOptional",
               props: {
@@ -621,7 +619,7 @@ export const SecretShopperAppointmentAvailabilityChildJson = [
               },
             },
             {
-              id: "ssaaQ2PercentMetStandard",
+              id: "q2PercentMetStandard",
               type: "number",
               validation: "numberOptional",
               props: {
@@ -631,7 +629,7 @@ export const SecretShopperAppointmentAvailabilityChildJson = [
               },
             },
             {
-              id: "ssaaQ3PercentMetStandard",
+              id: "q3PercentMetStandard",
               type: "number",
               validation: "numberOptional",
               props: {
@@ -641,7 +639,7 @@ export const SecretShopperAppointmentAvailabilityChildJson = [
               },
             },
             {
-              id: "ssaaQ4PercentMetStandard",
+              id: "q4PercentMetStandard",
               type: "number",
               validation: "numberOptional",
               props: {
@@ -657,7 +655,7 @@ export const SecretShopperAppointmentAvailabilityChildJson = [
           label: "Report results annually",
           children: [
             {
-              id: "ssaaReportResultsAnnually",
+              id: "reportResultsAnnually",
               type: "number",
               validation: "numberOptional",
               props: {
@@ -667,7 +665,7 @@ export const SecretShopperAppointmentAvailabilityChildJson = [
               },
             },
             {
-              id: "ssaaAnnualPercentMetStandardDate",
+              id: "annualPercentMetStandardDate",
               type: "date",
               validation: "dateOptional",
               props: {

--- a/services/ui-src/src/constants.ts
+++ b/services/ui-src/src/constants.ts
@@ -409,6 +409,194 @@ export const GeomappingChildJson = [
   },
 ];
 
+export const PlanProviderChildJson = [
+  {
+    id: "ppdrComplianceFrequency",
+    type: "checkbox",
+    validation: "checkboxOneOptional",
+    props: {
+      label: "Frequency of compliance findings (optional)",
+      hint: "Instructions",
+      choices: [
+        {
+          id: "sxC5M4JJz9qNCdNxJgQmJV",
+          label: "Report results by quarter",
+          children: [
+            {
+              id: "ppdrEnrolleesMeetingStandard",
+              type: "radio",
+              validation: "radioOptional",
+              props: {
+                choices: [
+                  {
+                    id: "gRCpgad2dhXDrmucTw8cnu",
+                    label: "Minimum number of network providers",
+                    children: [
+                      {
+                        id: "ppdrQ1NumberOfNetworkProviders",
+                        type: "number",
+                        validation: "numberOptional",
+                        props: {
+                          label: "Q1 (optional)",
+                          mask: "percentage",
+                          decimalPlacesToRoundTo: 0,
+                        },
+                      },
+                      {
+                        id: "ppdrQ2NumberOfNetworkProviders",
+                        type: "number",
+                        validation: "numberOptional",
+                        props: {
+                          label: "Q2 (optional)",
+                          mask: "percentage",
+                          decimalPlacesToRoundTo: 0,
+                        },
+                      },
+                      {
+                        id: "ppdrQ3NumberOfNetworkProviders",
+                        type: "number",
+                        validation: "numberOptional",
+                        props: {
+                          label: "Q3 (optional)",
+                          mask: "percentage",
+                          decimalPlacesToRoundTo: 0,
+                        },
+                      },
+                      {
+                        id: "ppdrQ4NumberOfNetworkProviders",
+                        type: "number",
+                        validation: "numberOptional",
+                        props: {
+                          label: "Q4 (optional)",
+                          mask: "percentage",
+                          decimalPlacesToRoundTo: 0,
+                        },
+                      },
+                    ],
+                  },
+                  {
+                    id: "a8kZrrUYcfUrnTM8UuHNmi",
+                    label: "Provider to enrollee ratio",
+                    children: [
+                      {
+                        id: "ppdrQ1ProviderToEnrolleeRatio",
+                        type: "number",
+                        validation: "numberOptional",
+                        props: {
+                          label: "Q1 (optional)",
+                          mask: "percentage",
+                          decimalPlacesToRoundTo: 0,
+                        },
+                      },
+                      {
+                        id: "ppdrQ2ProviderToEnrolleeRatio",
+                        type: "number",
+                        validation: "numberOptional",
+                        props: {
+                          label: "Q2 (optional)",
+                          mask: "percentage",
+                          decimalPlacesToRoundTo: 0,
+                        },
+                      },
+                      {
+                        id: "ppdrQ3ProviderToEnrolleeRatio",
+                        type: "number",
+                        validation: "numberOptional",
+                        props: {
+                          label: "Q3 (optional)",
+                          mask: "percentage",
+                          decimalPlacesToRoundTo: 0,
+                        },
+                      },
+                      {
+                        id: "ppdrQ4ProviderToEnrolleeRatio",
+                        type: "number",
+                        validation: "numberOptional",
+                        props: {
+                          label: "Q4 (optional)",
+                          mask: "percentage",
+                          decimalPlacesToRoundTo: 0,
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          id: "wz9n6q8nuxdUKnaw7gWUoj",
+          label: "Report results annually",
+          children: [
+            {
+              id: "ppdaReportResultsAnnually",
+              type: "radio",
+              validation: "radioOptional",
+              props: {
+                choices: [
+                  {
+                    id: "j4ch2jWhesE7SHQZYQmvJV",
+                    label: "Minimum number of Network Providers",
+                    children: [
+                      {
+                        id: "ppdrAnnualMinimumNumberOfNetworkProviders",
+                        type: "number",
+                        validation: "numberOptional",
+                        props: {
+                          label: "Annual (optional)",
+                          mask: "comma-separated",
+                          decimalPlacesToRoundTo: 0,
+                        },
+                      },
+                      {
+                        id: "ppdrAnnualMinimumNumberOfNetworkProvidersDate",
+                        type: "date",
+                        validation: {
+                          type: "dateOptional",
+                        },
+                        props: {
+                          label:
+                            "Date of analysis of annual snapshot (optional)",
+                        },
+                      },
+                    ],
+                  },
+                  {
+                    id: "dSHQvqgfa7YYoRBvSKkahW",
+                    label: "Provider to enrollee ratio",
+                    children: [
+                      {
+                        id: "ppdrAnnualProvidertoEnrolleeRatio",
+                        type: "number",
+                        validation: "numberOptional",
+                        props: {
+                          label: "Annual (optional)",
+                          mask: "comma-separated",
+                          decimalPlacesToRoundTo: 0,
+                        },
+                      },
+                      {
+                        id: "ppdrAnnualProvidertoEnrolleeRatioDate",
+                        type: "date",
+                        validation: "dateOptional",
+                        props: {
+                          label:
+                            "Date of analysis of annual snapshot (optional)",
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+
 export const SecretShopperAppointmentAvailabilityChildJson = [
   {
     id: "ssaaComplianceFrequency",

--- a/services/ui-src/src/utils/forms/dynamicItemFields.ts
+++ b/services/ui-src/src/utils/forms/dynamicItemFields.ts
@@ -1,6 +1,6 @@
 import {
-  DEFAULT_ANALYSIS_METHODS,
   GeomappingChildJson,
+  PlanProviderChildJson,
   SecretShopperAppointmentAvailabilityChildJson,
 } from "../../constants";
 import { AnyObject, EntityType, FormJson } from "types";
@@ -205,14 +205,18 @@ export const availableAnalysisMethods = (
   const SecretShopperJson = structuredClone(
     SecretShopperAppointmentAvailabilityChildJson
   );
+  const PlanProviderJson = structuredClone(PlanProviderChildJson);
   const updatedItemChoices = items.map((item) => {
     const id = `${analysisMethodsFieldId}_${item.id}`;
     const analysisMethod = { id, label: item.name };
     switch (item.name) {
-      case DEFAULT_ANALYSIS_METHODS[0].name:
+      case "Geomapping":
         createIDForChildrenOfAnalysisMethod(GeomappingJson, id);
         return { ...analysisMethod, children: GeomappingJson };
-      case DEFAULT_ANALYSIS_METHODS[3].name:
+      case "Plan Provider Directory Review":
+        createIDForChildrenOfAnalysisMethod(PlanProviderJson, id);
+        return { ...analysisMethod, children: PlanProviderJson };
+      case "Secret Shopper: Appointment Availability":
         createIDForChildrenOfAnalysisMethod(SecretShopperJson, id);
         return { ...analysisMethod, children: SecretShopperJson };
       default:

--- a/services/ui-src/src/utils/forms/naaarPlanCompliance.test.ts
+++ b/services/ui-src/src/utils/forms/naaarPlanCompliance.test.ts
@@ -195,6 +195,11 @@ describe("utils/forms/naaarPlanCompliance", () => {
         },
         {
           id: "mockUUID3",
+          name: "Plan Provider Directory Review",
+          analysis_method_applicable_plans: [{ value: "Plan 1" }],
+        },
+        {
+          id: "mockUUID4",
           name: "Secret Shopper: Appointment Availability",
           analysis_method_applicable_plans: [{ value: "Plan 1" }],
         },
@@ -210,6 +215,10 @@ describe("utils/forms/naaarPlanCompliance", () => {
             },
             {
               key: `standard_analysisMethodsUtilized-${entityId}-mockUUID3`,
+              value: "Plan Provider Directory Review",
+            },
+            {
+              key: `standard_analysisMethodsUtilized-${entityId}-mockUUID4`,
               value: "Secret Shopper: Appointment Availability",
             },
           ],
@@ -233,6 +242,11 @@ describe("utils/forms/naaarPlanCompliance", () => {
         },
         {
           id: "planCompliance43868-standard-id-nonComplianceAnalyses_mockUUID3",
+          label: "Plan Provider Directory Review",
+          children: expect.any(Array),
+        },
+        {
+          id: "planCompliance43868-standard-id-nonComplianceAnalyses_mockUUID4",
           label: "Secret Shopper: Appointment Availability",
           children: expect.any(Array),
         },


### PR DESCRIPTION
### Description
Add Plan Provider Directory Review children to plan compliance section, seen below:
![Screenshot 2025-04-16 at 2 18 04 PM](https://github.com/user-attachments/assets/6828cb1e-9fc9-41d2-aed1-345b2b5ef634)



### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4266

---
### How to test
Create a NAAAR report, make sure to add `Plan Provider Directory Review` as an analysis method in the standard and the plan. Fill it out until you get into plan compliance, select the checkbox stating that the plan is non-compliant, see that `Plan Provider Directory Review1 is an option to select and then its children match the figma.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
