### PR TITLE
CMDCT-4631 - buckets must block non-ssl connections

### DIFF
--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -95,6 +95,22 @@ resources:
         LoggingConfiguration:
           DestinationBucketName: ${env:LOGGING_BUCKET, ssm:/configuration/${self:custom.stage}/s3/accessLogsBucket, ssm:/configuration/default/s3/accessLogsBucket}
           LogFilePrefix: ${env:LOGGING_BUCKET, ssm:/configuration/${self:custom.stage}/s3/accessLogsPrefix, ssm:/configuration/default/s3/accessLogsPrefix}
+    McparFormPolicy:
+      Type: AWS::S3::BucketPolicy
+      Properties:
+        Bucket: !Ref McparFormBucket
+        PolicyDocument:
+          Statement:
+            - Sid: "AllowSSLRequestsOnly"
+              Effect: Deny
+              Action: "s3:*"
+              Principal: "*"
+              Resource:
+                - !Sub arn:aws:s3:::${McparFormBucket}/*
+                - !Sub arn:aws:s3:::${McparFormBucket}
+              Condition:
+                Bool:
+                  aws:SecureTransport: false
     MlrReportTable:
       Type: AWS::DynamoDB::Table
       Properties:
@@ -132,6 +148,22 @@ resources:
         LoggingConfiguration:
           DestinationBucketName: ${env:LOGGING_BUCKET, ssm:/configuration/${self:custom.stage}/s3/accessLogsBucket, ssm:/configuration/default/s3/accessLogsBucket}
           LogFilePrefix: ${env:LOGGING_BUCKET, ssm:/configuration/${self:custom.stage}/s3/accessLogsPrefix, ssm:/configuration/default/s3/accessLogsPrefix}
+    MlrFormPolicy:
+      Type: AWS::S3::BucketPolicy
+      Properties:
+        Bucket: !Ref MlrFormBucket
+        PolicyDocument:
+          Statement:
+            - Sid: "AllowSSLRequestsOnly"
+              Effect: Deny
+              Action: "s3:*"
+              Principal: "*"
+              Resource:
+                - !Sub arn:aws:s3:::${MlrFormBucket}/*
+                - !Sub arn:aws:s3:::${MlrFormBucket}
+              Condition:
+                Bool:
+                  aws:SecureTransport: false
     NaaarReportTable:
       Type: AWS::DynamoDB::Table
       Properties:
@@ -169,6 +201,22 @@ resources:
         LoggingConfiguration:
           DestinationBucketName: ${env:LOGGING_BUCKET, ssm:/configuration/${self:custom.stage}/s3/accessLogsBucket, ssm:/configuration/default/s3/accessLogsBucket}
           LogFilePrefix: ${env:LOGGING_BUCKET, ssm:/configuration/${self:custom.stage}/s3/accessLogsPrefix, ssm:/configuration/default/s3/accessLogsPrefix}
+    NaaarFormPolicy:
+      Type: AWS::S3::BucketPolicy
+      Properties:
+        Bucket: !Ref NaaarFormBucket
+        PolicyDocument:
+          Statement:
+            - Sid: "AllowSSLRequestsOnly"
+              Effect: Deny
+              Action: "s3:*"
+              Principal: "*"
+              Resource:
+                - !Sub arn:aws:s3:::${NaaarFormBucket}/*
+                - !Sub arn:aws:s3:::${NaaarFormBucket}
+              Condition:
+                Bool:
+                  aws:SecureTransport: false
     FormTemplateVersionsTable:
       Type: AWS::DynamoDB::Table
       Properties:


### PR DESCRIPTION
### Description
There are 3 buckets in database serverless config that lack required ssl only policy.

### Related ticket(s)
CMDCT-4631

---
### How to test
Check that policy is now on buckets named:
```
database-cmdct-4631-mcpar
database-cmdct-4631-mlr
database-cmdct-4631-naaar
```


### Notes
NA

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
