### PR TITLE
Cmdct 4528 error fix

### DIFF
--- a/services/ui-src/src/components/reports/DrawerReportEntityRows.test.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportEntityRows.test.tsx
@@ -12,9 +12,9 @@ import {
   mockNaaarReportContext,
   mockNaaarReportStore,
   mockNaaarAnalysisMethodsPageJson,
+  mockAnalysisMethodEntityStore,
 } from "utils/testing/setupJest";
 import { DEFAULT_ANALYSIS_METHODS } from "../../constants";
-import { EntityType, McrEntityState } from "types";
 
 const mockUseNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
@@ -60,20 +60,6 @@ describe("<DrawerReportEntityRow />", () => {
   });
 
   describe("Analysis methods custom logic", () => {
-    const mockAnalysisMethodEntityStore: McrEntityState = {
-      entities: [],
-      entityType: EntityType.ANALYSIS_METHODS,
-      selectedEntity: {
-        id: "k9t7YoOeTOAXX3s7qF6XfN33",
-        name: "Geomapping",
-        isRequired: true,
-      },
-      // ACTIONS
-      setSelectedEntity: () => {},
-      setEntityType: () => {},
-      setEntities: () => {},
-    };
-
     beforeEach(() => {
       const mockNaaarReportContextWithCustomAnalysisMethods: any =
         mockNaaarReportContext;
@@ -87,6 +73,12 @@ describe("<DrawerReportEntityRow />", () => {
           id: "mock-id",
           custom_analysis_method_name: "New Method",
           custom_analysis_method_description: "mock description",
+          analysis_applicable: [
+            {
+              key: "analysis_applicable",
+              value: "Yes",
+            },
+          ],
           analysis_method_frequency: [
             {
               key: "analysis_method_frequency",

--- a/services/ui-src/src/components/reports/DrawerReportEntityRows.test.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportEntityRows.test.tsx
@@ -9,7 +9,6 @@ import {
   mockMcparReportStore,
   mockEntityStore,
   mockMcparIlosPageJson,
-  mockNaaarReportContext,
   mockNaaarReportStore,
   mockNaaarAnalysisMethodsPageJson,
   mockAnalysisMethodEntityStore,
@@ -70,86 +69,6 @@ describe("<DrawerReportEntityRow />", () => {
     });
   });
 
-  describe("Analysis methods custom logic", () => {
-    beforeEach(() => {
-      const mockNaaarReportContextWithCustomAnalysisMethods: any =
-        mockNaaarReportContext;
-
-      const { report } = mockNaaarReportContextWithCustomAnalysisMethods;
-
-      // add custom entity to render special row type
-      report.fieldData["analysisMethods"] = [
-        DEFAULT_ANALYSIS_METHODS[0],
-        {
-          id: "mock-id",
-          custom_analysis_method_name: "New Method",
-          custom_analysis_method_description: "mock description",
-          analysis_applicable: [
-            {
-              key: "analysis_applicable",
-              value: "Yes",
-            },
-          ],
-          analysis_method_frequency: [
-            {
-              key: "analysis_method_frequency",
-              value: "Weekly",
-            },
-          ],
-          analysis_method_applicable_plans: [
-            {
-              key: "mock-id-1",
-              value: "Plan 1",
-            },
-            {
-              key: "mock-id-2",
-              value: "Plan 2",
-            },
-            {
-              key: "mock-id-3",
-              value: "Plan 3",
-            },
-          ],
-        },
-      ];
-
-      const mockCustomNaaarReportStore = {
-        ...mockNaaarReportStore,
-        report,
-        reportsByState: [report],
-      };
-
-      mockedUseStore.mockReturnValue({
-        ...mockStateUserStore,
-        ...mockCustomNaaarReportStore,
-        ...mockAnalysisMethodEntityStore,
-      });
-
-      const drawerReportPageWithCustomEntities = (
-        <RouterWrappedComponent>
-          <ReportContext.Provider
-            value={mockNaaarReportContextWithCustomAnalysisMethods}
-          >
-            <DrawerReportPage route={mockNaaarAnalysisMethodsPageJson} />
-          </ReportContext.Provider>
-        </RouterWrappedComponent>
-      );
-
-      render(drawerReportPageWithCustomEntities);
-    });
-
-    test("Should display comma separated plans list", async () => {
-      const CommaSeparatedList = screen.getByText(
-        "Weekly: Plan 1, Plan 2, Plan 3",
-        {
-          trim: true,
-          collapseWhitespace: true,
-        }
-      );
-      expect(CommaSeparatedList).toBeVisible();
-    });
-  });
-
   describe("NAAAR Analysis Methods", () => {
     const incompleteAnalysisMethodsReport = {
       ...mockNaaarReportWithAnalysisMethods,
@@ -182,6 +101,73 @@ describe("<DrawerReportEntityRow />", () => {
       report: incompleteAnalysisMethodsReport,
       reportsByState: [incompleteAnalysisMethodsReport],
     };
+
+    const customAnalysisMethodsReport = {
+      ...mockNaaarReportWithAnalysisMethods,
+      fieldData: {
+        ...mockNaaarReportFieldData,
+        analysisMethods: [
+          DEFAULT_ANALYSIS_METHODS[0],
+          {
+            id: "mock-id",
+            custom_analysis_method_name: "New Method",
+            custom_analysis_method_description: "mock description",
+            analysis_applicable: [
+              {
+                key: "analysis_applicable",
+                value: "Yes",
+              },
+            ],
+            analysis_method_frequency: [
+              {
+                key: "analysis_method_frequency",
+                value: "Weekly",
+              },
+            ],
+            analysis_method_applicable_plans: [
+              {
+                key: "mock-id-1",
+                value: "Plan 1",
+              },
+              {
+                key: "mock-id-2",
+                value: "Plan 2",
+              },
+              {
+                key: "mock-id-3",
+                value: "Plan 3",
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const mockCustomAnalysisMethodsReportStore = {
+      ...mockNaaarReportStore,
+      report: customAnalysisMethodsReport,
+      reportsByState: [customAnalysisMethodsReport],
+    };
+
+    test("Should display comma separated plans list", async () => {
+      mockedUseStore.mockReturnValue({
+        ...mockStateUserStore,
+        ...mockCustomAnalysisMethodsReportStore,
+        ...mockAnalysisMethodEntityStore,
+      });
+
+      render(drawerReportPageWithAnalysisMethods);
+
+      const CommaSeparatedList = screen.getByText(
+        "Weekly: Plan 1, Plan 2, Plan 3",
+        {
+          trim: true,
+          collapseWhitespace: true,
+        }
+      );
+      expect(CommaSeparatedList).toBeVisible();
+    });
+
     test("should render rows when analysis methods are incomplete", async () => {
       mockedUseStore.mockReturnValue({
         ...mockStateUserStore,

--- a/services/ui-src/src/components/reports/DrawerReportEntityRows.test.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportEntityRows.test.tsx
@@ -13,6 +13,9 @@ import {
   mockNaaarReportStore,
   mockNaaarAnalysisMethodsPageJson,
   mockAnalysisMethodEntityStore,
+  mockNaaarReportWithAnalysisMethods,
+  mockNaaarReportFieldData,
+  mockNaaarReportWithAnalysisMethodsContext,
 } from "utils/testing/setupJest";
 import { DEFAULT_ANALYSIS_METHODS } from "../../constants";
 
@@ -34,6 +37,14 @@ const drawerReportPageWithEntities = (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockMcparReportContext}>
       <DrawerReportPage route={mockMcparIlosPageJson} />
+    </ReportContext.Provider>
+  </RouterWrappedComponent>
+);
+
+const drawerReportPageWithAnalysisMethods = (
+  <RouterWrappedComponent>
+    <ReportContext.Provider value={mockNaaarReportWithAnalysisMethodsContext}>
+      <DrawerReportPage route={mockNaaarAnalysisMethodsPageJson} />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
@@ -136,6 +147,50 @@ describe("<DrawerReportEntityRow />", () => {
         }
       );
       expect(CommaSeparatedList).toBeVisible();
+    });
+  });
+
+  describe("NAAAR Analysis Methods", () => {
+    const incompleteAnalysisMethodsReport = {
+      ...mockNaaarReportWithAnalysisMethods,
+      fieldData: {
+        ...mockNaaarReportFieldData,
+        analysisMethods: [
+          {
+            ...DEFAULT_ANALYSIS_METHODS[0],
+            analysis_applicable: [
+              {
+                key: "analysis_applicable",
+                value: "No",
+              },
+            ],
+            analysis_method_frequency: [],
+            analysis_method_applicable_plans: [],
+          },
+        ],
+        providerTypes: [
+          {
+            key: "mock-key",
+            value: "mock-value",
+          },
+        ],
+      },
+    };
+
+    const mockIncompleteAnalysisMethodsReportStore = {
+      ...mockNaaarReportStore,
+      report: incompleteAnalysisMethodsReport,
+      reportsByState: [incompleteAnalysisMethodsReport],
+    };
+    test("should render rows when analysis methods are incomplete", async () => {
+      mockedUseStore.mockReturnValue({
+        ...mockStateUserStore,
+        ...mockIncompleteAnalysisMethodsReportStore,
+        ...mockAnalysisMethodEntityStore,
+      });
+      render(drawerReportPageWithAnalysisMethods);
+
+      expect(screen.getByText("Not utilized")).toBeVisible();
     });
   });
 });

--- a/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
@@ -105,9 +105,12 @@ export const DrawerReportPageEntityRows = ({
         }
 
         const plans = entity?.analysis_method_applicable_plans;
+        const isUtilized =
+          entity?.analysis_applicable &&
+          entity?.analysis_applicable[0]?.value === "Yes";
         let completeText = "Not utilized";
 
-        if (plans) {
+        if (plans && isUtilized) {
           const frequencyVal = entity.analysis_method_frequency[0].value;
           const frequency = otherSpecify(
             frequencyVal,

--- a/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
@@ -103,7 +103,6 @@ export const DrawerReportPageEntityRows = ({
           const incompleteText = "Select “Enter” to complete response.";
           return <Text sx={sx.incompleteText}>{incompleteText}</Text>;
         }
-
         const plans = entity?.analysis_method_applicable_plans;
         const isUtilized =
           entity?.analysis_applicable &&

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -330,7 +330,7 @@ export const mockNaaarAnalysisMethodsPageJson = {
     id: "am",
     fields: [
       {
-        id: "mock-field-id",
+        id: "analysis_applicable",
         props: {
           choices: [
             {

--- a/services/ui-src/src/utils/testing/mockRouter.tsx
+++ b/services/ui-src/src/utils/testing/mockRouter.tsx
@@ -2,5 +2,7 @@ import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
 
 export const RouterWrappedComponent: React.FC = ({ children }) => (
-  <Router>{children}</Router>
+  <Router future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+    {children}
+  </Router>
 );


### PR DESCRIPTION
### Description
Fixes a bug where marking all analysis methods as "not utilized" caused the analysis methods page to crash


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4528

---
### How to test
Already created a report in deployed env: 

1. In Section 1 > Analysis methods (/naaar/state-and-program-information/analysis-methods), edit an analysis method.
2. For the question "Is this analysis method utilized to assess plan compliance?" answer **Yes** and fill out the rest of the fields in the drawer.
3. Save and close the drawer.
4. Edit the remaining analysis methods and answer **No**.
5. Edit the analysis method marked as **Yes** and change the answer to **No**.
6. Save and close the drawer.
7. The page should still render, you should see no errors, and the table row should say "Not utilized"

**Note:** this is a workaround to an edge case that still needs to be solved for. That user flow is pending product requirements.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
