### PR TITLE
NAAAR PDF non-compliance card feature: more tests and cleanup

### DIFF
--- a/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
@@ -23,12 +23,14 @@ export const ExportedEntityDetailsTable = ({
   entity,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   showHintText,
+  entityType: passedEntityType,
+  entityIndex,
   ...props
 }: Props) => {
   const { report } = useStore();
   const { tableHeaders } = verbiage;
 
-  const entityType = props?.entityType ?? EntityType.PROGRAM;
+  const entityType = passedEntityType ?? EntityType.PROGRAM;
 
   const threeColumnHeaderItems = [
     tableHeaders.number,
@@ -55,7 +57,7 @@ export const ExportedEntityDetailsTable = ({
         !hideHintText,
         entity.id,
         entityType,
-        props?.entityIndex
+        entityIndex
       )}
     </Table>
   );
@@ -131,6 +133,8 @@ export interface Props {
   fields: FormField[];
   entity: EntityShape;
   showHintText?: boolean;
+  entityType?: EntityType;
+  entityIndex?: number;
   [key: string]: any;
 }
 

--- a/services/ui-src/src/components/export/ExportedPlanComplianceCard.test.tsx
+++ b/services/ui-src/src/components/export/ExportedPlanComplianceCard.test.tsx
@@ -23,7 +23,17 @@ const mockStandardFormattedData = {
 };
 
 const mockPlanFormattedData = {
-  name: "mock plan",
+  heading: "mock plan heading",
+  questions: [
+    {
+      question: "mock question 1",
+      answer: "mock answer 1",
+    },
+    {
+      question: "mock question 2",
+      answer: "mock answer 2",
+    },
+  ],
 };
 
 const ExportedPlanComplianceCardComponent = (
@@ -60,10 +70,13 @@ describe("<ExportedPlanComplianceCard />", () => {
       expect(screen.getByText(population)).toBeVisible();
 
       // plans
+      const { heading, questions } = mockPlanFormattedData;
 
-      // TODO: add back when other plan info is merged
-
-      // expect(screen.getByText(mockPlanFormattedData.name)).toBeVisible();
+      expect(screen.getByText(heading)).toBeVisible();
+      for (const q of questions) {
+        expect(screen.getByText(q.question)).toBeVisible();
+        expect(screen.getByText(q.answer)).toBeVisible();
+      }
     });
   });
 

