### PR TITLE
Cmdct 4597 - remove filtering of provider types in the standards drawer

### DIFF
--- a/services/app-api/forms/naaar.json
+++ b/services/app-api/forms/naaar.json
@@ -588,7 +588,7 @@
         "id": "danas",
         "fields": [
           {
-            "id": "standard_coreProviderTypeCoveredByStandard",
+            "id": "standard_coreProviderType",
             "type": "radio",
             "validation": "radio",
             "props": {
@@ -600,12 +600,12 @@
                   "label": "Primary Care",
                   "children": [
                     {
-                      "id": "standard_coreProviderTypeCoveredByStandard-UZK4hxPVnuYGcIgNzYFHCk",
+                      "id": "standard_coreProviderType_details-UZK4hxPVnuYGcIgNzYFHCk",
                       "type": "text",
                       "validation": {
                         "type": "text",
                         "nested": true,
-                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentFieldName": "standard_coreProviderType",
                         "parentOptionId": "standard_UZK4hxPVnuYGcIgNzYFHCk"
                       },
                       "props": {
@@ -619,12 +619,12 @@
                   "label": "Specialist",
                   "children": [
                     {
-                      "id": "standard_coreProviderTypeCoveredByStandard-uITThePQiXntwGGViPTD62",
+                      "id": "standard_coreProviderType_details-uITThePQiXntwGGViPTD62",
                       "type": "text",
                       "validation": {
                         "type": "text",
                         "nested": true,
-                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentFieldName": "standard_coreProviderType",
                         "parentOptionId": "standard_uITThePQiXntwGGViPTD62"
                       },
                       "props": {
@@ -638,12 +638,12 @@
                   "label": "Mental health",
                   "children": [
                     {
-                      "id": "standard_coreProviderTypeCoveredByStandard-9kBoKCLD1dYizieU5psnJi",
+                      "id": "standard_coreProviderType_details-9kBoKCLD1dYizieU5psnJi",
                       "type": "text",
                       "validation": {
                         "type": "text",
                         "nested": true,
-                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentFieldName": "standard_coreProviderType",
                         "parentOptionId": "standard_9kBoKCLD1dYizieU5psnJi"
                       },
                       "props": {
@@ -657,12 +657,12 @@
                   "label": "OB/GYN",
                   "children": [
                     {
-                      "id": "standard_coreProviderTypeCoveredByStandard-kV7553HIWXekySIFLiMXLW",
+                      "id": "standard_coreProviderType_details-kV7553HIWXekySIFLiMXLW",
                       "type": "text",
                       "validation": {
                         "type": "text",
                         "nested": true,
-                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentFieldName": "standard_coreProviderType",
                         "parentOptionId": "standard_kV7553HIWXekySIFLiMXLW"
                       },
                       "props": {
@@ -676,12 +676,12 @@
                   "label": "Hospital",
                   "children": [
                     {
-                      "id": "standard_coreProviderTypeCoveredByStandard-nzmRTbJeqBCoAabR4oHrrh",
+                      "id": "standard_coreProviderType_details-nzmRTbJeqBCoAabR4oHrrh",
                       "type": "text",
                       "validation": {
                         "type": "text",
                         "nested": true,
-                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentFieldName": "standard_coreProviderType",
                         "parentOptionId": "standard_nzmRTbJeqBCoAabR4oHrrh"
                       },
                       "props": {
@@ -695,12 +695,12 @@
                   "label": "Pharmacy",
                   "children": [
                     {
-                      "id": "standard_coreProviderTypeCoveredByStandard-cb4y58UmsRXVITpWL7l9up",
+                      "id": "standard_coreProviderType_details-cb4y58UmsRXVITpWL7l9up",
                       "type": "text",
                       "validation": {
                         "type": "text",
                         "nested": true,
-                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentFieldName": "standard_coreProviderType",
                         "parentOptionId": "standard_cb4y58UmsRXVITpWL7l9up"
                       },
                       "props": {
@@ -714,12 +714,12 @@
                   "label": "Dental",
                   "children": [
                     {
-                      "id": "standard_coreProviderTypeCoveredByStandard-tlzAMYfH4I7iIl5pjqAm7R",
+                      "id": "standard_coreProviderType_details-tlzAMYfH4I7iIl5pjqAm7R",
                       "type": "text",
                       "validation": {
                         "type": "text",
                         "nested": true,
-                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentFieldName": "standard_coreProviderType",
                         "parentOptionId": "standard_tlzAMYfH4I7iIl5pjqAm7R"
                       },
                       "props": {
@@ -733,12 +733,12 @@
                   "label": "LTSS",
                   "children": [
                     {
-                      "id": "standard_coreProviderTypeCoveredByStandard-WrMpSdivds4c0XfN2RPlRd",
+                      "id": "standard_coreProviderType_details-WrMpSdivds4c0XfN2RPlRd",
                       "type": "text",
                       "validation": {
                         "type": "text",
                         "nested": true,
-                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentFieldName": "standard_coreProviderType",
                         "parentOptionId": "standard_WrMpSdivds4c0XfN2RPlRd"
                       },
                       "props": {
@@ -752,12 +752,12 @@
                   "label": "Substance Use Disorder (SUD)",
                   "children": [
                     {
-                      "id": "standard_coreProviderTypeCoveredByStandard-qbR8X0YAh8vObedJPx6QTJ",
+                      "id": "standard_coreProviderType_details-qbR8X0YAh8vObedJPx6QTJ",
                       "type": "text",
                       "validation": {
                         "type": "text",
                         "nested": true,
-                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentFieldName": "standard_coreProviderType",
                         "parentOptionId": "standard_qbR8X0YAh8vObedJPx6QTJ"
                       },
                       "props": {

--- a/services/app-api/forms/naaar.json
+++ b/services/app-api/forms/naaar.json
@@ -589,49 +589,182 @@
         "fields": [
           {
             "id": "standard_coreProviderTypeCoveredByStandard",
-            "type": "checkbox",
-            "validation": "checkbox",
+            "type": "radio",
+            "validation": "radio",
             "props": {
               "label": "Core provider type covered by standard",
               "hint": "Enter the core provider type the standard applies to. If you wish to specify the provider type, select the core type most suitable and then add the more specific provider type under “Specialist details”.",
               "choices": [
                 {
                   "id": "standard_UZK4hxPVnuYGcIgNzYFHCk",
-                  "label": "Primary Care"
+                  "label": "Primary Care",
+                  "children": [
+                    {
+                      "id": "standard_standardDescription-standard_UZK4hxPVnuYGcIgNzYFHCk",
+                      "type": "text",
+                      "validation": {
+                        "type": "text",
+                        "nested": true,
+                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentOptionId": "standard_UZK4hxPVnuYGcIgNzYFHCk"
+                      },
+                      "props": {
+                        "label": "Specialist details (optional)"
+                      }
+                    }
+                  ]
                 },
                 {
                   "id": "standard_uITThePQiXntwGGViPTD62",
                   "label": "Specialist",
-                  "hint": "Include all specialists (except for Mental health) within this category. You’ll be able to specify them when creating standards."
+                  "children": [
+                    {
+                      "id": "standard_standardDescription-standard_uITThePQiXntwGGViPTD62",
+                      "type": "text",
+                      "validation": {
+                        "type": "text",
+                        "nested": true,
+                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentOptionId": "standard_uITThePQiXntwGGViPTD62"
+                      },
+                      "props": {
+                        "label": "Specialist details (optional)"
+                      }
+                    }
+                  ]
                 },
                 {
                   "id": "standard_9kBoKCLD1dYizieU5psnJi",
                   "label": "Mental health",
-                  "hint": "Include all mental health specialists within this category. You’ll be able to specify them when creating standards."
+                  "children": [
+                    {
+                      "id": "standard_standardDescription-standard_9kBoKCLD1dYizieU5psnJi",
+                      "type": "text",
+                      "validation": {
+                        "type": "text",
+                        "nested": true,
+                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentOptionId": "standard_9kBoKCLD1dYizieU5psnJi"
+                      },
+                      "props": {
+                        "label": "Specialist details (optional)"
+                      }
+                    }
+                  ]
                 },
                 {
                   "id": "standard_kV7553HIWXekySIFLiMXLW",
-                  "label": "OB/GYN"
+                  "label": "OB/GYN",
+                  "children": [
+                    {
+                      "id": "standard_standardDescription-standard_kV7553HIWXekySIFLiMXLW",
+                      "type": "text",
+                      "validation": {
+                        "type": "text",
+                        "nested": true,
+                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentOptionId": "standard_kV7553HIWXekySIFLiMXLW"
+                      },
+                      "props": {
+                        "label": "Specialist details (optional)"
+                      }
+                    }
+                  ]
                 },
                 {
                   "id": "standard_nzmRTbJeqBCoAabR4oHrrh",
-                  "label": "Hospital"
+                  "label": "Hospital",
+                  "children": [
+                    {
+                      "id": "standard_standardDescription-standard_nzmRTbJeqBCoAabR4oHrrh",
+                      "type": "text",
+                      "validation": {
+                        "type": "text",
+                        "nested": true,
+                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentOptionId": "standard_nzmRTbJeqBCoAabR4oHrrh"
+                      },
+                      "props": {
+                        "label": "Specialist details (optional)"
+                      }
+                    }
+                  ]
                 },
                 {
                   "id": "standard_cb4y58UmsRXVITpWL7l9up",
-                  "label": "Pharmacy"
+                  "label": "Pharmacy",
+                  "children": [
+                    {
+                      "id": "standard_standardDescription-standard_cb4y58UmsRXVITpWL7l9up",
+                      "type": "text",
+                      "validation": {
+                        "type": "text",
+                        "nested": true,
+                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentOptionId": "standard_cb4y58UmsRXVITpWL7l9up"
+                      },
+                      "props": {
+                        "label": "Specialist details (optional)"
+                      }
+                    }
+                  ]
                 },
                 {
                   "id": "standard_tlzAMYfH4I7iIl5pjqAm7R",
-                  "label": "Dental"
+                  "label": "Dental",
+                  "children": [
+                    {
+                      "id": "standard_standardDescription-standard_tlzAMYfH4I7iIl5pjqAm7R",
+                      "type": "text",
+                      "validation": {
+                        "type": "text",
+                        "nested": true,
+                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentOptionId": "standard_tlzAMYfH4I7iIl5pjqAm7R"
+                      },
+                      "props": {
+                        "label": "Specialist details (optional)"
+                      }
+                    }
+                  ]
                 },
                 {
                   "id": "standard_WrMpSdivds4c0XfN2RPlRd",
-                  "label": "LTSS"
+                  "label": "LTSS",
+                  "children": [
+                    {
+                      "id": "standard_standardDescription-standard_WrMpSdivds4c0XfN2RPlRd",
+                      "type": "text",
+                      "validation": {
+                        "type": "text",
+                        "nested": true,
+                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentOptionId": "standard_WrMpSdivds4c0XfN2RPlRd"
+                      },
+                      "props": {
+                        "label": "Specialist details (optional)"
+                      }
+                    }
+                  ]
                 },
                 {
                   "id": "standard_qbR8X0YAh8vObedJPx6QTJ",
-                  "label": "Substance Use Disorder (SUD)"
+                  "label": "Substance Use Disorder (SUD)",
+                  "children": [
+                    {
+                      "id": "standard_standardDescription-standard_qbR8X0YAh8vObedJPx6QTJ",
+                      "type": "text",
+                      "validation": {
+                        "type": "text",
+                        "nested": true,
+                        "parentFieldName": "standard_coreProviderTypeCoveredByStandard",
+                        "parentOptionId": "standard_qbR8X0YAh8vObedJPx6QTJ"
+                      },
+                      "props": {
+                        "label": "Specialist details (optional)"
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/services/app-api/forms/naaar.json
+++ b/services/app-api/forms/naaar.json
@@ -589,12 +589,51 @@
         "fields": [
           {
             "id": "standard_coreProviderTypeCoveredByStandard",
-            "type": "radio",
-            "validation": "radio",
+            "type": "checkbox",
+            "validation": "checkbox",
             "props": {
               "label": "Core provider type covered by standard",
               "hint": "Enter the core provider type the standard applies to. If you wish to specify the provider type, select the core type most suitable and then add the more specific provider type under “Specialist details”.",
-              "choices": []
+              "choices": [
+                {
+                  "id": "standard_UZK4hxPVnuYGcIgNzYFHCk",
+                  "label": "Primary Care"
+                },
+                {
+                  "id": "standard_uITThePQiXntwGGViPTD62",
+                  "label": "Specialist",
+                  "hint": "Include all specialists (except for Mental health) within this category. You’ll be able to specify them when creating standards."
+                },
+                {
+                  "id": "standard_9kBoKCLD1dYizieU5psnJi",
+                  "label": "Mental health",
+                  "hint": "Include all mental health specialists within this category. You’ll be able to specify them when creating standards."
+                },
+                {
+                  "id": "standard_kV7553HIWXekySIFLiMXLW",
+                  "label": "OB/GYN"
+                },
+                {
+                  "id": "standard_nzmRTbJeqBCoAabR4oHrrh",
+                  "label": "Hospital"
+                },
+                {
+                  "id": "standard_cb4y58UmsRXVITpWL7l9up",
+                  "label": "Pharmacy"
+                },
+                {
+                  "id": "standard_tlzAMYfH4I7iIl5pjqAm7R",
+                  "label": "Dental"
+                },
+                {
+                  "id": "standard_WrMpSdivds4c0XfN2RPlRd",
+                  "label": "LTSS"
+                },
+                {
+                  "id": "standard_qbR8X0YAh8vObedJPx6QTJ",
+                  "label": "Substance Use Disorder (SUD)"
+                }
+              ]
             }
           },
           {

--- a/services/app-api/forms/naaar.json
+++ b/services/app-api/forms/naaar.json
@@ -600,7 +600,7 @@
                   "label": "Primary Care",
                   "children": [
                     {
-                      "id": "standard_standardDescription-standard_UZK4hxPVnuYGcIgNzYFHCk",
+                      "id": "standard_coreProviderTypeCoveredByStandard-UZK4hxPVnuYGcIgNzYFHCk",
                       "type": "text",
                       "validation": {
                         "type": "text",
@@ -619,7 +619,7 @@
                   "label": "Specialist",
                   "children": [
                     {
-                      "id": "standard_standardDescription-standard_uITThePQiXntwGGViPTD62",
+                      "id": "standard_coreProviderTypeCoveredByStandard-uITThePQiXntwGGViPTD62",
                       "type": "text",
                       "validation": {
                         "type": "text",
@@ -638,7 +638,7 @@
                   "label": "Mental health",
                   "children": [
                     {
-                      "id": "standard_standardDescription-standard_9kBoKCLD1dYizieU5psnJi",
+                      "id": "standard_coreProviderTypeCoveredByStandard-9kBoKCLD1dYizieU5psnJi",
                       "type": "text",
                       "validation": {
                         "type": "text",
@@ -657,7 +657,7 @@
                   "label": "OB/GYN",
                   "children": [
                     {
-                      "id": "standard_standardDescription-standard_kV7553HIWXekySIFLiMXLW",
+                      "id": "standard_coreProviderTypeCoveredByStandard-kV7553HIWXekySIFLiMXLW",
                       "type": "text",
                       "validation": {
                         "type": "text",
@@ -676,7 +676,7 @@
                   "label": "Hospital",
                   "children": [
                     {
-                      "id": "standard_standardDescription-standard_nzmRTbJeqBCoAabR4oHrrh",
+                      "id": "standard_coreProviderTypeCoveredByStandard-nzmRTbJeqBCoAabR4oHrrh",
                       "type": "text",
                       "validation": {
                         "type": "text",
@@ -695,7 +695,7 @@
                   "label": "Pharmacy",
                   "children": [
                     {
-                      "id": "standard_standardDescription-standard_cb4y58UmsRXVITpWL7l9up",
+                      "id": "standard_coreProviderTypeCoveredByStandard-cb4y58UmsRXVITpWL7l9up",
                       "type": "text",
                       "validation": {
                         "type": "text",
@@ -714,7 +714,7 @@
                   "label": "Dental",
                   "children": [
                     {
-                      "id": "standard_standardDescription-standard_tlzAMYfH4I7iIl5pjqAm7R",
+                      "id": "standard_coreProviderTypeCoveredByStandard-tlzAMYfH4I7iIl5pjqAm7R",
                       "type": "text",
                       "validation": {
                         "type": "text",
@@ -733,7 +733,7 @@
                   "label": "LTSS",
                   "children": [
                     {
-                      "id": "standard_standardDescription-standard_WrMpSdivds4c0XfN2RPlRd",
+                      "id": "standard_coreProviderTypeCoveredByStandard-WrMpSdivds4c0XfN2RPlRd",
                       "type": "text",
                       "validation": {
                         "type": "text",
@@ -752,7 +752,7 @@
                   "label": "Substance Use Disorder (SUD)",
                   "children": [
                     {
-                      "id": "standard_standardDescription-standard_qbR8X0YAh8vObedJPx6QTJ",
+                      "id": "standard_coreProviderTypeCoveredByStandard-qbR8X0YAh8vObedJPx6QTJ",
                       "type": "text",
                       "validation": {
                         "type": "text",

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -75,7 +75,6 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
   const hasPlans = plans?.length > 0;
   const isReportingOnStandards =
     route.path === "/naaar/program-level-access-and-network-adequacy-standards";
-  // const hasProviderTypes = report?.fieldData?.["providerTypes"]?.length > 0;
 
   // check if user has completed default analysis methods (NAAAR)
   const completedAnalysisMethods = () => {
@@ -258,19 +257,18 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
     : "";
   const dashTitle = `${verbiage.dashboardTitle}${entityCount}`;
 
-  const isAddStandardsDisabled = !completedAnalysisMethods();
   const addStandardsButton = (
     <Button
       sx={sx.addStandardsButton}
       leftIcon={
         <Image
           sx={sx.buttonIcons}
-          src={isAddStandardsDisabled ? addIconSVG : addIconWhite}
+          src={completedAnalysisMethods() ? addIconWhite : addIconSVG}
           alt="Add"
         />
       }
       onClick={() => openRowDrawer()}
-      disabled={isAddStandardsDisabled}
+      disabled={!completedAnalysisMethods()}
     >
       {verbiage.addEntityButtonText}
     </Button>

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -75,7 +75,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
   const hasPlans = plans?.length > 0;
   const isReportingOnStandards =
     route.path === "/naaar/program-level-access-and-network-adequacy-standards";
-  const hasProviderTypes = report?.fieldData?.["providerTypes"]?.length > 0;
+  // const hasProviderTypes = report?.fieldData?.["providerTypes"]?.length > 0;
 
   // check if user has completed default analysis methods (NAAAR)
   const completedAnalysisMethods = () => {
@@ -242,8 +242,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
       );
     } else if (
       (isAnalysisMethodsPage && !hasPlans) ||
-      (isReportingOnStandards && !completedAnalysisMethods()) ||
-      (isReportingOnStandards && !hasProviderTypes)
+      (isReportingOnStandards && !completedAnalysisMethods())
     ) {
       return (
         <Box sx={sx.missingEntity}>
@@ -259,8 +258,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
     : "";
   const dashTitle = `${verbiage.dashboardTitle}${entityCount}`;
 
-  const isAddStandardsDisabled =
-    !hasProviderTypes || !completedAnalysisMethods();
+  const isAddStandardsDisabled = !completedAnalysisMethods();
   const addStandardsButton = (
     <Button
       sx={sx.addStandardsButton}

--- a/services/ui-src/src/utils/forms/dynamicItemFields.ts
+++ b/services/ui-src/src/utils/forms/dynamicItemFields.ts
@@ -67,7 +67,6 @@ export const generateAnalysisMethodChoices = (
 
 const availableItems = (items: AnyObject[], entityType: string) => {
   const ilosFieldName = "plan_ilosUtilizationByPlan";
-  const providerTypeFieldName = "standard_coreProviderTypeCoveredByStandard";
   const updatedItemChoices: AnyObject[] = [];
   items.forEach((item) => {
     if (entityType === EntityType.STANDARDS) {
@@ -83,41 +82,23 @@ const availableItems = (items: AnyObject[], entityType: string) => {
       ...item,
       label: item.name,
       checked: false,
-      ...(entityType === EntityType.ILOS
-        ? {
-            children: [
-              {
-                id: `${ilosFieldName}_${item.id}`,
-                type: "number",
-                validation: {
-                  type: "number",
-                  nested: true,
-                  parentFieldName: `${ilosFieldName}`,
-                  parentOptionId: item.id,
-                },
-                props: {
-                  decimalPlacesToRoundTo: 0,
-                },
-              },
-            ],
-          }
-        : entityType === EntityType.STANDARDS && {
-            children: [
-              {
-                id: `${providerTypeFieldName}-${item.id}-otherText`,
-                type: "text",
-                validation: {
-                  type: "textOptional",
-                  nested: true,
-                  parentFieldName: `${providerTypeFieldName}`,
-                  parentOptionId: item.id,
-                },
-                props: {
-                  label: "Specialist details (optional)",
-                },
-              },
-            ],
-          }),
+      ...(entityType === EntityType.ILOS && {
+        children: [
+          {
+            id: `${ilosFieldName}_${item.id}`,
+            type: "number",
+            validation: {
+              type: "number",
+              nested: true,
+              parentFieldName: `${ilosFieldName}`,
+              parentOptionId: item.id,
+            },
+            props: {
+              decimalPlacesToRoundTo: 0,
+            },
+          },
+        ],
+      }),
     });
   });
   return updatedItemChoices;

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -294,9 +294,6 @@ export const getForm = (params: getFormParams) => {
   const addEntityDrawerForm = route.addEntityDrawerForm || ({} as FormJson);
   const plans =
     report?.fieldData?.plans?.map((plan: { name: string }) => plan) || [];
-  const providerTypes = report?.fieldData?.providerTypes?.map(
-    (providerType: { name: string }) => providerType
-  );
   const analysisMethodsUsedByPlans = report?.fieldData?.analysisMethods?.filter(
     (analysisMethod: AnyObject) =>
       analysisMethod.analysis_applicable?.[0].value === "Yes" ||
@@ -316,13 +313,14 @@ export const getForm = (params: getFormParams) => {
             )
           : generateDrawerItemFields(drawerForm, plans, EntityType.PLANS);
       }
-      if (isReportingOnStandards && providerTypes?.length > 0) {
-        const providerTypeFields = generateDrawerItemFields(
-          drawerForm,
-          providerTypes,
-          EntityType.STANDARDS
-        );
-        modifiedForm.fields.splice(0, 1, providerTypeFields.fields[0]);
+      if (isReportingOnStandards) {
+        // const providerTypeFields = generateDrawerItemFields(
+        //   drawerForm,
+        //   providerTypes,
+        //   EntityType.STANDARDS
+        // );
+        // modifiedForm.fields.splice(0, 1, providerTypeFields.fields[0]);
+
         generateAnalysisMethodChoices(drawerForm, analysisMethodsUsedByPlans);
       }
       break;

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -314,13 +314,6 @@ export const getForm = (params: getFormParams) => {
           : generateDrawerItemFields(drawerForm, plans, EntityType.PLANS);
       }
       if (isReportingOnStandards) {
-        // const providerTypeFields = generateDrawerItemFields(
-        //   drawerForm,
-        //   providerTypes,
-        //   EntityType.STANDARDS
-        // );
-        // modifiedForm.fields.splice(0, 1, providerTypeFields.fields[0]);
-
         generateAnalysisMethodChoices(drawerForm, analysisMethodsUsedByPlans);
       }
       break;

--- a/services/ui-src/src/utils/tables/mapNaaarStandardsData.test.ts
+++ b/services/ui-src/src/utils/tables/mapNaaarStandardsData.test.ts
@@ -27,7 +27,7 @@ describe("mapNaaarStandardsData()", () => {
     const incompleteData: EntityShape[] = [
       {
         id: "mockStandard",
-        standard_coreProviderTypeCoveredByStandard: [
+        standard_coreProviderType: [
           { key: "mockProviderType", value: "Mock Provider" },
         ],
         standard_standardType: [

--- a/services/ui-src/src/utils/tables/mapNaaarStandardsData.ts
+++ b/services/ui-src/src/utils/tables/mapNaaarStandardsData.ts
@@ -8,7 +8,7 @@ export const mapNaaarStandardEntity = <T>(
   index?: number
 ) => {
   const [provider, standardType, population, region] = [
-    "standard_coreProviderTypeCoveredByStandard",
+    "standard_coreProviderType",
     "standard_standardType",
     "standard_populationCoveredByStandard",
     "standard_applicableRegion",
@@ -17,11 +17,9 @@ export const mapNaaarStandardEntity = <T>(
     const value = parentObj[0]?.value;
     let otherText = entity[`${key}-otherText`];
 
-    if (key === "standard_coreProviderTypeCoveredByStandard") {
+    if (key === "standard_coreProviderType") {
       const providerKey = parentObj[0].key;
-      const providerId = providerKey
-        .split("standard_coreProviderTypeCoveredByStandard-")
-        .pop();
+      const providerId = providerKey.split("standard_coreProviderType-").pop();
       otherText = entity[`${key}-${providerId}-otherText`];
 
       const matchText = `${value}; ${otherText}`;

--- a/services/ui-src/src/utils/testing/mockEntities.tsx
+++ b/services/ui-src/src/utils/testing/mockEntities.tsx
@@ -204,14 +204,13 @@ export const mockNaaarStandards: EntityShape[] = [
         value: "Mock Method 2",
       },
     ],
-    standard_coreProviderTypeCoveredByStandard: [
+    standard_coreProviderType: [
       {
-        key: "standard_coreProviderTypeCoveredByStandard-mock-plan-id-1",
+        key: "standard_coreProviderType-mock-plan-id-1",
         value: "Mock Provider",
       },
     ],
-    "standard_coreProviderTypeCoveredByStandard-mock-plan-id-1-otherText":
-      "Mock Other Provider",
+    "standard_coreProviderType-mock-plan-id-1-otherText": "Mock Other Provider",
     standard_standardType: [
       { key: "mockStandardType", value: "Mock Standard Type" },
     ],

--- a/services/ui-src/src/utils/testing/mockReport.tsx
+++ b/services/ui-src/src/utils/testing/mockReport.tsx
@@ -427,9 +427,9 @@ export const mockNaaarReportFieldData = {
   standards: [
     {
       id: "e78c5-a830-541-ac6e-d567ea7d413",
-      standard_coreProviderTypeCoveredByStandard: [
+      standard_coreProviderType: [
         {
-          key: "standard_coreProviderTypeCoveredByStandard-mock-id",
+          key: "standard_coreProviderType-mock-id",
           value: "Primary Care",
         },
       ],


### PR DESCRIPTION
### Description
It was decided that users should still have all provider types available to them in the drawer when they're creating a standard. The provider types and child text fields are now hardcoded in the json file.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4597

---
### How to test
Create a standard, see that all provider types are available options and the child text field appears upon selection. 
See that there are no changes to drawer functionality in the NAAAR report


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
