### PR TITLE
fix custom analysis methods display text

### DIFF
--- a/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
@@ -105,8 +105,7 @@ export const DrawerReportPageEntityRows = ({
         }
         const plans = entity?.analysis_method_applicable_plans;
         const isUtilized =
-          entity?.analysis_applicable &&
-          entity?.analysis_applicable[0]?.value === "Yes";
+          entity?.analysis_applicable?.[0]?.value === "Yes" || isCustomEntity;
         let completeText = "Not utilized";
 
         if (plans && isUtilized) {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Custom analysis methods were displaying "not utilized" because the utilization conditional was not accounting for them.

Custom analysis methods should always be considered utilized, meaning they always display all their field info.

- Update conditional to acknowledge custom analysis methods
- Simplify logic for default method check

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4528 cont.

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[Deployed env](https://d2tw2rvizpllob.cloudfront.net/)
- Log in as a state user
- Create a NAAAR (or view existing one)
- Add a plan
- Go to analysis methods and test the following:
  - a default method marked "not applicable" displays "Not utilized"
  - a default method marked "applicable" displays frequency and plan info
  - a custom method always displays all info, and is never "not utilized"

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
