### PR TITLE
CMDCT-4445 Improve labeling of dashboard table buttons

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
@@ -231,9 +231,7 @@ describe("<DashboardTable />", () => {
     test("Clicking 'Edit' button on a report row fetches the field data, then navigates to report", async () => {
       render(dashboardViewWithReports);
       mockMcparReportContext.fetchReport.mockReturnValueOnce(mockMcparReport);
-      const enterReportButton = screen.getAllByRole("button", {
-        name: "Edit",
-      })[0];
+      const enterReportButton = screen.getAllByTestId("enter-report")[0];
       expect(enterReportButton).toBeVisible();
       await userEvent.click(enterReportButton);
       await waitFor(async () => {
@@ -255,9 +253,9 @@ describe("<DashboardTable />", () => {
       });
     });
 
-    test("Clicking 'Edit Report' icon opens the AddEditProgramModal", async () => {
+    test("Clicking the edit icon opens the AddEditProgramModal", async () => {
       render(dashboardViewWithReports);
-      const addReportButton = screen.getAllByAltText("Edit Report")[0];
+      const addReportButton = screen.getAllByAltText(/^Edit/)[0];
       expect(addReportButton).toBeVisible();
       await userEvent.click(addReportButton);
       await waitFor(async () => {
@@ -272,7 +270,7 @@ describe("<DashboardTable />", () => {
       });
       render(dashboardViewWithLockedReport);
       await waitFor(() => {
-        const addReportButtons = screen.queryAllByAltText("Edit Report");
+        const addReportButtons = screen.queryAllByAltText(/^Edit/);
         expect(addReportButtons).toHaveLength(0);
       });
     });

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -1,5 +1,5 @@
 // components
-import { Button, Td, Tr, Spinner } from "@chakra-ui/react";
+import { Td, Tr } from "@chakra-ui/react";
 import { Table } from "components";
 // types
 import { ReportMetadataShape, ReportType } from "types";
@@ -11,6 +11,7 @@ import {
   DashboardTableProps,
   DateFields,
   EditReportButton,
+  ActionButton,
   getStatus,
   tableBody,
 } from "./DashboardTableUtils";
@@ -39,6 +40,7 @@ export const DashboardTable = ({
           {isStateLevelUser && !report?.locked && (
             <EditReportButton
               report={report}
+              reportType={report.reportType}
               openAddEditReportModal={openAddEditReportModal}
               sxOverride={sxOverride}
             />
@@ -71,20 +73,14 @@ export const DashboardTable = ({
         )}
         {/* Action Buttons */}
         <Td sx={sxOverride.editReportButtonCell}>
-          <Button
-            variant="outline"
-            data-testid="enter-report"
-            onClick={() => enterSelectedReport(report)}
-            isDisabled={report?.archived}
-          >
-            {entering && reportId == report.id ? (
-              <Spinner size="md" />
-            ) : isStateLevelUser && !report?.locked ? (
-              "Edit"
-            ) : (
-              "View"
-            )}
-          </Button>
+          <ActionButton
+            report={report}
+            reportType={reportType}
+            reportId={reportId}
+            isStateLevelUser={isStateLevelUser}
+            entering={entering}
+            enterSelectedReport={enterSelectedReport}
+          />
         </Td>
         {isAdmin && (
           <Td>

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTableUtils.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTableUtils.tsx
@@ -31,8 +31,18 @@ export interface DashboardTableProps {
 
 export interface EditReportProps {
   report: ReportMetadataShape;
+  reportType: string;
   openAddEditReportModal: Function;
   sxOverride: AnyObject;
+}
+
+export interface ActionButtonProps {
+  report: ReportMetadataShape;
+  reportType: string;
+  reportId: string | undefined;
+  isStateLevelUser: boolean;
+  entering: boolean;
+  enterSelectedReport: Function;
 }
 
 export interface DateFieldProps {
@@ -88,15 +98,54 @@ export const tableBody = (body: TableContentShape, isAdmin: boolean) => {
 
 export const EditReportButton = ({
   report,
+  reportType,
   openAddEditReportModal,
   sxOverride,
 }: EditReportProps) => {
   return (
     <Box display="inline" sx={sxOverride.editReport}>
       <button onClick={() => openAddEditReportModal(report)}>
-        <Image src={editIcon} alt="Edit Report" />
+        <Image
+          src={editIcon}
+          alt={
+            reportType !== ReportType.MLR
+              ? `Edit ${report.programName} due ${convertDateUtcToEt(
+                  report.dueDate
+                )} report submission set-up information`
+              : `Edit ${report.programName} report submission set-up information`
+          }
+        />
       </button>
     </Box>
+  );
+};
+
+export const ActionButton = ({
+  report,
+  reportType,
+  reportId,
+  isStateLevelUser,
+  entering,
+  enterSelectedReport,
+}: ActionButtonProps) => {
+  const editOrView = isStateLevelUser && !report?.locked ? "Edit" : "View";
+
+  return (
+    <Button
+      variant="outline"
+      aria-label={
+        reportType !== ReportType.MLR
+          ? `${editOrView} ${report.programName} due ${convertDateUtcToEt(
+              report.dueDate
+            )} report`
+          : `${editOrView} ${report.programName} report`
+      }
+      data-testid="enter-report"
+      onClick={() => enterSelectedReport(report)}
+      isDisabled={report?.archived}
+    >
+      {entering && reportId == report.id ? <Spinner size="md" /> : editOrView}
+    </Button>
   );
 };
 

--- a/services/ui-src/src/components/pages/Dashboard/SortableDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/SortableDashboardTable.tsx
@@ -75,6 +75,7 @@ export const SortableDashboardTable = ({
         return isStateLevelUser && !report.locked ? (
           <EditReportButton
             report={report}
+            reportType={reportType}
             openAddEditReportModal={openAddEditReportModal}
             sxOverride={sxOverride}
           />

--- a/tests/cypress/e2e/mcpar/dashboard.cy.js
+++ b/tests/cypress/e2e/mcpar/dashboard.cy.js
@@ -39,7 +39,7 @@ describe("MCPAR Dashboard Page - Program Creation/Editing/Archiving", () => {
     }).should("be.visible");
 
     // edit the report
-    cy.get('[alt="Edit Report"]').last().click();
+    cy.get('[alt^="Edit"]').last().click();
 
     cy.contains(`automated test - ${currentDate}`, {
       matchCase: true,


### PR DESCRIPTION
### Description
Add labels for dashboard actions that give more details to assistive tech.

![Managed Care Reporting 2025-05-15 at 16 43 46@2x](https://github.com/user-attachments/assets/b798ae88-79e6-4694-908b-ee7cbabc93ce)


### Related ticket(s)
CMDCT-4445

---
### How to test
* Run the application locally (or via [deploy env](https://du56q745f6pm7.cloudfront.net))
* Navigate to any dashboard (`/mcpar`, `/mlr`, or `/naaar`)
* Create forms (can even use the new `yarn db:seed`)
* Check the accessible names of the buttons inside of the dashboard table to ensure that they are:
  1. unique
  2. better describe what the button does


### Notes
Because all reports share the same dashboard table, they all get the improvement

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---