--- a/services/ui-src/src/components/export/ExportedPlanComplianceCard.tsx
+++ b/services/ui-src/src/components/export/ExportedPlanComplianceCard.tsx
@@ -13,7 +13,7 @@ export const ExportedPlanComplianceCard = ({
   planData,
 }: Props) => {
   return (
-    <Card sxOverride={sx.card} data-testid="exportedPlanComplianceCard">
+    <Card sxOverride={sx.card}>
       <Box>
         <EntityCardTopSection
           entityType={EntityType.STANDARDS}

--- a/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedPlanOverlayReportSection.tsx
@@ -115,7 +115,6 @@ export const ExportedPlanOverlayReportSection = ({ section }: Props) => {
             key={plan.id}
             standardData={standardData}
             planData={planData}
-            verbiage={exportVerbiage}
           />
         );
       };

--- a/services/ui-src/src/utils/reports/entities.test.ts
+++ b/services/ui-src/src/utils/reports/entities.test.ts
@@ -1,5 +1,9 @@
 import { getAddEditDrawerText, getFormattedEntityData } from "./entities";
+// constants
+import { exceptionsStatus, nonComplianceStatus } from "../../constants";
+// types
 import { EntityType } from "types";
+// utils
 import {
   mockAccessMeasuresEntity,
   mockCompletedAccessMeasuresFormattedEntityData,
@@ -15,99 +19,219 @@ import {
   mockModalDrawerReportPageVerbiage,
 } from "utils/testing/setupJest";
 
-describe("Test getFormattedEntityData", () => {
-  it("Returns correct data for access measures", () => {
-    const entityData = getFormattedEntityData(
-      EntityType.ACCESS_MEASURES,
-      mockAccessMeasuresEntity
-    );
-    expect(entityData).toEqual(mockCompletedAccessMeasuresFormattedEntityData);
+describe("getFormattedEntityData()", () => {
+  describe("entity type: access measures", () => {
+    test("Returns correct data for access measures", () => {
+      const entityData = getFormattedEntityData(
+        EntityType.ACCESS_MEASURES,
+        mockAccessMeasuresEntity
+      );
+      expect(entityData).toEqual(
+        mockCompletedAccessMeasuresFormattedEntityData
+      );
+    });
+
+    test("returns 'Add' when no conditions are met", () => {
+      const result = getAddEditDrawerText(
+        EntityType.ACCESS_MEASURES,
+        { provider: false },
+        mockModalDrawerReportPageVerbiage
+      );
+      expect(result).toBe("Add Mock drawer title");
+    });
+
+    test("returns 'Edit' when provider exists for ACCESS_MEASURES", () => {
+      const result = getAddEditDrawerText(
+        EntityType.ACCESS_MEASURES,
+        { provider: true },
+        mockModalDrawerReportPageVerbiage
+      );
+      expect(result).toBe("Edit Mock drawer title");
+    });
   });
 
-  it("Returns correct data for quality measures with no completed measures", () => {
-    const entityData = getFormattedEntityData(
-      EntityType.QUALITY_MEASURES,
-      mockQualityMeasuresEntity,
-      mockReportFieldData
-    );
-    expect(entityData).toEqual(
-      mockUnfinishedQualityMeasuresFormattedEntityData
-    );
+  describe("entity type: quality measures", () => {
+    test("Returns correct data for quality measures with no completed measures", () => {
+      const entityData = getFormattedEntityData(
+        EntityType.QUALITY_MEASURES,
+        mockQualityMeasuresEntity,
+        mockReportFieldData
+      );
+      expect(entityData).toEqual(
+        mockUnfinishedQualityMeasuresFormattedEntityData
+      );
+    });
+
+    test("Returns correct data for quality measures with some completed measures", () => {
+      const entityData = getFormattedEntityData(
+        EntityType.QUALITY_MEASURES,
+        mockQualityMeasuresEntityMissingDetails,
+        mockReportFieldData
+      );
+      expect(entityData).toEqual(
+        mockQualityMeasuresFormattedEntityDataMissingDetails
+      );
+    });
+
+    test("Returns correct data for quality measures with fully completed measures", () => {
+      const entityData = getFormattedEntityData(
+        EntityType.QUALITY_MEASURES,
+        mockCompletedQualityMeasuresEntity,
+        mockReportFieldData
+      );
+      expect(entityData).toEqual(
+        mockCompletedQualityMeasuresFormattedEntityData
+      );
+    });
+
+    test("returns 'Edit' when perPlanResponses exists for QUALITY_MEASURES", () => {
+      const result = getAddEditDrawerText(
+        EntityType.QUALITY_MEASURES,
+        { perPlanResponses: [{ name: "plan 1", response: "n/a" }] },
+        mockModalDrawerReportPageVerbiage
+      );
+      expect(result).toBe("Edit Mock drawer title");
+    });
   });
 
-  it("Returns correct data for quality measures with some completed measures", () => {
-    const entityData = getFormattedEntityData(
-      EntityType.QUALITY_MEASURES,
-      mockQualityMeasuresEntityMissingDetails,
-      mockReportFieldData
-    );
-    expect(entityData).toEqual(
-      mockQualityMeasuresFormattedEntityDataMissingDetails
-    );
+  describe("entity type: sanctions", () => {
+    test("Returns correct data for sanctions", () => {
+      const entityData = getFormattedEntityData(
+        EntityType.SANCTIONS,
+        mockSanctionsEntity,
+        mockReportFieldData
+      );
+      expect(entityData).toEqual(mockCompletedSanctionsFormattedEntityData);
+    });
+
+    test("returns 'Edit' when assessmentDate exists for SANCTIONS", () => {
+      const result = getAddEditDrawerText(
+        EntityType.SANCTIONS,
+        { assessmentDate: true },
+        mockModalDrawerReportPageVerbiage
+      );
+      expect(result).toBe("Edit Mock drawer title");
+    });
   });
 
-  it("Returns correct data for quality measures with fully completed measures", () => {
-    const entityData = getFormattedEntityData(
-      EntityType.QUALITY_MEASURES,
-      mockCompletedQualityMeasuresEntity,
-      mockReportFieldData
-    );
-    expect(entityData).toEqual(mockCompletedQualityMeasuresFormattedEntityData);
+  describe("entity type: plans", () => {
+    const mockPlanData = {
+      id: "mock id",
+      name: "mock plan name",
+    };
+
+    test("Returns correct data for non-compliant plans", () => {
+      const mockNonCompliantPlan = {
+        ...mockPlanData,
+        exceptionsNonCompliance: nonComplianceStatus,
+        "mock-nonComplianceDescription": "mock description",
+        "mock-nonComplianceAnalyses": [
+          {
+            id: "id-1",
+            value: "mock analysis method 1",
+          },
+          {
+            id: "id-2",
+            value: "mock analysis method 2",
+          },
+        ],
+        "mock-nonCompliancePlanToAchieveCompliance":
+          "mock plan to achieve compliance",
+        "mock-nonComplianceMonitoringProgress": "mock monitoring progress",
+        "mock-nonComplianceReassessmentDate": "mock reassessment date",
+      };
+
+      const entityData = getFormattedEntityData(
+        EntityType.PLANS,
+        mockNonCompliantPlan
+      );
+
+      const expectedData = {
+        heading: `Plan deficiencies for ${mockNonCompliantPlan.name}: 42 C.F.R. § 438.68`,
+        questions: [
+          {
+            question: "Description",
+            answer: "mock description",
+          },
+          {
+            question: "Analyses used to identify deficiencies",
+            answer: "mock analysis method 1, mock analysis method 2",
+          },
+          {
+            question: "What the plan will do to achieve compliance",
+            answer: "mock plan to achieve compliance",
+          },
+          {
+            question: "Monitoring progress",
+            answer: "mock monitoring progress",
+          },
+          {
+            question: "Reassessment date",
+            answer: "mock reassessment date",
+          },
+        ],
+      };
+
+      expect(entityData).toEqual(expectedData);
+    });
+
+    test("Returns correct data for exception plans", () => {
+      const mockExceptionPlan = {
+        ...mockPlanData,
+        exceptionsNonCompliance: exceptionsStatus,
+        "mock-exceptionsDescription": "mock description",
+        "mock-exceptionsJustification": "mock justification",
+      };
+
+      const entityData = getFormattedEntityData(
+        EntityType.PLANS,
+        mockExceptionPlan
+      );
+
+      const expectedData = {
+        heading: `Exceptions granted for ${mockExceptionPlan.name} under 42 C.F.R. § 438.68(d)`,
+        questions: [
+          {
+            question:
+              "Describe any network adequacy standard exceptions that the state has granted to the plan under 42 C.F.R. § 438.68(d).",
+            answer: "mock description",
+          },
+          {
+            question:
+              "Justification for exceptions granted under 42 C.F.R. § 438.68(d)",
+            answer: "mock justification",
+          },
+        ],
+      };
+
+      expect(entityData).toEqual(expectedData);
+    });
+
+    test("Returns just a heading when no exception or non-compliance status given", () => {
+      const entityData = getFormattedEntityData(EntityType.PLANS, mockPlanData);
+
+      const expectedData = {
+        heading: `Problem displaying data for ${mockPlanData.name}`,
+      };
+
+      expect(entityData).toEqual(expectedData);
+    });
   });
 
-  it("Returns correct data for sanctions", () => {
+  test("Returns empty array when no entity provided", () => {
     const entityData = getFormattedEntityData(
-      EntityType.SANCTIONS,
-      mockSanctionsEntity,
-      mockReportFieldData
+      EntityType.PLANS, // could be any type
+      undefined
     );
-    expect(entityData).toEqual(mockCompletedSanctionsFormattedEntityData);
+    expect(entityData).toEqual({});
   });
 
-  it("Returns empty object if invalid entity type is passed", () => {
+  test("Returns empty object if invalid entity type is passed", () => {
     const entityData = getFormattedEntityData(
       "invalid entity type" as EntityType,
       mockSanctionsEntity,
       mockReportFieldData
     );
     expect(entityData).toEqual({});
-  });
-});
-
-describe("Test getFormattedEntityData", () => {
-  test("returns 'Add' when no conditions are met", () => {
-    const result = getAddEditDrawerText(
-      EntityType.ACCESS_MEASURES,
-      { provider: false },
-      mockModalDrawerReportPageVerbiage
-    );
-    expect(result).toBe("Add Mock drawer title");
-  });
-
-  test("returns 'Edit' when provider exists for ACCESS_MEASURES", () => {
-    const result = getAddEditDrawerText(
-      EntityType.ACCESS_MEASURES,
-      { provider: true },
-      mockModalDrawerReportPageVerbiage
-    );
-    expect(result).toBe("Edit Mock drawer title");
-  });
-
-  test("returns 'Edit' when perPlanResponses exists for QUALITY_MEASURES", () => {
-    const result = getAddEditDrawerText(
-      EntityType.QUALITY_MEASURES,
-      { perPlanResponses: [{ name: "plan 1", response: "n/a" }] },
-      mockModalDrawerReportPageVerbiage
-    );
-    expect(result).toBe("Edit Mock drawer title");
-  });
-
-  test("returns 'Edit' when assessmentDate exists for SANCTIONS", () => {
-    const result = getAddEditDrawerText(
-      EntityType.SANCTIONS,
-      { assessmentDate: true },
-      mockModalDrawerReportPageVerbiage
-    );
-    expect(result).toBe("Edit Mock drawer title");
   });
 });

--- a/services/ui-src/src/utils/reports/entities.test.ts
+++ b/services/ui-src/src/utils/reports/entities.test.ts
@@ -216,14 +216,11 @@ describe("getFormattedEntityData()", () => {
 
       expect(entityData).toEqual(expectedData);
     });
-  });
 
-  test("Returns empty array when no entity provided", () => {
-    const entityData = getFormattedEntityData(
-      EntityType.PLANS, // could be any type
-      undefined
-    );
-    expect(entityData).toEqual({});
+    test("Returns empty array when no entity provided", () => {
+      const entityData = getFormattedEntityData(EntityType.PLANS, undefined);
+      expect(entityData).toEqual({});
+    });
   });
 
   test("Returns empty object if invalid entity type is passed", () => {

--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -57,6 +57,9 @@ export const getFormattedEntityData = (
   entity?: EntityShape,
   reportFieldData?: AnyObject
 ) => {
+  if (!entity) {
+    return {};
+  }
   switch (entityType) {
     case EntityType.ACCESS_MEASURES:
       return {
@@ -113,9 +116,6 @@ export const getFormattedEntityData = (
         perPlanResponses: getPlanValues(entity, reportFieldData?.plans),
       };
     case EntityType.PLANS:
-      if (!entity) {
-        return {};
-      }
       const plan = entity; // eslint-disable-line no-case-declarations
 
       // display information for non-compliant standards

--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -57,9 +57,6 @@ export const getFormattedEntityData = (
   entity?: EntityShape,
   reportFieldData?: AnyObject
 ) => {
-  if (!entity) {
-    return {};
-  }
   switch (entityType) {
     case EntityType.ACCESS_MEASURES:
       return {
@@ -116,6 +113,9 @@ export const getFormattedEntityData = (
         perPlanResponses: getPlanValues(entity, reportFieldData?.plans),
       };
     case EntityType.PLANS:
+      if (!entity) {
+        return {};
+      }
       const plan = entity; // eslint-disable-line no-case-declarations
 
       // display information for non-compliant standards


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
#### TESTS
`ExportedPlanComplianceCard.test.tsx`
  - add coverage for export plan card display
`ExportedPlanOverlayReportSection.test.tsx`
  - add coverage for non-compliant and exceptions logic
`entities.test.ts`
  - add coverage for PLAN type


#### CLEANUP
`ExportedEntityDetailsTable.tsx`
  - Declare `entityType` and `entityIndex` parameters to eliminate console error about DOM props
`ExportedPlanComplianceCard.tsx`
  - remove unused testid
`ExportedPlanOverlayReportSection.tsx`
  - merge fixup: remove unused verbiage prop
`entities.test.ts`
  - reorganize file per current standard

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4468

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- unit tests pass
- when merged to feature branch, coverage passes codeclimate checks
  - if not, will create another branch for more tests


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment