### PR TITLE
save & return bug

### DIFF
--- a/services/ui-src/src/components/forms/SaveReturnButton.test.tsx
+++ b/services/ui-src/src/components/forms/SaveReturnButton.test.tsx
@@ -1,33 +1,68 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import {
+  mockAdminUserStore,
+  mockStateUserStore,
+} from "utils/testing/mockZustand";
 import { SaveReturnButton } from "./SaveReturnButton";
+import { useStore } from "utils";
 
 const mockDisabledOnClick = jest.fn();
 const mockOnClick = jest.fn();
+const disabledOnClick = jest.fn();
+jest.mock("utils/state/useStore");
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 
 describe("<SaveReturnButton />", () => {
-  test("renders Save & return button", async () => {
-    render(<SaveReturnButton onClick={mockOnClick} />);
+  describe("<SaveReturnButton />", () => {
+    beforeEach(async () => {
+      mockedUseStore.mockReturnValue({
+        ...mockStateUserStore,
+      });
+    });
+    test("renders Save & return button", async () => {
+      render(<SaveReturnButton onClick={mockOnClick} />);
 
-    const button = screen.getByRole("button", { name: "Save & return" });
-    await userEvent.click(button);
-    expect(mockOnClick).toBeCalled();
+      const button = screen.getByRole("button", { name: "Save & return" });
+      await userEvent.click(button);
+      expect(mockOnClick).toBeCalled();
+    });
+
+    test("renders Return button", async () => {
+      render(
+        <SaveReturnButton
+          disabled={true}
+          disabledOnClick={mockDisabledOnClick}
+        />
+      );
+
+      const button = screen.getByRole("button", { name: "Return" });
+      await userEvent.click(button);
+      expect(mockDisabledOnClick).toBeCalled();
+    });
+
+    test("renders Spinner", async () => {
+      render(<SaveReturnButton submitting={true} />);
+
+      const loading = screen.getByRole("button", { name: "Loading..." });
+      expect(loading).toBeVisible();
+    });
   });
 
-  test("renders Return button", async () => {
-    render(
-      <SaveReturnButton disabled={true} disabledOnClick={mockDisabledOnClick} />
-    );
+  describe("admin view", () => {
+    beforeEach(async () => {
+      mockedUseStore.mockReturnValue({
+        ...mockAdminUserStore,
+      });
+    });
+    test("calls disabledOnClick for admin", async () => {
+      render(
+        <SaveReturnButton disabledOnClick={disabledOnClick} formId="form-123" />
+      );
 
-    const button = screen.getByRole("button", { name: "Return" });
-    await userEvent.click(button);
-    expect(mockDisabledOnClick).toBeCalled();
-  });
-
-  test("renders Spinner", async () => {
-    render(<SaveReturnButton submitting={true} />);
-
-    const loading = screen.getByRole("button", { name: "Loading..." });
-    expect(loading).toBeVisible();
+      const button = screen.getByRole("button", { name: "Return" });
+      await userEvent.click(button);
+      expect(disabledOnClick).toHaveBeenCalled();
+    });
   });
 });

--- a/services/ui-src/src/components/forms/SaveReturnButton.test.tsx
+++ b/services/ui-src/src/components/forms/SaveReturnButton.test.tsx
@@ -14,7 +14,7 @@ jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 
 describe("<SaveReturnButton />", () => {
-  describe("<SaveReturnButton />", () => {
+  describe("<SaveReturnButton /> for state user", () => {
     beforeEach(async () => {
       mockedUseStore.mockReturnValue({
         ...mockStateUserStore,

--- a/services/ui-src/src/components/forms/SaveReturnButton.tsx
+++ b/services/ui-src/src/components/forms/SaveReturnButton.tsx
@@ -13,18 +13,18 @@ export const SaveReturnButton = ({
   onClick,
   submitting = false,
 }: Props) => {
-  const { userIsAdmin, userIsReadOnly } = useStore().user ?? {};
+  const { userIsEndUser } = useStore().user ?? {};
   // formId is for a single form, onClick is for multiple forms/custom action
 
   const handlers =
     // prevent submit for admin or read-only user
-    userIsAdmin || userIsReadOnly
+    !userIsEndUser
       ? { onClick: disabledOnClick }
       : onClick
       ? { onClick }
       : { form: formId! };
 
-  const buttonText = userIsAdmin || userIsReadOnly ? "Return" : "Save & return";
+  const buttonText = !userIsEndUser ? "Return" : "Save & return";
   return (
     <Box sx={{ ...sx.footerBox, ...(border && sx.footerBoxBorder) }}>
       <Flex sx={sx.buttonFlex}>

--- a/services/ui-src/src/components/forms/SaveReturnButton.tsx
+++ b/services/ui-src/src/components/forms/SaveReturnButton.tsx
@@ -3,6 +3,7 @@ import { MouseEventHandler } from "react";
 import { Box, Button, Flex, Image, Spinner } from "@chakra-ui/react";
 // assets
 import nextIcon from "assets/icons/icon_next_white.png";
+import { useStore } from "utils";
 
 export const SaveReturnButton = ({
   border = true,
@@ -12,9 +13,18 @@ export const SaveReturnButton = ({
   onClick,
   submitting = false,
 }: Props) => {
+  const { userIsAdmin, userIsReadOnly } = useStore().user ?? {};
   // formId is for a single form, onClick is for multiple forms/custom action
-  const handlers = onClick ? { onClick } : { form: formId };
 
+  const handlers =
+    // prevent submit for admin or read-only user
+    userIsAdmin || userIsReadOnly
+      ? { onClick: disabledOnClick }
+      : onClick
+      ? { onClick }
+      : { form: formId! };
+
+  const buttonText = userIsAdmin || userIsReadOnly ? "Return" : "Save & return";
   return (
     <Box sx={{ ...sx.footerBox, ...(border && sx.footerBoxBorder) }}>
       <Flex sx={sx.buttonFlex}>
@@ -34,7 +44,7 @@ export const SaveReturnButton = ({
             type="submit"
             {...handlers}
           >
-            {submitting ? <Spinner size="md" /> : "Save & return"}
+            {submitting ? <Spinner size="md" /> : buttonText}
           </Button>
         )}
       </Flex>

--- a/services/ui-src/src/components/overlays/PlanComplianceTableOverlay.tsx
+++ b/services/ui-src/src/components/overlays/PlanComplianceTableOverlay.tsx
@@ -245,6 +245,7 @@ export const PlanComplianceTableOverlay = ({
             border={false}
             onClick={closeEntityDetailsOverlay}
             submitting={submitting}
+            disabledOnClick={closeEntityDetailsOverlay}
           />
         </Box>
       </Box>


### PR DESCRIPTION
### Description

This was found in the bug bash. Any kind of user saw the same `Save & return` button, with the onClick triggering a submission. This fix changes the text to `Return` for admin and read-only users, and prevents the submit call.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4520

---
Fill out a NAAAR report, go into Plan Compliance. Go through all three levels to see that the button looks correct, navigates backwards correctly, and there is no attempt to submit the form.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
