### PR TITLE
swap field order for non-compliance

### DIFF
--- a/services/app-api/forms/naaar.json
+++ b/services/app-api/forms/naaar.json
@@ -1287,19 +1287,6 @@
                         "label": "Standard is non-compliant for this plan",
                         "children": [
                           {
-                            "id": "planCompliance43868_standard-nonComplianceDescription",
-                            "type": "textarea",
-                            "validation": {
-                              "type": "text",
-                              "nested": true,
-                              "parentFieldName": "planCompliance43868_standard"
-                            },
-                            "props": {
-                              "hint": "Describe plan deficiencies identified during the reporting period.",
-                              "label": "Plan deficiencies: 42 C.F.R. § 438.68 description"
-                            }
-                          },
-                          {
                             "id": "planCompliance43868_standard-nonComplianceAnalyses",
                             "type": "checkbox",
                             "validation": {
@@ -1328,6 +1315,19 @@
                                 }
                               ],
                               "choices": []
+                            }
+                          },
+                          {
+                            "id": "planCompliance43868_standard-nonComplianceDescription",
+                            "type": "textarea",
+                            "validation": {
+                              "type": "text",
+                              "nested": true,
+                              "parentFieldName": "planCompliance43868_standard"
+                            },
+                            "props": {
+                              "hint": "Describe plan deficiencies identified during the reporting period.",
+                              "label": "Plan deficiencies: 42 C.F.R. § 438.68 description"
                             }
                           },
                           {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Move textarea question from first to second so that the analysis methods question comes first in non-compliance child form

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4525

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Report already set up in [deployed env](https://d34abr3qmi5fd7.cloudfront.net/) under `stateuser@test.com`, Minnesota
- Log in as a state user
- Create a NAAAR
- Enter plans, provider type coverage, analysis methods, and standards
- Go to plan compliance and mark a plan as non-compliant for 438.68
- Enter the details view and mark a standard as non-compliant
- Notice the analysis methods are listed first in the sub-fields
- Verify special analysis methods like Geomapping and Secret Shopper AA still have their child fields show up

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary
---