### PR TITLE
Cmdct 4589 - fix analysis methods logic when plans are deleted

### DIFF
--- a/services/ui-src/src/components/fields/DynamicField.tsx
+++ b/services/ui-src/src/components/fields/DynamicField.tsx
@@ -180,6 +180,11 @@ export const DynamicField = ({ name, label, isRequired, ...props }: Props) => {
             delete method.analysis_method_frequency;
           }
 
+          if ("custom_analysis_method_name" in method) {
+            delete method.analysis_method_applicable_plans;
+            delete method.analysis_method_frequency;
+          }
+
           return method;
         }
       );

--- a/services/ui-src/src/components/fields/DynamicField.tsx
+++ b/services/ui-src/src/components/fields/DynamicField.tsx
@@ -145,8 +145,6 @@ export const DynamicField = ({ name, label, isRequired, ...props }: Props) => {
       // filter analysis methods to remove deleted plans
       const filteredAnalysisMethods = report?.fieldData?.analysisMethods?.map(
         (method: EntityShape) => {
-          const analysisApplicable = method.analysis_applicable?.[0]?.value;
-
           if (method.analysis_method_applicable_plans?.length) {
             method.analysis_method_applicable_plans =
               method.analysis_method_applicable_plans.filter(
@@ -158,12 +156,25 @@ export const DynamicField = ({ name, label, isRequired, ...props }: Props) => {
                 }
               );
           }
+          const analysisMethodNotUtilized =
+            method.analysis_applicable?.[0]?.value === "No";
 
-          if (
-            method.analysis_method_applicable_plans?.length === 0 ||
-            analysisApplicable === "No"
-          ) {
+          const analysisMethodUtilizedWithoutPlans =
+            method.analysis_applicable?.[0]?.value === "Yes" &&
+            method.analysis_method_applicable_plans?.length === 0;
+
+          const reportPlans = report.fieldData?.plans.filter(
+            (plan: AnyObject) => {
+              return plan.id !== selectedRecord.id;
+            }
+          );
+
+          if (analysisMethodUtilizedWithoutPlans) {
             delete method.analysis_applicable;
+            delete method.analysis_method_applicable_plans;
+            delete method.analysis_method_frequency;
+          } else if (analysisMethodNotUtilized) {
+            if (reportPlans.length === 0) delete method.analysis_applicable;
             delete method.analysis_method_applicable_plans;
             delete method.analysis_method_frequency;
           }

--- a/services/ui-src/src/components/fields/DynamicField.tsx
+++ b/services/ui-src/src/components/fields/DynamicField.tsx
@@ -174,6 +174,7 @@ export const DynamicField = ({ name, label, isRequired, ...props }: Props) => {
             delete method.analysis_method_applicable_plans;
             delete method.analysis_method_frequency;
           } else if (analysisMethodNotUtilized) {
+            // revert not utilized analysis methods to unanswered state if there are no plans
             if (reportPlans.length === 0) delete method.analysis_applicable;
             delete method.analysis_method_applicable_plans;
             delete method.analysis_method_frequency;

--- a/services/ui-src/src/components/fields/DynamicField.tsx
+++ b/services/ui-src/src/components/fields/DynamicField.tsx
@@ -145,12 +145,29 @@ export const DynamicField = ({ name, label, isRequired, ...props }: Props) => {
       // filter analysis methods to remove deleted plans
       const filteredAnalysisMethods = report?.fieldData?.analysisMethods?.map(
         (method: EntityShape) => {
+          const analysisApplicable = method.analysis_applicable?.[0]?.value;
+
           if (method.analysis_method_applicable_plans?.length) {
             method.analysis_method_applicable_plans =
               method.analysis_method_applicable_plans.filter(
-                (plan: AnyObject) => plan.key !== selectedRecord.id
+                (plan: AnyObject) => {
+                  const planKey: string = plan.key
+                    .split("analysis_method_applicable_plans-")
+                    .pop();
+                  return planKey !== selectedRecord.id;
+                }
               );
           }
+
+          if (
+            method.analysis_method_applicable_plans?.length === 0 ||
+            analysisApplicable === "No"
+          ) {
+            delete method.analysis_applicable;
+            delete method.analysis_method_applicable_plans;
+            delete method.analysis_method_frequency;
+          }
+
           return method;
         }
       );

--- a/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
@@ -103,11 +103,11 @@ export const DrawerReportPageEntityRows = ({
           const incompleteText = "Select “Enter” to complete response.";
           return <Text sx={sx.incompleteText}>{incompleteText}</Text>;
         }
-        const plans = entity?.analysis_method_applicable_plans;
         const isUtilized =
           entity?.analysis_applicable?.[0]?.value === "Yes" || isCustomEntity;
         let completeText = "Not utilized";
 
+        const plans = entity?.analysis_method_applicable_plans;
         if (plans && isUtilized) {
           const frequencyVal = entity.analysis_method_frequency[0].value;
           const frequency = otherSpecify(


### PR DESCRIPTION
### Description
As a state user, when I delete a plan, in the plan section, that has previously been selected within the Analysis Methods AND there is no other plan selected for that Analysis method then the analysis method should revert to its unanswered default state 
As a state user, when I delete ALL my plans, then the analysis methods page should revert to its default state



### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4589

---
### How to test

https://d3rfe4bkvdu570.cloudfront.net/

Create at least two plans and then create the following analysis methods:

1. one that is not utilized
2. one that is utilized by the first plan only
3. one that is utilized by the second plan only
4. one that is utilized by both plans
5. a custom analysis method utilized by one plan


Verify that:
 when there are multiple plans and only plan 1 is deleted: 
     analysis method #1 is unchanged
     analysis method #2 reverts to unanswered state
     analysis method #3 is unchanged
     analysis method #4 only shows plan 1 being utilized
     the custom method should behave the same way as the required methods

 when there is 1 plan and that plan is deleted: 
     all analysis methods revert to unanswered state



### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
