### PR TITLE
mock structured clone in jest globals

### DIFF
--- a/services/app-api/handlers/reports/create.test.ts
+++ b/services/app-api/handlers/reports/create.test.ts
@@ -26,8 +26,6 @@ jest.mock("../../utils/auth/authorization", () => ({
   hasPermissions: jest.fn().mockReturnValue(true),
 }));
 
-global.structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
-
 const mockProxyEvent = {
   ...proxyEvent,
   headers: { "cognito-identity-id": "test" },

--- a/services/app-api/utils/formTemplates/formTemplates.test.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.test.ts
@@ -35,8 +35,6 @@ const dynamoClientMock = mockClient(DynamoDBDocumentClient);
 const programIsPCCM = true;
 const programIsNotPCCM = false;
 
-global.structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
-
 const currentMLRFormHash = createHash("md5")
   .update(JSON.stringify(mlr))
   .digest("hex");

--- a/services/app-api/utils/testing/setupJest.ts
+++ b/services/app-api/utils/testing/setupJest.ts
@@ -3,6 +3,12 @@ import sign from "jwt-encode";
 import { MCPARReportMetadata, MLRReportMetadata } from "../types";
 import { mockReportRoutes } from "./mocks/mockReport";
 
+// GLOBALS
+
+global.structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
+
+// MOCKS
+
 export const mockS3PutObjectCommandOutput = {
   $metadata: { attempts: 1 },
   ETag: "some etag value",

--- a/services/ui-src/src/components/overlays/EntityDetailsMultiformOverlay.test.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsMultiformOverlay.test.tsx
@@ -19,7 +19,6 @@ import {
 import { useStore } from "utils";
 import { EntityType, ReportShape } from "types";
 
-global.structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
 window.HTMLElement.prototype.scrollIntoView = jest.fn();
 
 jest.mock("utils/state/useStore");

--- a/services/ui-src/src/components/overlays/PlanComplianceTableOverlay.test.tsx
+++ b/services/ui-src/src/components/overlays/PlanComplianceTableOverlay.test.tsx
@@ -20,8 +20,6 @@ import {
 } from "utils/testing/setupJest";
 import { useStore } from "utils";
 
-global.structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
-
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 mockedUseStore.mockReturnValue({

--- a/services/ui-src/src/utils/forms/dynamicItemFields.test.ts
+++ b/services/ui-src/src/utils/forms/dynamicItemFields.test.ts
@@ -131,8 +131,6 @@ const mockAnalysisMethods: AnyObject[] = [
   },
 ];
 
-global.structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
-
 describe("generateDrawerItemFields for ILOS", () => {
   const result = generateDrawerItemFields(
     mockIlosForm,

--- a/services/ui-src/src/utils/forms/naaarPlanCompliance.test.ts
+++ b/services/ui-src/src/utils/forms/naaarPlanCompliance.test.ts
@@ -18,8 +18,6 @@ import {
   hasComplianceDetails,
 } from "utils";
 
-global.structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
-
 describe("utils/forms/naaarPlanCompliance", () => {
   describe("hasComplianceDetails()", () => {
     const exceptionsNonCompliance = [

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -5,6 +5,7 @@ import "jest-axe/extend-expect";
 // GLOBALS
 
 global.React = React;
+global.structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
 
 /* Mocks window.matchMedia (https://bit.ly/3Qs4ZrV) */
 Object.defineProperty(window, "matchMedia", {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
the version of jest we use does not recognize the `structuredClone` function. upgrading jest is a big lift, and we have been mocking `structuredClone` with its dated equivalent `JSON.parse(JSON.stringify(obj))`

- Include `structuredClone` mock in jest setup such that we need only define it once

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- all ui-src/ tests pass
- all app-api/ tests pass