### PR TITLE
NAAAR PDF: Add standards display info to non-compliance cards

### DIFF
--- a/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.tsx
@@ -184,10 +184,22 @@ export const EntityCardBottomSection = ({
     case EntityType.STANDARDS:
       return (
         <Box sx={{ ...sx.highlightContainer, padding: "0.5rem" }}>
-          <Text fontWeight={"bold"} fontSize={"xs"}>
-            Provider type(s)
-          </Text>
-          <Text fontSize={"sm"}>{formattedEntityData.provider}</Text>
+          <Text sx={{ ...sx.subtitle, marginTop: "0" }}>Provider type(s)</Text>
+          <Text sx={sx.subtext}>{formattedEntityData.provider}</Text>
+          <Flex>
+            <Box sx={sx.standardDetailsBoxes}>
+              <Text sx={sx.subtitle}>Analysis method(s)</Text>
+              <Text sx={sx.subtext}>{formattedEntityData.analysisMethods}</Text>
+            </Box>
+            <Box sx={sx.standardDetailsBoxes}>
+              <Text sx={sx.subtitle}>Region</Text>
+              <Text sx={sx.subtext}>{formattedEntityData.region}</Text>
+            </Box>
+            <Box sx={sx.standardDetailsBoxes}>
+              <Text sx={sx.subtitle}>Population</Text>
+              <Text sx={sx.subtext}>{formattedEntityData.population}</Text>
+            </Box>
+          </Flex>
         </Box>
       );
     default:
@@ -248,5 +260,9 @@ const sx = {
   notAnswered: {
     fontSize: "sm",
     color: "palette.error_darker",
+  },
+  standardDetailsBoxes: {
+    width: "10.5rem",
+    marginRight: "3rem",
   },
 };

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 // components
-import { Grid, GridItem, Heading, Text } from "@chakra-ui/react";
+import { Flex, Grid, GridItem, Heading, Text } from "@chakra-ui/react";
 // types
 import { AnyObject, EntityType } from "types";
 
@@ -136,8 +136,14 @@ export const EntityCardTopSection = ({
     case EntityType.STANDARDS:
       return (
         <>
-          <Text sx={sx.standardHeading}>
-            {formattedEntityData.standardType}
+          <Flex>
+            <Text sx={sx.standardCount}>{formattedEntityData.count}</Text>
+            <Text sx={sx.standardHeading}>
+              {formattedEntityData.standardType}
+            </Text>
+          </Flex>
+          <Text sx={sx.standardDescription}>
+            {formattedEntityData.description}
           </Text>
         </>
       );
@@ -188,9 +194,18 @@ const sx = {
       color: "palette.error_darker",
     },
   },
+  standardCount: {
+    width: "44px",
+    fontWeight: "bold",
+    fontSize: "sm",
+    color: "palette.gray_medium",
+  },
   standardHeading: {
     fontWeight: "bold",
     fontSize: "md",
+  },
+  standardDescription: {
+    marginTop: "1rem",
   },
   planHeading: {
     marginTop: "1rem",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Add standard details to non-compliance cards in PDF

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4468 pt. 3

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a NAAAR
- Add a plan, at least one provider type, and at least one analysis method
- Add two or three standards
- In plan compliance, mark your plan as non-compliant for 438.68
- In non-compliance details, mark one standard as non-compliant and one as an exception. If you added a third, leave it incomplete
- View the PDF
- Scroll to section three and verify:
  - Each card lists standard related information and matches [Figma](https://www.figma.com/design/QcoVlfZ2adUBnzcHiI0G0S/MDCT-MCR-NAAAR?node-id=1356-27090&t=CGPOJkTMtx8hWQMP-0)
  - Standards with no compliance details do not display

| Before | After |
| ------ | ----- |
| <img width="351" alt="Screenshot 2025-05-01 at 10 58 31 AM" src="https://github.com/user-attachments/assets/110561f1-5130-4373-9b24-593363700c62" /> | <img width="365" alt="Screenshot 2025-05-01 at 10 59 39 AM" src="https://github.com/user-attachments/assets/9bb6d080-080e-4487-a4bd-3fbc5194bf47" /> |


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

To be reviewed by design and product once complete

---
