### PR TITLE
NAAAR PDF: Non-compliance details

### DIFF
--- a/logs/launchdarkly-flags.log
+++ b/logs/launchdarkly-flags.log
@@ -5,7 +5,7 @@
 ./services/ui-src/src/components/cards/TemplateCard.tsx:33:useFlags()?.naaarReport;
 ./services/ui-src/src/components/forms/AdminDashSelector.tsx:40:useFlags()?.naaarReport;
 ./services/ui-src/src/components/modals/AddEditReportModal.tsx:44:useFlags()?.naaarReport;
-./services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx:214:useFlags()?.sortableDashboardTable;
+./services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx:206:useFlags()?.sortableDashboardTable;
 
 # LaunchDarkly flags in tests
 ./services/ui-src/src/components/app/AppRoutes.test.tsx:142:mockLDFlags.set({ naaarReport: true });

--- a/services/ui-src/src/components/cards/Card.tsx
+++ b/services/ui-src/src/components/cards/Card.tsx
@@ -1,10 +1,12 @@
 import { ReactChild } from "react";
 // components
 import { Box } from "@chakra-ui/react";
+// types
+import { AnyObject } from "types";
 
-export const Card = ({ children, ...props }: Props) => {
+export const Card = ({ children, sxOverride, ...props }: Props) => {
   return (
-    <Box {...props} sx={{ ...sx.root, ...props?.sxOverride }}>
+    <Box {...props} sx={{ ...sx.root, ...sxOverride }}>
       {children}
     </Box>
   );
@@ -12,6 +14,7 @@ export const Card = ({ children, ...props }: Props) => {
 
 interface Props {
   children?: ReactChild | ReactChild[];
+  sxOverride?: AnyObject;
   [key: string]: any;
 }
 

--- a/services/ui-src/src/components/cards/Card.tsx
+++ b/services/ui-src/src/components/cards/Card.tsx
@@ -4,7 +4,7 @@ import { Box } from "@chakra-ui/react";
 
 export const Card = ({ children, ...props }: Props) => {
   return (
-    <Box {...props} sx={sx.root}>
+    <Box {...props} sx={{ ...sx.root, ...props?.sxOverride }}>
       {children}
     </Box>
   );

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.tsx
@@ -181,6 +181,27 @@ export const EntityCardBottomSection = ({
           )}
         </>
       );
+    case EntityType.STANDARDS:
+      return (
+        <Box sx={{ ...sx.highlightContainer, padding: "0.5rem" }}>
+          <Text sx={{ ...sx.subtitle, marginTop: "0" }}>Provider type(s)</Text>
+          <Text sx={sx.subtext}>{formattedEntityData.provider}</Text>
+          <Flex>
+            <Box sx={sx.standardDetailsBoxes}>
+              <Text sx={sx.subtitle}>Analysis method(s)</Text>
+              <Text sx={sx.subtext}>{formattedEntityData.analysisMethods}</Text>
+            </Box>
+            <Box sx={sx.standardDetailsBoxes}>
+              <Text sx={sx.subtitle}>Region</Text>
+              <Text sx={sx.subtext}>{formattedEntityData.region}</Text>
+            </Box>
+            <Box sx={sx.standardDetailsBoxes}>
+              <Text sx={sx.subtitle}>Population</Text>
+              <Text sx={sx.subtext}>{formattedEntityData.population}</Text>
+            </Box>
+          </Flex>
+        </Box>
+      );
     default:
       return <Text>{entityType}</Text>;
   }
@@ -239,5 +260,9 @@ const sx = {
   notAnswered: {
     fontSize: "sm",
     color: "palette.error_darker",
+  },
+  standardDetailsBoxes: {
+    width: "10.5rem",
+    marginRight: "3rem",
   },
 };

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 // components
-import { Grid, GridItem, Heading, Text } from "@chakra-ui/react";
+import { Flex, Grid, GridItem, Heading, Text } from "@chakra-ui/react";
 // types
 import { AnyObject, EntityType } from "types";
 
@@ -133,6 +133,28 @@ export const EntityCardTopSection = ({
           <Text sx={sx.subtext}>{formattedEntityData.description}</Text>
         </>
       );
+    case EntityType.STANDARDS:
+      return (
+        <>
+          <Flex>
+            <Text sx={sx.standardCount}>{formattedEntityData.count}</Text>
+            <Text sx={sx.standardHeading}>
+              {formattedEntityData.standardType}
+            </Text>
+          </Flex>
+          <Text sx={sx.standardDescription}>
+            {formattedEntityData.description}
+          </Text>
+        </>
+      );
+    case EntityType.PLANS:
+      return (
+        <>
+          <Text sx={sx.planHeading}>
+            Plan deficiencies for {formattedEntityData.name}: 42 C.F.R. § 438.68
+          </Text>
+        </>
+      );
     default:
       return <Text>{entityType}</Text>;
   }
@@ -171,5 +193,26 @@ const sx = {
     "&.pdf-color": {
       color: "palette.error_darker",
     },
+  },
+  standardCount: {
+    width: "44px",
+    fontWeight: "bold",
+    fontSize: "sm",
+    color: "palette.gray_medium",
+  },
+  standardHeading: {
+    fontWeight: "bold",
+    fontSize: "md",
+  },
+  standardDescription: {
+    marginTop: "1rem",
+  },
+  planHeading: {
+    marginTop: "1rem",
+    paddingTop: "1rem",
+    borderTop: "1px solid",
+    borderTopColor: "palette.gray_lighter",
+    fontWeight: "bold",
+    fontSize: "md",
   },
 };

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardTopSection.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 // components
-import { Flex, Grid, GridItem, Heading, Text } from "@chakra-ui/react";
+import { Box, Flex, Grid, GridItem, Heading, Text } from "@chakra-ui/react";
 // types
 import { AnyObject, EntityType } from "types";
 
@@ -150,9 +150,15 @@ export const EntityCardTopSection = ({
     case EntityType.PLANS:
       return (
         <>
-          <Text sx={sx.planHeading}>
-            Plan deficiencies for {formattedEntityData.name}: 42 C.F.R. § 438.68
-          </Text>
+          <Text sx={sx.planHeading}>{formattedEntityData.heading}</Text>
+          {formattedEntityData?.questions?.map((q: AnyObject) => {
+            return (
+              <Box key={`${q.question} ${q.answer}`}>
+                <Text sx={sx.subtitle}>{q.question}</Text>
+                <Text sx={sx.subtext}>{q.answer}</Text>
+              </Box>
+            );
+          })}
         </>
       );
     default:

--- a/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
@@ -13,15 +13,6 @@ import {
 } from "types";
 // utils
 import { assertExhaustive, getEntityDetailsMLR, useStore } from "utils";
-// verbiage
-import mcparVerbiage from "verbiage/pages/mcpar/mcpar-export";
-import mlrVerbiage from "verbiage/pages/mlr/mlr-export";
-
-const exportVerbiageMap: { [key in ReportType]: any } = {
-  MCPAR: mcparVerbiage,
-  MLR: mlrVerbiage,
-  NAAAR: undefined,
-};
 
 export const ExportedEntityDetailsOverlaySection = ({
   section,
@@ -33,7 +24,6 @@ export const ExportedEntityDetailsOverlaySection = ({
   return (
     <Box sx={sx.sectionHeading} {...props}>
       <ExportedSectionHeading
-        heading={exportVerbiageMap[report?.reportType as ReportType]}
         verbiage={{
           ...section.verbiage,
           intro: {

--- a/services/ui-src/src/components/export/ExportedEntityDetailsTable.test.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTable.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
 // components
 import { ExportedEntityDetailsTable } from "components";
+// types
+import { ReportType } from "types";
 // utils
 import {
   mockMlrReportContext,
@@ -29,6 +31,12 @@ const exportedEntityDetailsTableComponent = () => (
   ></ExportedEntityDetailsTable>
 );
 describe("<ExportedEntityDetailsTable />", () => {
+  beforeAll(() => {
+    localStorage.setItem("selectedReportType", ReportType.MLR);
+  });
+  afterAll(() => {
+    localStorage.setItem("selectedReportType", "");
+  });
   test("renders successfully", async () => {
     const { findAllByText, findByTestId } = render(
       exportedEntityDetailsTableComponent()

--- a/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
@@ -23,12 +23,14 @@ export const ExportedEntityDetailsTable = ({
   entity,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   showHintText,
+  entityType: passedEntityType,
+  entityIndex,
   ...props
 }: Props) => {
   const { report } = useStore();
   const { tableHeaders } = verbiage;
 
-  const entityType = props?.entityType ?? EntityType.PROGRAM;
+  const entityType = passedEntityType ?? EntityType.PROGRAM;
 
   const threeColumnHeaderItems = [
     tableHeaders.number,
@@ -55,7 +57,7 @@ export const ExportedEntityDetailsTable = ({
         !hideHintText,
         entity.id,
         entityType,
-        props?.entityIndex
+        entityIndex
       )}
     </Table>
   );
@@ -131,6 +133,8 @@ export interface Props {
   fields: FormField[];
   entity: EntityShape;
   showHintText?: boolean;
+  entityType?: EntityType;
+  entityIndex?: number;
   [key: string]: any;
 }
 

--- a/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
@@ -28,7 +28,7 @@ export const ExportedEntityDetailsTable = ({
   const { report } = useStore();
   const { tableHeaders } = verbiage;
 
-  const entityType = EntityType.PROGRAM;
+  const entityType = props?.entityType ?? EntityType.PROGRAM;
 
   const threeColumnHeaderItems = [
     tableHeaders.number,
@@ -54,7 +54,8 @@ export const ExportedEntityDetailsTable = ({
         report,
         !hideHintText,
         entity.id,
-        entityType
+        entityType,
+        props?.entityIndex
       )}
     </Table>
   );
@@ -66,7 +67,8 @@ export const renderFieldTableBody = (
   report: ReportShape | undefined,
   showHintText: boolean,
   entityId: string,
-  entityType: EntityType
+  entityType: EntityType,
+  entityIndex?: number
 ) => {
   const tableRows: ReactElement[] = [];
   // recursively renders field rows
@@ -91,6 +93,7 @@ export const renderFieldTableBody = (
         showHintText={showHintText}
         entityId={entityId}
         optional={optional}
+        entityIndex={entityIndex}
       />
     );
 
@@ -128,6 +131,7 @@ export interface Props {
   fields: FormField[];
   entity: EntityShape;
   showHintText?: boolean;
+  [key: string]: any;
 }
 
 const sx = {

--- a/services/ui-src/src/components/export/ExportedEntityDetailsTableRow.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTableRow.tsx
@@ -22,6 +22,7 @@ export const ExportedEntityDetailsTableRow = ({
   showHintText = true,
   entityId,
   optional,
+  entityIndex,
 }: Props) => {
   const { report } = useStore();
   const reportData = report?.fieldData;
@@ -82,7 +83,8 @@ export const ExportedEntityDetailsTableRow = ({
             formField,
             reportData[entityType],
             entityId,
-            parentFieldCheckedChoiceIds
+            parentFieldCheckedChoiceIds,
+            entityIndex
           )}
       </Td>
     </Tr>
@@ -97,6 +99,7 @@ export interface Props {
   parentFieldCheckedChoiceIds?: string[];
   showHintText?: boolean;
   optional?: boolean;
+  entityIndex?: number;
 }
 
 const sx = {

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -10,20 +10,15 @@ import {
 } from "types";
 import { NaaarStandardsTableShape } from "components/tables/SortableNaaarStandardsTable";
 // utils
-import { getEntityDetailsMLR, mapNaaarStandardsData, useStore } from "utils";
-// verbiage
-import mcparVerbiage from "verbiage/pages/mcpar/mcpar-export";
-import mlrVerbiage from "verbiage/pages/mlr/mlr-export";
-import naaarVerbiage from "verbiage/pages/naaar/naaar-export";
+import {
+  getEntityDetailsMLR,
+  getReportVerbiage,
+  mapNaaarStandardsData,
+  useStore,
+} from "utils";
 // assets
 import unfinishedIcon from "assets/icons/icon_error_circle_bright.png";
 import finishedIcon from "assets/icons/icon_check_circle.png";
-
-const exportVerbiageMap: { [key in ReportType]: any } = {
-  MCPAR: mcparVerbiage,
-  MLR: mlrVerbiage,
-  NAAAR: naaarVerbiage,
-};
 
 export const ExportedModalOverlayReportSection = ({ section }: Props) => {
   const { report } = useStore();
@@ -31,9 +26,9 @@ export const ExportedModalOverlayReportSection = ({ section }: Props) => {
   const entities = report?.fieldData?.[entityType];
   const entityCount = entities?.length;
 
-  const verbiage = exportVerbiageMap[report?.reportType as ReportType];
+  const { exportVerbiage } = getReportVerbiage(report?.reportType);
 
-  const { modalOverlayTableHeaders } = verbiage;
+  const { emptyEntityMessage, modalOverlayTableHeaders } = exportVerbiage;
 
   const headerLabels = Object.values(
     modalOverlayTableHeaders as Record<string, string>
@@ -44,9 +39,7 @@ export const ExportedModalOverlayReportSection = ({ section }: Props) => {
       {entityType === EntityType.STANDARDS && (
         <Text sx={sx.standardCount}>
           Standard total count:{" "}
-          {entityCount > 0
-            ? entityCount
-            : verbiage.emptyEntityMessage[entityType]}
+          {entityCount > 0 ? entityCount : emptyEntityMessage[entityType]}
         </Text>
       )}
       {entityType === EntityType.STANDARDS && !entityCount ? null : (

--- a/services/ui-src/src/components/export/ExportedPlanComplianceCard.test.tsx
+++ b/services/ui-src/src/components/export/ExportedPlanComplianceCard.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+// components
+import { ExportedPlanComplianceCard } from "components";
+// utils
+import { mockNaaarReportStore } from "utils/testing/setupJest";
+import { useStore } from "utils";
+import { testA11y } from "utils/testing/commonTests";
+
+jest.mock("utils/state/useStore");
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+mockedUseStore.mockReturnValue({
+  ...mockNaaarReportStore,
+});
+
+const mockStandardFormattedData = {
+  count: "1",
+  standardType: "mock type",
+  description: "mock description",
+  provider: "mock provider",
+  analysisMethods: "mock method 1, mock method 2",
+  region: "mock region",
+  population: "mock population",
+};
+
+const mockPlanFormattedData = {
+  name: "mock plan",
+};
+
+const ExportedPlanComplianceCardComponent = (
+  <ExportedPlanComplianceCard
+    standardData={mockStandardFormattedData}
+    planData={mockPlanFormattedData}
+  />
+);
+
+describe("<ExportedPlanComplianceCard />", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  describe("Test ExportedPlanComplianceCard section displays all available information for standards and plans", () => {
+    test("complete card", () => {
+      render(ExportedPlanComplianceCardComponent);
+
+      // standards
+      const {
+        count,
+        standardType,
+        description,
+        provider,
+        analysisMethods,
+        region,
+        population,
+      } = mockStandardFormattedData;
+      expect(screen.getByText(count)).toBeVisible();
+      expect(screen.getByText(standardType)).toBeVisible();
+      expect(screen.getByText(description)).toBeVisible();
+      expect(screen.getByText(provider)).toBeVisible();
+      expect(screen.getByText(analysisMethods)).toBeVisible();
+      expect(screen.getByText(region)).toBeVisible();
+      expect(screen.getByText(population)).toBeVisible();
+
+      // plans
+
+      // TODO: add back when other plan info is merged
+
+      // expect(screen.getByText(mockPlanFormattedData.name)).toBeVisible();
+    });
+  });
+
+  describe("Test ExportedPlanComplianceCard accessibility", () => {
+    testA11y(ExportedPlanComplianceCardComponent);
+  });
+});

--- a/services/ui-src/src/components/export/ExportedPlanComplianceCard.test.tsx
+++ b/services/ui-src/src/components/export/ExportedPlanComplianceCard.test.tsx
@@ -23,7 +23,17 @@ const mockStandardFormattedData = {
 };
 
 const mockPlanFormattedData = {
-  name: "mock plan",
+  heading: "mock plan heading",
+  questions: [
+    {
+      question: "mock question 1",
+      answer: "mock answer 1",
+    },
+    {
+      question: "mock question 2",
+      answer: "mock answer 2",
+    },
+  ],
 };
 
 const ExportedPlanComplianceCardComponent = (
@@ -60,10 +70,13 @@ describe("<ExportedPlanComplianceCard />", () => {
       expect(screen.getByText(population)).toBeVisible();
 
       // plans
+      const { heading, questions } = mockPlanFormattedData;
 
-      // TODO: add back when other plan info is merged
-
-      // expect(screen.getByText(mockPlanFormattedData.name)).toBeVisible();
+      expect(screen.getByText(heading)).toBeVisible();
+      for (const q of questions) {
+        expect(screen.getByText(q.question)).toBeVisible();
+        expect(screen.getByText(q.answer)).toBeVisible();
+      }
     });
   });
 

--- a/services/ui-src/src/components/export/ExportedPlanComplianceCard.tsx
+++ b/services/ui-src/src/components/export/ExportedPlanComplianceCard.tsx
@@ -13,7 +13,7 @@ export const ExportedPlanComplianceCard = ({
   planData,
 }: Props) => {
   return (
-    <Card sxOverride={sx.card} data-testid="exportedPlanComplianceCard">
+    <Card sxOverride={sx.card}>
       <Box>
         <EntityCardTopSection
           entityType={EntityType.STANDARDS}

--- a/services/ui-src/src/components/export/ExportedPlanComplianceCard.tsx
+++ b/services/ui-src/src/components/export/ExportedPlanComplianceCard.tsx
@@ -11,7 +11,6 @@ import { AnyObject, EntityType } from "types";
 export const ExportedPlanComplianceCard = ({
   standardData,
   planData,
-  verbiage,
 }: Props) => {
   return (
     <Card sxOverride={sx.card} data-testid="exportedPlanComplianceCard">
@@ -23,7 +22,6 @@ export const ExportedPlanComplianceCard = ({
         />
         <EntityCardBottomSection
           entityType={EntityType.STANDARDS}
-          verbiage={verbiage}
           formattedEntityData={standardData}
           printVersion={true}
         />
@@ -40,7 +38,6 @@ export const ExportedPlanComplianceCard = ({
 interface Props {
   standardData: AnyObject;
   planData: AnyObject;
-  verbiage: AnyObject;
 }
 
 const sx = {

--- a/services/ui-src/src/components/export/ExportedPlanComplianceCard.tsx
+++ b/services/ui-src/src/components/export/ExportedPlanComplianceCard.tsx
@@ -1,0 +1,53 @@
+// components
+import {
+  Card,
+  EntityCardBottomSection,
+  EntityCardTopSection,
+} from "components";
+import { Box } from "@chakra-ui/react";
+// types
+import { AnyObject, EntityType } from "types";
+
+export const ExportedPlanComplianceCard = ({
+  standardData,
+  planData,
+  verbiage,
+}: Props) => {
+  return (
+    <Card sxOverride={sx.card} data-testid="exportedPlanComplianceCard">
+      <Box>
+        <EntityCardTopSection
+          entityType={EntityType.STANDARDS}
+          formattedEntityData={standardData}
+          printVersion={true}
+        />
+        <EntityCardBottomSection
+          entityType={EntityType.STANDARDS}
+          verbiage={verbiage}
+          formattedEntityData={standardData}
+          printVersion={true}
+        />
+        <EntityCardTopSection
+          entityType={EntityType.PLANS}
+          formattedEntityData={planData}
+          printVersion={true}
+        />
+      </Box>
+    </Card>
+  );
+};
+
+interface Props {
+  standardData: AnyObject;
+  planData: AnyObject;
+  verbiage: AnyObject;
+}
+
+const sx = {
+  card: {
+    marginY: "1.5rem",
+    boxShadow: "none",
+    border: "1px solid",
+    borderColor: "palette.gray_light",
+  },
+};

--- a/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.tsx
@@ -32,8 +32,6 @@ import {
   parseCustomHtml,
   useStore,
 } from "utils";
-// verbiage
-import exportVerbiage from "verbiage/pages/naaar/naaar-export";
 
 /*
  * Designed originally for the plan compliance portion of the NAAAR report
@@ -105,7 +103,6 @@ export const ExportedPlanOverlayReportSection = ({ section }: Props) => {
             plan,
             report?.fieldData
           )}
-          verbiage={exportVerbiage}
         />
       );
 

--- a/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.tsx
@@ -94,17 +94,31 @@ export const ExportedPlanOverlayReportSection = ({ section }: Props) => {
         (standard) => standard?.exceptionsNonCompliance === exceptionsStatus
       );
 
-      const nonComplianceDetails = (standardData: NaaarStandardsTableShape) => (
-        <ExportedPlanComplianceCard
-          key={plan.id}
-          standardData={standardData}
-          planData={getFormattedEntityData(
-            EntityType.PLANS,
-            plan,
-            report?.fieldData
-          )}
-        />
-      );
+      const nonComplianceDetails = (standardData: NaaarStandardsTableShape) => {
+        // filter plan data to just this standard's
+        const standardRelatedPlanData = Object.entries(plan).filter(
+          ([key, _]) => key.includes(standardData.id)
+        );
+        const planDataToFormat: EntityShape = {
+          ...Object.fromEntries(standardRelatedPlanData),
+          id: plan.id,
+          name: plan.name,
+          exceptionsNonCompliance: standardData.exceptionsNonCompliance,
+        };
+        const planData = getFormattedEntityData(
+          EntityType.PLANS,
+          planDataToFormat
+        );
+
+        return (
+          <ExportedPlanComplianceCard
+            key={plan.id}
+            standardData={standardData}
+            planData={planData}
+            verbiage={exportVerbiage}
+          />
+        );
+      };
 
       return (
         <Box key={plan.id}>

--- a/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.tsx
@@ -115,7 +115,6 @@ export const ExportedPlanOverlayReportSection = ({ section }: Props) => {
             key={plan.id}
             standardData={standardData}
             planData={planData}
-            verbiage={exportVerbiage}
           />
         );
       };

--- a/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.tsx
@@ -1,12 +1,17 @@
 // components
 import { Box, Heading, Td, Text, Tr } from "@chakra-ui/react";
-import { Table } from "components";
+import { Table, ExportedEntityDetailsTable } from "components";
 // constants
 import { nonCompliantLabel } from "../../constants";
 // styling
 import { exportTableSx } from "./ExportedReportFieldTable";
 // types
-import { EntityShape, PlanOverlayReportPageShape } from "types";
+import {
+  EntityShape,
+  EntityType,
+  FormField,
+  PlanOverlayReportPageShape,
+} from "types";
 // utils
 import {
   getExceptionsNonComplianceCounts,
@@ -40,12 +45,17 @@ export const ExportedPlanOverlayReportSection = ({ section }: Props) => {
   const formVerbiage438206 = section.details.forms[1].verbiage;
   const complianceAssuranceHeading438206 = formVerbiage438206.heading;
   const complianceAssuranceHint438206 = formVerbiage438206.hint;
+  const nonCompliantDetailsHeading438206 =
+    section.details.forms[1].table.bodyRows[0][1];
+  const nonCompliantDetailsChildForm438206 =
+    section.details.childForms[1].form.fields;
 
   const displayPlansList = () => {
-    return plans.map((plan: EntityShape) => {
+    return plans.map((plan: EntityShape, index: number) => {
       const answer43868 = plan?.planCompliance43868_assurance?.[0]?.value;
       const answer438206 = plan?.planCompliance438206_assurance?.[0]?.value;
       const isNotCompliant43868 = answer43868 === nonCompliantLabel;
+      const isNotCompliant438206 = answer438206 === nonCompliantLabel;
 
       // counts
       const exceptionsNonComplianceKeys = getExceptionsNonComplianceKeys(plan);
@@ -87,6 +97,22 @@ export const ExportedPlanOverlayReportSection = ({ section }: Props) => {
             complianceAssuranceHint438206,
             answer438206
           )}
+          {isNotCompliant438206 && (
+            <>
+              <Heading as="h4" sx={sx.h4}>
+                {nonCompliantDetailsHeading438206}
+              </Heading>
+              <ExportedEntityDetailsTable
+                key={`table-${plan.id}`}
+                fields={nonCompliantDetailsChildForm438206 as FormField[]}
+                entity={plan}
+                showHintText={false}
+                caption={nonCompliantDetailsHeading438206}
+                entityType={EntityType.PLANS}
+                entityIndex={index}
+              />
+            </>
+          )}
         </Box>
       );
     });
@@ -117,7 +143,7 @@ const complianceTable = (
         {heading}
       </Heading>
       <Table
-        sx={exportTableSx}
+        sx={{ ...exportTableSx, ...sx.tableHeader }}
         className={"two-column"}
         content={{
           caption: sectionName,
@@ -142,6 +168,15 @@ const complianceTable = (
 };
 
 const sx = {
+  tableHeader: {
+    ".desktop &": {
+      "&.two-column": {
+        "th:first-of-type": {
+          paddingLeft: "5rem",
+        },
+      },
+    },
+  },
   planNameHeading: {
     fontSize: "xl",
     paddingBottom: "1.5rem",
@@ -156,7 +191,7 @@ const sx = {
     color: "palette.gray_medium",
   },
   answerCell: {
-    width: "50%",
+    width: "51%",
   },
   notAnsweredStyling: {
     color: "palette.error_darker",

--- a/services/ui-src/src/components/export/ExportedReportBanner.tsx
+++ b/services/ui-src/src/components/export/ExportedReportBanner.tsx
@@ -1,29 +1,17 @@
 // components
 import { Box, Button, Image, Spinner, Text } from "@chakra-ui/react";
 // types
-import { ReportRoute, ReportType } from "types";
+import { ReportRoute } from "types";
 // utils
-import { useStore } from "utils";
-// verbiage
-import mcparVerbiage from "verbiage/pages/mcpar/mcpar-export";
-import mlrVerbiage from "verbiage/pages/mlr/mlr-export";
-import naaarVerbiage from "verbiage/pages/naaar/naaar-export";
+import { getReportVerbiage, useStore } from "utils";
 // assets
 import pdfIcon from "assets/icons/icon_pdf_white.png";
 
 export const ExportedReportBanner = () => {
   const { report } = useStore();
-  const reportType = (report?.reportType ||
-    localStorage.getItem("selectedReportType")) as ReportType;
 
-  const verbiageMap: { [key in ReportType]: any } = {
-    MCPAR: mcparVerbiage,
-    MLR: mlrVerbiage,
-    NAAAR: naaarVerbiage,
-  };
-
-  const verbiage = verbiageMap[reportType];
-  const { reportBanner } = verbiage;
+  const { exportVerbiage } = getReportVerbiage(report?.reportType);
+  const { reportBanner } = exportVerbiage;
 
   const routesToRender = report?.formTemplate.routes.filter(
     (route: ReportRoute) => route

--- a/services/ui-src/src/components/export/ExportedSectionHeading.tsx
+++ b/services/ui-src/src/components/export/ExportedSectionHeading.tsx
@@ -50,7 +50,7 @@ export const ExportedSectionHeading = ({ heading, verbiage }: Props) => {
 };
 
 export interface Props {
-  heading: string;
+  heading?: string;
   verbiage?: ReportPageVerbiage;
 }
 

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -48,6 +48,7 @@ export { ExportedEntityDetailsOverlaySection } from "./export/ExportedEntityDeta
 export { ExportedEntityDetailsTable } from "./export/ExportedEntityDetailsTable";
 export { ExportedEntityDetailsTableRow } from "./export/ExportedEntityDetailsTableRow";
 export { ExportedPlanOverlayReportSection } from "./export/ExportedPlanOverlayReportSection";
+export { ExportedPlanComplianceCard } from "./export/ExportedPlanComplianceCard";
 // fields
 export { CheckboxField } from "./fields/CheckboxField";
 export { ChoiceField } from "./fields/ChoiceField";

--- a/services/ui-src/src/components/layout/InfoSection.tsx
+++ b/services/ui-src/src/components/layout/InfoSection.tsx
@@ -1,4 +1,4 @@
-import React, { ReactChild } from "react";
+import React, { ReactNode } from "react";
 // components
 import { Box, Flex, Heading, Text } from "@chakra-ui/react";
 
@@ -27,7 +27,7 @@ interface Props {
     header: string;
     body: string;
   };
-  children?: ReactChild | ReactChild[];
+  children?: ReactNode | ReactNode[];
   [key: string]: any;
 }
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -28,15 +28,13 @@ import { AnyObject, ReportMetadataShape, ReportKeys, ReportShape } from "types";
 // utils
 import {
   convertDateUtcToEt,
+  getReportVerbiage,
   parseCustomHtml,
   useBreakpoint,
   useStore,
 } from "utils";
 import { States } from "../../../constants";
 // verbiage
-import mcparVerbiage from "verbiage/pages/mcpar/mcpar-dashboard";
-import mlrVerbiage from "verbiage/pages/mlr/mlr-dashboard";
-import naaarVerbiage from "verbiage/pages/naaar/naaar-dashboard";
 import accordion from "verbiage/pages/accordion";
 // assets
 import arrowLeftIcon from "assets/icons/icon_arrow_left_blue.png";
@@ -75,13 +73,7 @@ export const DashboardPage = ({ reportType }: Props) => {
     undefined
   );
 
-  const dashboardVerbiageMap: any = {
-    MCPAR: mcparVerbiage,
-    MLR: mlrVerbiage,
-    NAAAR: naaarVerbiage,
-  };
-
-  const dashboardVerbiage = dashboardVerbiageMap[reportType]!;
+  const { dashboardVerbiage } = getReportVerbiage(reportType);
   const { intro, body } = dashboardVerbiage;
 
   // if an admin or a read-only user has selected a state, retrieve it from local storage

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -16,11 +16,7 @@ import {
   ReportType,
 } from "types";
 // utils
-import { assertExhaustive, useStore } from "utils";
-// verbiage
-import mcparVerbiage from "verbiage/pages/mcpar/mcpar-export";
-import mlrVerbiage from "verbiage/pages/mlr/mlr-export";
-import naaarVerbiage from "verbiage/pages/naaar/naaar-export";
+import { assertExhaustive, getReportVerbiage, useStore } from "utils";
 
 export const ExportedReportPage = () => {
   const { report } = useStore();
@@ -31,13 +27,7 @@ export const ExportedReportPage = () => {
   const reportType = (report?.reportType ||
     localStorage.getItem("selectedReportType")) as ReportType;
 
-  const exportVerbiageMap: { [key in ReportType]: any } = {
-    MCPAR: mcparVerbiage,
-    MLR: mlrVerbiage,
-    NAAAR: naaarVerbiage,
-  };
-
-  const exportVerbiage = exportVerbiageMap[reportType];
+  const { exportVerbiage } = getReportVerbiage(reportType);
   const { metadata, reportPage, tableHeaders } = exportVerbiage;
 
   return (

--- a/services/ui-src/src/components/pages/GetStarted/ReportGetStartedPage.tsx
+++ b/services/ui-src/src/components/pages/GetStarted/ReportGetStartedPage.tsx
@@ -16,7 +16,7 @@ import {
   SpreadsheetWidget,
 } from "components";
 // verbiage
-import mcparVerbiage from "verbiage/pages/mcpar/mcpar-get-started";
+import mcparGetStartedVerbiage from "verbiage/pages/mcpar/mcpar-get-started";
 // assets
 import arrowLeftIcon from "assets/icons/icon_arrow_left_blue.png";
 import nextIcon from "assets/icons/icon_next_white.png";
@@ -26,12 +26,7 @@ import NavigationSectionsSubmissionImage from "assets/other/nav_sections_review_
 export const ReportGetStartedPage = ({ reportType }: Props) => {
   const navigate = useNavigate();
 
-  const getStartedVerbiageMap: any = {
-    MCPAR: mcparVerbiage,
-  };
-
-  const getStartedVerbiage = getStartedVerbiageMap[reportType]!;
-  const { intro, body, pageLink } = getStartedVerbiage;
+  const { intro, body, pageLink } = mcparGetStartedVerbiage;
 
   const [section1, section2, section3] = body.sections;
 

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -14,11 +14,12 @@ import { Alert, Modal, ReportContext, StatusTable } from "components";
 // types
 import { AlertTypes, AnyObject, ReportStatus, ReportType } from "types";
 // utils
-import { parseCustomHtml, useStore, utcDateToReadableDate } from "utils";
-// verbiage
-import MCPARVerbiage from "verbiage/pages/mcpar/mcpar-review-and-submit";
-import MLRVerbiage from "verbiage/pages/mlr/mlr-review-and-submit";
-import NAAARverbiage from "verbiage/pages/naaar/naaar-review-and-submit";
+import {
+  getReportVerbiage,
+  parseCustomHtml,
+  useStore,
+  utcDateToReadableDate,
+} from "utils";
 // assets
 import checkIcon from "assets/icons/icon_check_circle.png";
 import iconSearchDefault from "assets/icons/icon_search_blue.png";
@@ -49,20 +50,9 @@ export const ReviewSubmitPage = () => {
     id: reportId,
   };
 
-  let reviewVerbiage;
-  switch (reportType) {
-    case "MCPAR":
-      reviewVerbiage = MCPARVerbiage;
-      break;
-    case "MLR":
-      reviewVerbiage = MLRVerbiage;
-      break;
-    default:
-      // we cannot get to the review page without a report in the store, so assume the remaining type
-      reviewVerbiage = NAAARverbiage;
-  }
+  const { reviewAndSubmitVerbiage } = getReportVerbiage(report?.reportType);
 
-  const { alertBox } = reviewVerbiage;
+  const { alertBox } = reviewAndSubmitVerbiage;
 
   useEffect(() => {
     if (report?.id) {
@@ -113,7 +103,7 @@ export const ReviewSubmitPage = () => {
             name={report.submissionName || report.programName}
             date={report?.submittedOnDate}
             submittedBy={report?.submittedBy}
-            reviewVerbiage={reviewVerbiage}
+            reviewVerbiage={reviewAndSubmitVerbiage}
             stateName={report.fieldData.stateName!}
           />
         ) : (
@@ -124,7 +114,7 @@ export const ReviewSubmitPage = () => {
             onClose={onClose}
             submitting={submitting}
             isPermittedToSubmit={isPermittedToSubmit}
-            reviewVerbiage={reviewVerbiage}
+            reviewVerbiage={reviewAndSubmitVerbiage}
           />
         )}
       </Flex>

--- a/services/ui-src/src/components/tables/SortableNaaarStandardsTable.tsx
+++ b/services/ui-src/src/components/tables/SortableNaaarStandardsTable.tsx
@@ -91,6 +91,7 @@ interface Props {
 }
 
 export interface NaaarStandardsTableShape {
+  id: string;
   count: number;
   provider: string;
   standardType: string;

--- a/services/ui-src/src/utils/index.ts
+++ b/services/ui-src/src/utils/index.ts
@@ -46,3 +46,5 @@ export * from "./state/useStore";
 // text
 export * from "./text/compareText";
 export * from "./text/translate";
+// verbiage
+export * from "./verbiage/verbiage";

--- a/services/ui-src/src/utils/other/export.test.tsx
+++ b/services/ui-src/src/utils/other/export.test.tsx
@@ -1,16 +1,21 @@
 import { render, screen } from "@testing-library/react";
 // types
-import { FormField, AnyObject } from "types";
+import { FormField, AnyObject, ReportType } from "types";
 // utils
 import {
   parseFormFieldInfo,
   renderResponseData,
   renderDefaultFieldResponse,
   getNestedIlosResponses,
+  getVerbiage,
   renderDrawerDataCell,
   renderDataCell,
 } from "./export";
 import { mockFormField, mockNestedFormField } from "utils/testing/setupJest";
+// verbiage
+import McparVerbiage from "verbiage/pages/mcpar/mcpar-export";
+import MlrVerbiage from "verbiage/pages/mlr/mlr-export";
+import NaaarVerbiage from "verbiage/pages/naaar/naaar-export";
 
 const emailInput: FormField = {
   id: "email-field-id",
@@ -376,5 +381,34 @@ describe("Test renderDefaultFieldResponse", () => {
       "1.10" as unknown as AnyObject
     );
     expect(textField.props.children).toBe("$1.10");
+  });
+});
+
+describe("getVerbiage()", () => {
+  afterEach(() => {
+    localStorage.setItem("selectedReportType", "");
+  });
+  test("Returns MLR when matching", () => {
+    localStorage.setItem("selectedReportType", ReportType.MLR);
+    const verbiage = getVerbiage();
+    expect(verbiage.metadata.subject).toBe(MlrVerbiage.metadata.subject);
+  });
+
+  test("Returns NAAAR when matching", () => {
+    localStorage.setItem("selectedReportType", ReportType.NAAAR);
+    const verbiage = getVerbiage();
+    expect(verbiage.metadata.subject).toBe(NaaarVerbiage.metadata.subject);
+  });
+
+  test("Returns MCPAR when matching", () => {
+    localStorage.setItem("selectedReportType", ReportType.MCPAR);
+    const verbiage = getVerbiage();
+    expect(verbiage.metadata.subject).toBe(McparVerbiage.metadata.subject);
+  });
+
+  test("Returns MCPAR as default", () => {
+    localStorage.setItem("selectedReportType", "");
+    const verbiage = getVerbiage();
+    expect(verbiage.metadata.subject).toBe(McparVerbiage.metadata.subject);
   });
 });

--- a/services/ui-src/src/utils/other/export.test.tsx
+++ b/services/ui-src/src/utils/other/export.test.tsx
@@ -1,21 +1,16 @@
 import { render, screen } from "@testing-library/react";
 // types
-import { FormField, AnyObject, ReportType } from "types";
+import { FormField, AnyObject } from "types";
 // utils
 import {
   parseFormFieldInfo,
   renderResponseData,
   renderDefaultFieldResponse,
   getNestedIlosResponses,
-  getVerbiage,
   renderDrawerDataCell,
   renderDataCell,
 } from "./export";
 import { mockFormField, mockNestedFormField } from "utils/testing/setupJest";
-// verbiage
-import McparVerbiage from "verbiage/pages/mcpar/mcpar-export";
-import MlrVerbiage from "verbiage/pages/mlr/mlr-export";
-import NaaarVerbiage from "verbiage/pages/naaar/naaar-export";
 
 const emailInput: FormField = {
   id: "email-field-id",
@@ -381,34 +376,5 @@ describe("Test renderDefaultFieldResponse", () => {
       "1.10" as unknown as AnyObject
     );
     expect(textField.props.children).toBe("$1.10");
-  });
-});
-
-describe("getVerbiage()", () => {
-  afterEach(() => {
-    localStorage.setItem("selectedReportType", "");
-  });
-  test("Returns MLR when matching", () => {
-    localStorage.setItem("selectedReportType", ReportType.MLR);
-    const verbiage = getVerbiage();
-    expect(verbiage.metadata.subject).toBe(MlrVerbiage.metadata.subject);
-  });
-
-  test("Returns NAAAR when matching", () => {
-    localStorage.setItem("selectedReportType", ReportType.NAAAR);
-    const verbiage = getVerbiage();
-    expect(verbiage.metadata.subject).toBe(NaaarVerbiage.metadata.subject);
-  });
-
-  test("Returns MCPAR when matching", () => {
-    localStorage.setItem("selectedReportType", ReportType.MCPAR);
-    const verbiage = getVerbiage();
-    expect(verbiage.metadata.subject).toBe(McparVerbiage.metadata.subject);
-  });
-
-  test("Returns MCPAR as default", () => {
-    localStorage.setItem("selectedReportType", "");
-    const verbiage = getVerbiage();
-    expect(verbiage.metadata.subject).toBe(McparVerbiage.metadata.subject);
   });
 });

--- a/services/ui-src/src/utils/other/export.test.tsx
+++ b/services/ui-src/src/utils/other/export.test.tsx
@@ -11,6 +11,8 @@ import {
   renderDataCell,
 } from "./export";
 import { mockFormField, mockNestedFormField } from "utils/testing/setupJest";
+// verbiage
+import McparExportVerbiage from "verbiage/pages/mcpar/mcpar-export";
 
 const emailInput: FormField = {
   id: "email-field-id",
@@ -84,6 +86,33 @@ describe("Test rendering methods", () => {
     );
 
     expect(result[0].props.children).toBe("plan 1");
+  });
+
+  test("renders an error for ilos field when missing plans", () => {
+    const dynamicFormField = {
+      id: "plan_ilosOfferedByPlan",
+      type: "dynamic",
+      validation: "dynamic",
+      props: {
+        label: "Plan name",
+      },
+    };
+
+    const mockFieldResponseData = {
+      plans: [],
+    };
+
+    const result = renderDataCell(
+      dynamicFormField,
+      mockFieldResponseData,
+      "drawer"
+    );
+
+    render(result);
+
+    expect(
+      screen.getByText(McparExportVerbiage.missingEntry.missingPlans)
+    ).toBeVisible();
   });
 
   // Analysis methods rendering

--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -8,6 +8,7 @@ import {
   EntityType,
   FieldChoice,
   FormField,
+  ReportType,
 } from "types";
 // utils
 import {
@@ -17,7 +18,22 @@ import {
   otherSpecify,
 } from "utils";
 // verbiage
-import verbiage from "verbiage/pages/mcpar/mcpar-export";
+import McparVerbiage from "verbiage/pages/mcpar/mcpar-export";
+import MlrVerbiage from "verbiage/pages/mlr/mlr-export";
+import NaaarVerbiage from "verbiage/pages/naaar/naaar-export";
+
+export const getVerbiage = () => {
+  const reportType = localStorage.getItem("selectedReportType");
+  switch (reportType) {
+    case ReportType.MLR:
+      return MlrVerbiage;
+    case ReportType.NAAAR:
+      return NaaarVerbiage;
+    case ReportType.MCPAR:
+    default:
+      return McparVerbiage;
+  }
+};
 
 // checks for type of data cell to be render and calls the appropriate renderer
 export const renderDataCell = (
@@ -39,7 +55,7 @@ export const renderDataCell = (
       entityResponseData = [
         {
           id: uuid(),
-          name: verbiage.missingEntry.missingPlans,
+          name: McparVerbiage.missingEntry.missingPlans,
         },
       ];
     } else {
@@ -89,23 +105,24 @@ export const renderOverlayEntityDataCell = (
   formField: FormField,
   entityResponseData: EntityShape[],
   entityId: string,
-  parentFieldCheckedChoiceIds?: string[]
+  parentFieldCheckedChoiceIds?: string[],
+  entityIndex?: number
 ) => {
   const entity = entityResponseData.find((ent) => ent.id === entityId);
 
-  if (!entity || !entity[formField.id]) {
+  const fieldId = formField.groupId ?? formField.id;
+
+  if (!entity || !entity[fieldId]) {
     const validationType =
       typeof formField.validation === "object"
         ? formField.validation.type
         : formField.validation;
 
-    if (validationType.includes("Optional")) {
-      return <Text>{verbiage.missingEntry.noResponse}, optional</Text>;
+    if (validationType.includes("Optional") || formField?.groupId) {
+      return <Text>{getVerbiage().missingEntry.noResponseOptional}</Text>;
     } else {
       return (
-        <Text sx={sx.noResponse}>
-          {verbiage.missingEntry.noResponse}; required
-        </Text>
+        <Text sx={sx.noResponse}>{getVerbiage().missingEntry.noResponse}</Text>
       );
     }
   }
@@ -118,10 +135,11 @@ export const renderOverlayEntityDataCell = (
       <Text>
         {renderResponseData(
           formField,
-          entity[formField.id],
+          entity[fieldId],
           entityResponseData,
           "modalOverlay",
-          notApplicable
+          notApplicable,
+          entityIndex
         )}
       </Text>
     </Box>
@@ -174,7 +192,7 @@ export const renderDrawerDataCell = (
 
     // check if this is the ILOS topic
     const isMissingPlansMessage =
-      entity.name === verbiage.missingEntry.missingPlans;
+      entity.name === McparVerbiage.missingEntry.missingPlans;
 
     const entityName = entity?.name || entity?.custom_analysis_method_name;
 
@@ -210,20 +228,20 @@ export const renderDrawerDataCell = (
               !("plan_ilosOfferedByPlan" in entity) && (
                 // there are plans added, but no responses for its nested ILOS
                 <Text sx={sx.noResponse}>
-                  {verbiage.missingEntry.noResponse}
+                  {McparVerbiage.missingEntry.noResponse}
                 </Text>
               )}
         </ul>
       </Box>
     );
-  }) ?? <Text sx={sx.noResponse}>{verbiage.missingEntry.noResponse}</Text>;
+  }) ?? <Text sx={sx.noResponse}>{getVerbiage().missingEntry.noResponse}</Text>;
 
 export const renderDynamicDataCell = (fieldResponseData: AnyObject) =>
   fieldResponseData?.map((entity: EntityShape) => (
     <Text key={entity.id} sx={sx.dynamicItem}>
       {entity.name}
     </Text>
-  )) ?? <Text sx={sx.noResponse}>{verbiage.missingEntry.noResponse}</Text>;
+  )) ?? <Text sx={sx.noResponse}>{getVerbiage().missingEntry.noResponse}</Text>;
 
 export const renderResponseData = (
   formField: FormField,
@@ -240,8 +258,8 @@ export const renderResponseData = (
     : fieldResponseData;
 
   const missingEntryVerbiage = notApplicable
-    ? verbiage.missingEntry.notApplicable
-    : verbiage.missingEntry.noResponse;
+    ? getVerbiage().missingEntry.notApplicable
+    : getVerbiage().missingEntry.noResponse;
 
   const missingEntryStyle = notApplicable ? sx.notApplicable : sx.noResponse;
 
@@ -289,9 +307,9 @@ export const renderChoiceListFieldResponse = (
     const shouldDisplayRelatedOtherTextEntry =
       choice.children?.[0]?.id.endsWith("-otherText");
     const relatedOtherTextEntry =
-      pageType === "drawer"
-        ? widerResponseData[entityIndex]?.[firstChildId]
-        : widerResponseData?.[firstChildId];
+      widerResponseData?.[entityIndex]?.[firstChildId] ??
+      widerResponseData?.[firstChildId];
+
     return (
       <Text key={choice.id} sx={sx.fieldChoice}>
         {choice.label}

--- a/services/ui-src/src/utils/reports/entities.test.ts
+++ b/services/ui-src/src/utils/reports/entities.test.ts
@@ -1,5 +1,9 @@
 import { getAddEditDrawerText, getFormattedEntityData } from "./entities";
+// constants
+import { exceptionsStatus, nonComplianceStatus } from "../../constants";
+// types
 import { EntityType } from "types";
+// utils
 import {
   mockAccessMeasuresEntity,
   mockCompletedAccessMeasuresFormattedEntityData,
@@ -15,99 +19,216 @@ import {
   mockModalDrawerReportPageVerbiage,
 } from "utils/testing/setupJest";
 
-describe("Test getFormattedEntityData", () => {
-  it("Returns correct data for access measures", () => {
-    const entityData = getFormattedEntityData(
-      EntityType.ACCESS_MEASURES,
-      mockAccessMeasuresEntity
-    );
-    expect(entityData).toEqual(mockCompletedAccessMeasuresFormattedEntityData);
+describe("getFormattedEntityData()", () => {
+  describe("entity type: access measures", () => {
+    test("Returns correct data for access measures", () => {
+      const entityData = getFormattedEntityData(
+        EntityType.ACCESS_MEASURES,
+        mockAccessMeasuresEntity
+      );
+      expect(entityData).toEqual(
+        mockCompletedAccessMeasuresFormattedEntityData
+      );
+    });
+
+    test("returns 'Add' when no conditions are met", () => {
+      const result = getAddEditDrawerText(
+        EntityType.ACCESS_MEASURES,
+        { provider: false },
+        mockModalDrawerReportPageVerbiage
+      );
+      expect(result).toBe("Add Mock drawer title");
+    });
+
+    test("returns 'Edit' when provider exists for ACCESS_MEASURES", () => {
+      const result = getAddEditDrawerText(
+        EntityType.ACCESS_MEASURES,
+        { provider: true },
+        mockModalDrawerReportPageVerbiage
+      );
+      expect(result).toBe("Edit Mock drawer title");
+    });
   });
 
-  it("Returns correct data for quality measures with no completed measures", () => {
-    const entityData = getFormattedEntityData(
-      EntityType.QUALITY_MEASURES,
-      mockQualityMeasuresEntity,
-      mockReportFieldData
-    );
-    expect(entityData).toEqual(
-      mockUnfinishedQualityMeasuresFormattedEntityData
-    );
+  describe("entity type: quality measures", () => {
+    test("Returns correct data for quality measures with no completed measures", () => {
+      const entityData = getFormattedEntityData(
+        EntityType.QUALITY_MEASURES,
+        mockQualityMeasuresEntity,
+        mockReportFieldData
+      );
+      expect(entityData).toEqual(
+        mockUnfinishedQualityMeasuresFormattedEntityData
+      );
+    });
+
+    test("Returns correct data for quality measures with some completed measures", () => {
+      const entityData = getFormattedEntityData(
+        EntityType.QUALITY_MEASURES,
+        mockQualityMeasuresEntityMissingDetails,
+        mockReportFieldData
+      );
+      expect(entityData).toEqual(
+        mockQualityMeasuresFormattedEntityDataMissingDetails
+      );
+    });
+
+    test("Returns correct data for quality measures with fully completed measures", () => {
+      const entityData = getFormattedEntityData(
+        EntityType.QUALITY_MEASURES,
+        mockCompletedQualityMeasuresEntity,
+        mockReportFieldData
+      );
+      expect(entityData).toEqual(
+        mockCompletedQualityMeasuresFormattedEntityData
+      );
+    });
+
+    test("returns 'Edit' when perPlanResponses exists for QUALITY_MEASURES", () => {
+      const result = getAddEditDrawerText(
+        EntityType.QUALITY_MEASURES,
+        { perPlanResponses: [{ name: "plan 1", response: "n/a" }] },
+        mockModalDrawerReportPageVerbiage
+      );
+      expect(result).toBe("Edit Mock drawer title");
+    });
   });
 
-  it("Returns correct data for quality measures with some completed measures", () => {
-    const entityData = getFormattedEntityData(
-      EntityType.QUALITY_MEASURES,
-      mockQualityMeasuresEntityMissingDetails,
-      mockReportFieldData
-    );
-    expect(entityData).toEqual(
-      mockQualityMeasuresFormattedEntityDataMissingDetails
-    );
+  describe("entity type: sanctions", () => {
+    test("Returns correct data for sanctions", () => {
+      const entityData = getFormattedEntityData(
+        EntityType.SANCTIONS,
+        mockSanctionsEntity,
+        mockReportFieldData
+      );
+      expect(entityData).toEqual(mockCompletedSanctionsFormattedEntityData);
+    });
+
+    test("returns 'Edit' when assessmentDate exists for SANCTIONS", () => {
+      const result = getAddEditDrawerText(
+        EntityType.SANCTIONS,
+        { assessmentDate: true },
+        mockModalDrawerReportPageVerbiage
+      );
+      expect(result).toBe("Edit Mock drawer title");
+    });
   });
 
-  it("Returns correct data for quality measures with fully completed measures", () => {
-    const entityData = getFormattedEntityData(
-      EntityType.QUALITY_MEASURES,
-      mockCompletedQualityMeasuresEntity,
-      mockReportFieldData
-    );
-    expect(entityData).toEqual(mockCompletedQualityMeasuresFormattedEntityData);
+  describe("entity type: plans", () => {
+    const mockPlanData = {
+      id: "mock id",
+      name: "mock plan name",
+    };
+
+    test("Returns correct data for non-compliant plans", () => {
+      const mockNonCompliantPlan = {
+        ...mockPlanData,
+        exceptionsNonCompliance: nonComplianceStatus,
+        "mock-nonComplianceDescription": "mock description",
+        "mock-nonComplianceAnalyses": [
+          {
+            id: "id-1",
+            value: "mock analysis method 1",
+          },
+          {
+            id: "id-2",
+            value: "mock analysis method 2",
+          },
+        ],
+        "mock-nonCompliancePlanToAchieveCompliance":
+          "mock plan to achieve compliance",
+        "mock-nonComplianceMonitoringProgress": "mock monitoring progress",
+        "mock-nonComplianceReassessmentDate": "mock reassessment date",
+      };
+
+      const entityData = getFormattedEntityData(
+        EntityType.PLANS,
+        mockNonCompliantPlan
+      );
+
+      const expectedData = {
+        heading: `Plan deficiencies for ${mockNonCompliantPlan.name}: 42 C.F.R. § 438.68`,
+        questions: [
+          {
+            question: "Description",
+            answer: "mock description",
+          },
+          {
+            question: "Analyses used to identify deficiencies",
+            answer: "mock analysis method 1, mock analysis method 2",
+          },
+          {
+            question: "What the plan will do to achieve compliance",
+            answer: "mock plan to achieve compliance",
+          },
+          {
+            question: "Monitoring progress",
+            answer: "mock monitoring progress",
+          },
+          {
+            question: "Reassessment date",
+            answer: "mock reassessment date",
+          },
+        ],
+      };
+
+      expect(entityData).toEqual(expectedData);
+    });
+
+    test("Returns correct data for exception plans", () => {
+      const mockExceptionPlan = {
+        ...mockPlanData,
+        exceptionsNonCompliance: exceptionsStatus,
+        "mock-exceptionsDescription": "mock description",
+        "mock-exceptionsJustification": "mock justification",
+      };
+
+      const entityData = getFormattedEntityData(
+        EntityType.PLANS,
+        mockExceptionPlan
+      );
+
+      const expectedData = {
+        heading: `Exceptions granted for ${mockExceptionPlan.name} under 42 C.F.R. § 438.68(d)`,
+        questions: [
+          {
+            question:
+              "Describe any network adequacy standard exceptions that the state has granted to the plan under 42 C.F.R. § 438.68(d).",
+            answer: "mock description",
+          },
+          {
+            question:
+              "Justification for exceptions granted under 42 C.F.R. § 438.68(d)",
+            answer: "mock justification",
+          },
+        ],
+      };
+
+      expect(entityData).toEqual(expectedData);
+    });
+
+    test("Returns just a heading when no exception or non-compliance status given", () => {
+      const entityData = getFormattedEntityData(EntityType.PLANS, mockPlanData);
+
+      const expectedData = {
+        heading: `Problem displaying data for ${mockPlanData.name}`,
+      };
+
+      expect(entityData).toEqual(expectedData);
+    });
+
+    test("Returns empty array when no entity provided", () => {
+      const entityData = getFormattedEntityData(EntityType.PLANS, undefined);
+      expect(entityData).toEqual({});
+    });
   });
 
-  it("Returns correct data for sanctions", () => {
-    const entityData = getFormattedEntityData(
-      EntityType.SANCTIONS,
-      mockSanctionsEntity,
-      mockReportFieldData
-    );
-    expect(entityData).toEqual(mockCompletedSanctionsFormattedEntityData);
-  });
-
-  it("Returns empty object if invalid entity type is passed", () => {
+  test("Returns empty object if invalid entity type is passed", () => {
     const entityData = getFormattedEntityData(
       "invalid entity type" as EntityType,
       mockSanctionsEntity,
       mockReportFieldData
     );
     expect(entityData).toEqual({});
-  });
-});
-
-describe("Test getFormattedEntityData", () => {
-  test("returns 'Add' when no conditions are met", () => {
-    const result = getAddEditDrawerText(
-      EntityType.ACCESS_MEASURES,
-      { provider: false },
-      mockModalDrawerReportPageVerbiage
-    );
-    expect(result).toBe("Add Mock drawer title");
-  });
-
-  test("returns 'Edit' when provider exists for ACCESS_MEASURES", () => {
-    const result = getAddEditDrawerText(
-      EntityType.ACCESS_MEASURES,
-      { provider: true },
-      mockModalDrawerReportPageVerbiage
-    );
-    expect(result).toBe("Edit Mock drawer title");
-  });
-
-  test("returns 'Edit' when perPlanResponses exists for QUALITY_MEASURES", () => {
-    const result = getAddEditDrawerText(
-      EntityType.QUALITY_MEASURES,
-      { perPlanResponses: [{ name: "plan 1", response: "n/a" }] },
-      mockModalDrawerReportPageVerbiage
-    );
-    expect(result).toBe("Edit Mock drawer title");
-  });
-
-  test("returns 'Edit' when assessmentDate exists for SANCTIONS", () => {
-    const result = getAddEditDrawerText(
-      EntityType.SANCTIONS,
-      { assessmentDate: true },
-      mockModalDrawerReportPageVerbiage
-    );
-    expect(result).toBe("Edit Mock drawer title");
   });
 });

--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -1,10 +1,13 @@
-// utils
+// constants
+import { exceptionsStatus, nonComplianceStatus } from "../../constants";
+// types
 import {
   AnyObject,
   EntityShape,
   EntityType,
   ModalDrawerReportPageVerbiage,
 } from "types";
+// utils
 import { compareText, maskResponseData, otherSpecify, translate } from "utils";
 
 const getRadioValue = (entity: EntityShape | undefined, label: string) => {
@@ -110,8 +113,93 @@ export const getFormattedEntityData = (
         perPlanResponses: getPlanValues(entity, reportFieldData?.plans),
       };
     case EntityType.PLANS:
+      if (!entity) {
+        return {};
+      }
+      const plan = entity; // eslint-disable-line no-case-declarations
+
+      // display information for non-compliant standards
+      if (plan?.exceptionsNonCompliance === nonComplianceStatus) {
+        const planKeys = Object.keys(plan);
+        const nonComplianceDescriptionKey: any = planKeys.find((key: string) =>
+          key.endsWith("-nonComplianceDescription")
+        );
+        const nonComplianceAnalysesKey: any = planKeys.find((key: string) =>
+          key.endsWith("-nonComplianceAnalyses")
+        );
+        const nonCompliancePlanToAchieveComplianceKey: any = planKeys.find(
+          (key: string) => key.endsWith("-nonCompliancePlanToAchieveCompliance")
+        );
+        const nonComplianceMonitoringProgressKey: any = planKeys.find(
+          (key: string) => key.endsWith("-nonComplianceMonitoringProgress")
+        );
+        const nonComplianceReassessmentDateKey: any = planKeys.find(
+          (key: string) => key.endsWith("-nonComplianceReassessmentDate")
+        );
+
+        const analysisMethodsUsed = plan[nonComplianceAnalysesKey].map(
+          (method: EntityShape) => method.value
+        );
+
+        return {
+          heading: `Plan deficiencies for ${
+            plan?.name || "plan"
+          }: 42 C.F.R. § 438.68`,
+          questions: [
+            {
+              question: "Description",
+              answer: plan[nonComplianceDescriptionKey],
+            },
+            {
+              question: "Analyses used to identify deficiencies",
+              answer: analysisMethodsUsed.join(", "),
+            },
+            {
+              question: "What the plan will do to achieve compliance",
+              answer: plan[nonCompliancePlanToAchieveComplianceKey],
+            },
+            {
+              question: "Monitoring progress",
+              answer: plan[nonComplianceMonitoringProgressKey],
+            },
+            {
+              question: "Reassessment date",
+              answer: plan[nonComplianceReassessmentDateKey],
+            },
+          ],
+        };
+      }
+
+      // display information for exceptions standards
+      if (plan?.exceptionsNonCompliance === exceptionsStatus) {
+        const planKeys = Object.keys(plan);
+        const exceptionsDescriptionKey: any = planKeys.find((key: string) =>
+          key.endsWith("-exceptionsDescription")
+        );
+        const exceptionsJustificationKey: any = planKeys.find((key: string) =>
+          key.endsWith("-exceptionsJustification")
+        );
+
+        return {
+          heading: `Exceptions granted for ${
+            plan?.name || "plan"
+          } under 42 C.F.R. § 438.68(d)`,
+          questions: [
+            {
+              question:
+                "Describe any network adequacy standard exceptions that the state has granted to the plan under 42 C.F.R. § 438.68(d).",
+              answer: plan[exceptionsDescriptionKey],
+            },
+            {
+              question:
+                "Justification for exceptions granted under 42 C.F.R. § 438.68(d)",
+              answer: plan[exceptionsJustificationKey],
+            },
+          ],
+        };
+      }
       return {
-        name: entity?.name,
+        heading: `Problem displaying data for ${plan?.name || "plan"}`,
       };
     default:
       return {};

--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -109,6 +109,10 @@ export const getFormattedEntityData = (
         description: entity?.qualityMeasure_description,
         perPlanResponses: getPlanValues(entity, reportFieldData?.plans),
       };
+    case EntityType.PLANS:
+      return {
+        name: entity?.name,
+      };
     default:
       return {};
   }

--- a/services/ui-src/src/utils/tables/mapNaaarStandardsData.test.ts
+++ b/services/ui-src/src/utils/tables/mapNaaarStandardsData.test.ts
@@ -9,6 +9,7 @@ describe("mapNaaarStandardsData()", () => {
     const tableData = mapNaaarStandardsData<any>(mockNaaarStandards);
     const expectedData = [
       {
+        id: "mockStandard",
         count: 1,
         provider: "Mock Provider; Mock Other Provider",
         standardType: "Mock Standard Type",
@@ -41,6 +42,7 @@ describe("mapNaaarStandardsData()", () => {
     const tableData = mapNaaarStandardsData<any>(incompleteData);
     const expectedData = [
       {
+        id: "mockStandard",
         count: 1,
         provider: "Mock Provider",
         standardType: "Mock Standard Type",

--- a/services/ui-src/src/utils/tables/mapNaaarStandardsData.ts
+++ b/services/ui-src/src/utils/tables/mapNaaarStandardsData.ts
@@ -51,6 +51,7 @@ export const mapNaaarStandardEntity = <T>(
     .join(", ");
 
   return {
+    id: entity.id,
     count: index === undefined ? 0 : index + 1,
     provider,
     standardType,

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -677,9 +677,22 @@ export const mockNaaarPlanCompliancePageJson = {
     ],
     childForms: [
       {
-        parentForm: "mockParentFormId",
+        parentForm: "mockParentFormId1",
         form: {
           id: "mockChildFormId1",
+          fields: [
+            {
+              id: "mockChildFormFieldId1",
+              type: "textarea",
+              validation: "text",
+            },
+          ],
+        },
+      },
+      {
+        parentForm: "mockParentFormId2",
+        form: {
+          id: "mockChildFormId2",
           fields: [
             {
               id: "mockChildFormFieldId1",

--- a/services/ui-src/src/utils/verbiage/verbiage.test.ts
+++ b/services/ui-src/src/utils/verbiage/verbiage.test.ts
@@ -1,0 +1,109 @@
+import { ReportType } from "types";
+import { getReportVerbiage } from "./verbiage";
+// dashboard verbiage
+import McparDashboardVerbiage from "verbiage/pages/mcpar/mcpar-dashboard";
+import MlrDashboardVerbiage from "verbiage/pages/mlr/mlr-dashboard";
+import NaaarDashboardVerbiage from "verbiage/pages/naaar/naaar-dashboard";
+// export verbiage
+import McparExportVerbiage from "verbiage/pages/mcpar/mcpar-export";
+import MlrExportVerbiage from "verbiage/pages/mlr/mlr-export";
+import NaaarExportVerbiage from "verbiage/pages/naaar/naaar-export";
+// get started verbiage
+import McparGetStartedVerbiage from "verbiage/pages/mcpar/mcpar-get-started";
+// review and submit verbiage
+import McparReviewAndSubmitVerbiage from "verbiage/pages/mcpar/mcpar-review-and-submit";
+import MlrReviewAndSubmitVerbiage from "verbiage/pages/mlr/mlr-review-and-submit";
+import NaaarReviewAndSubmitVerbiage from "verbiage/pages/naaar/naaar-review-and-submit";
+
+describe("getReportVerbiage()", () => {
+  afterEach(() => {
+    localStorage.setItem("selectedReportType", "");
+  });
+  test("Returns MLR when matching passed report type", () => {
+    const { dashboardVerbiage, exportVerbiage, reviewAndSubmitVerbiage } =
+      getReportVerbiage(ReportType.MLR);
+    expect(dashboardVerbiage.intro.header).toBe(
+      MlrDashboardVerbiage.intro.header
+    );
+    expect(exportVerbiage.metadata.subject).toBe(
+      MlrExportVerbiage.metadata.subject
+    );
+    expect(reviewAndSubmitVerbiage.print.printPageUrl).toBe(
+      MlrReviewAndSubmitVerbiage.print.printPageUrl
+    );
+  });
+
+  test("Returns MLR when matching stored report type", () => {
+    localStorage.setItem("selectedReportType", ReportType.MLR);
+    const { dashboardVerbiage, exportVerbiage, reviewAndSubmitVerbiage } =
+      getReportVerbiage();
+    expect(dashboardVerbiage.intro.header).toBe(
+      MlrDashboardVerbiage.intro.header
+    );
+    expect(exportVerbiage.metadata.subject).toBe(
+      MlrExportVerbiage.metadata.subject
+    );
+    expect(reviewAndSubmitVerbiage.print.printPageUrl).toBe(
+      MlrReviewAndSubmitVerbiage.print.printPageUrl
+    );
+  });
+
+  test("Returns NAAAR when matching stored report type", () => {
+    localStorage.setItem("selectedReportType", ReportType.NAAAR);
+    const { dashboardVerbiage, exportVerbiage, reviewAndSubmitVerbiage } =
+      getReportVerbiage();
+    expect(dashboardVerbiage.intro.header).toBe(
+      NaaarDashboardVerbiage.intro.header
+    );
+    expect(exportVerbiage.metadata.subject).toBe(
+      NaaarExportVerbiage.metadata.subject
+    );
+    expect(reviewAndSubmitVerbiage.print.printPageUrl).toBe(
+      NaaarReviewAndSubmitVerbiage.print.printPageUrl
+    );
+  });
+
+  test("Returns MCPAR when matching stored report type", () => {
+    localStorage.setItem("selectedReportType", ReportType.MCPAR);
+    const {
+      dashboardVerbiage,
+      exportVerbiage,
+      getStartedVerbiage,
+      reviewAndSubmitVerbiage,
+    } = getReportVerbiage();
+    expect(dashboardVerbiage.intro.header).toBe(
+      McparDashboardVerbiage.intro.header
+    );
+    expect(exportVerbiage.metadata.subject).toBe(
+      McparExportVerbiage.metadata.subject
+    );
+    expect(getStartedVerbiage.intro.header).toBe(
+      McparGetStartedVerbiage.intro.header
+    );
+    expect(reviewAndSubmitVerbiage.print.printPageUrl).toBe(
+      McparReviewAndSubmitVerbiage.print.printPageUrl
+    );
+  });
+
+  test("Returns MCPAR as default", () => {
+    localStorage.setItem("selectedReportType", "");
+    const {
+      dashboardVerbiage,
+      exportVerbiage,
+      getStartedVerbiage,
+      reviewAndSubmitVerbiage,
+    } = getReportVerbiage();
+    expect(dashboardVerbiage.intro.header).toBe(
+      McparDashboardVerbiage.intro.header
+    );
+    expect(exportVerbiage.metadata.subject).toBe(
+      McparExportVerbiage.metadata.subject
+    );
+    expect(getStartedVerbiage.intro.header).toBe(
+      McparGetStartedVerbiage.intro.header
+    );
+    expect(reviewAndSubmitVerbiage.print.printPageUrl).toBe(
+      McparReviewAndSubmitVerbiage.print.printPageUrl
+    );
+  });
+});

--- a/services/ui-src/src/utils/verbiage/verbiage.ts
+++ b/services/ui-src/src/utils/verbiage/verbiage.ts
@@ -1,0 +1,49 @@
+// types
+import { AnyObject, ReportType } from "types";
+// dashboard verbiage
+import McparDashboardVerbiage from "verbiage/pages/mcpar/mcpar-dashboard";
+import MlrDashboardVerbiage from "verbiage/pages/mlr/mlr-dashboard";
+import NaaarDashboardVerbiage from "verbiage/pages/naaar/naaar-dashboard";
+// export verbiage
+import McparExportVerbiage from "verbiage/pages/mcpar/mcpar-export";
+import MlrExportVerbiage from "verbiage/pages/mlr/mlr-export";
+import NaaarExportVerbiage from "verbiage/pages/naaar/naaar-export";
+// get started verbiage
+import McparGetStartedVerbiage from "verbiage/pages/mcpar/mcpar-get-started";
+// review and submit verbiage
+import McparReviewAndSubmitVerbiage from "verbiage/pages/mcpar/mcpar-review-and-submit";
+import MlrReviewAndSubmitVerbiage from "verbiage/pages/mlr/mlr-review-and-submit";
+import NaaarReviewAndSubmitVerbiage from "verbiage/pages/naaar/naaar-review-and-submit";
+
+const mcparVerbiage = {
+  dashboardVerbiage: McparDashboardVerbiage,
+  getStartedVerbiage: McparGetStartedVerbiage,
+  exportVerbiage: McparExportVerbiage,
+  reviewAndSubmitVerbiage: McparReviewAndSubmitVerbiage,
+};
+
+const mlrVerbiage = {
+  dashboardVerbiage: MlrDashboardVerbiage,
+  exportVerbiage: MlrExportVerbiage,
+  reviewAndSubmitVerbiage: MlrReviewAndSubmitVerbiage,
+};
+
+const naaarVerbiage = {
+  dashboardVerbiage: NaaarDashboardVerbiage,
+  exportVerbiage: NaaarExportVerbiage,
+  reviewAndSubmitVerbiage: NaaarReviewAndSubmitVerbiage,
+};
+
+export const getReportVerbiage = (reportType?: string): AnyObject => {
+  const reportTypeSelector =
+    reportType ?? localStorage.getItem("selectedReportType");
+  switch (reportTypeSelector) {
+    case ReportType.MLR:
+      return mlrVerbiage;
+    case ReportType.NAAAR:
+      return naaarVerbiage;
+    case ReportType.MCPAR:
+    default:
+      return mcparVerbiage;
+  }
+};

--- a/services/ui-src/src/verbiage/pages/mcpar/mcpar-export.ts
+++ b/services/ui-src/src/verbiage/pages/mcpar/mcpar-export.ts
@@ -1,6 +1,7 @@
 export default {
   missingEntry: {
     noResponse: "Not answered",
+    noResponseOptional: "Not answered",
     notApplicable: "Not applicable",
     missingPlans:
       "This program is missing plans. You won't be able to complete this section until you've added all the managed care plans that serve enrollees in the program. Go to section A: Add Plans.",

--- a/services/ui-src/src/verbiage/pages/mlr/mlr-export.ts
+++ b/services/ui-src/src/verbiage/pages/mlr/mlr-export.ts
@@ -1,6 +1,7 @@
 export default {
   missingEntry: {
-    noResponse: "Not answered",
+    noResponse: "Not answered; required",
+    noResponseOptional: "Not answered, optional",
     notApplicable: "Not applicable",
   },
   reportBanner: {

--- a/services/ui-src/src/verbiage/pages/naaar/naaar-export.ts
+++ b/services/ui-src/src/verbiage/pages/naaar/naaar-export.ts
@@ -1,4 +1,9 @@
 export default {
+  missingEntry: {
+    noResponse: "Not answered",
+    noResponseOptional: "Not answered, optional",
+    notApplicable: "Not applicable",
+  },
   reportBanner: {
     intro: "Click below to export or print NAAAR Report shown here",
     pdfButton: "Download PDF",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Feature branch for non-compliant information in export view. 

Details of each change in PRs:
- https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12137
- https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12141
- https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12144
- https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12145
- https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12149
- https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12150
- https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12156

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4468

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[deployed env](https://d1gv6jaj9kkotu.cloudfront.net/) (where I've done all the setup for you!)
- Log in as a state user
- Create a NAAAR report
- Add two plans
- Complete the provider type coverage page
- Complete the analysis methods page, checking all of them as applicable for all plans, and adding custom methods
- Add three standards, selecting all analysis methods for all standards
- Go to the plan compliance page
  - Set one plan as compliant to both 438.68 and 438.206 and one plan as non-compliant to both
  - Add non-compliance details for 438.68
    - Enter details for the first and last standard, marking one as non-compliant and one as an exception
  - Add non-compliance details for 438.206
- View the PDF
- Verify it matches the [Figma](https://www.figma.com/design/QcoVlfZ2adUBnzcHiI0G0S/MDCT-MCR-NAAAR?node-id=580-56655&p=f&t=RdG1XPKiM9VzTP3Y-0) for all the various scenarios represented:
  - For 438.68
    - Standard cards display under the appropriate section (non-compliant or exception)
    - Only standards with answers show up in the PDF
    - Standard cards display a number in the upper left that matches their number in the standards table
    - Standard cards display all information for non-compliance
      - Note: we are not showing optional nested field info for analysis methods under non-compliance, just the name of the method
  - For 438.206
    - All input information shows up in the table

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary
---