### PR TITLE
CMDCT-4665 Add await to accessibility playwright tests

### DIFF
--- a/tests/playwright/pages/home.spec.ts
+++ b/tests/playwright/pages/home.spec.ts
@@ -2,11 +2,14 @@ import { expect, test } from "../utils/fixtures/base";
 import { BasePage } from "../utils";
 
 test.describe("state user home page", () => {
+  test.beforeEach(async ({ stateHomePage }) => {
+    await stateHomePage.goto();
+    await stateHomePage.isReady();
+  });
+
   test("Should see the correct home page as a state user", async ({
     stateHomePage,
   }) => {
-    await stateHomePage.goto();
-    await stateHomePage.isReady();
     await expect(stateHomePage.mcparButton).toBeVisible();
     await expect(stateHomePage.mlrButton).toBeVisible();
     await expect(stateHomePage.naaarButton).toBeVisible();
@@ -15,24 +18,25 @@ test.describe("state user home page", () => {
   test("Is accessible on all device types for state user", async ({
     stateHomePage,
   }) => {
-    await stateHomePage.goto();
     await stateHomePage.e2eA11y();
   });
 });
 
 test.describe("admin user home page", () => {
+  test.beforeEach(async ({ adminHomePage }) => {
+    await adminHomePage.goto();
+    await adminHomePage.isReady();
+  });
+
   test("Should see the correct home page as an admin user", async ({
     adminHomePage,
   }) => {
-    await adminHomePage.goto();
-    await adminHomePage.isReady();
     await expect(adminHomePage.dropdown).toBeVisible();
   });
 
   test("Is accessible on all device types for admin user", async ({
     adminHomePage,
   }) => {
-    await adminHomePage.goto();
     await adminHomePage.e2eA11y();
   });
 });

--- a/tests/playwright/pages/profile.spec.ts
+++ b/tests/playwright/pages/profile.spec.ts
@@ -6,6 +6,7 @@ let adminPage: Page;
 let userPage: Page;
 let adminContext: BrowserContext;
 let userContext: BrowserContext;
+let profilePage: ProfilePage;
 
 test.beforeAll(async ({ browser }) => {
   adminContext = await browser.newContext({
@@ -25,36 +26,40 @@ test.afterAll(async () => {
 });
 
 test.describe("Admin profile", () => {
-  test("admin profile should have banner edit button", async () => {
-    const profilePage = new ProfilePage(adminPage);
+  test.beforeEach(async () => {
+    profilePage = new ProfilePage(adminPage);
     await profilePage.goto();
     await profilePage.isReady();
+  });
+
+  test("admin profile should have banner edit button", async () => {
     await expect(profilePage.bannerEditorButton).toBeVisible();
   });
+
   test(
     "Is accessible on all device types for admin user",
     { tag: "@admin" },
     async () => {
-      const profilePage = new ProfilePage(adminPage);
-      await profilePage.goto();
       await profilePage.e2eA11y();
     }
   );
 });
 
 test.describe("State user profile", async () => {
-  test("state user profile should not have banner edit button", async () => {
-    const profilePage = new ProfilePage(userPage);
+  test.beforeEach(async () => {
+    profilePage = new ProfilePage(userPage);
     await profilePage.goto();
     await profilePage.isReady();
+  });
+
+  test("state user profile should not have banner edit button", async () => {
     await expect(profilePage.bannerEditorButton).not.toBeVisible();
   });
+
   test(
     "Is accessible on all device types for state user",
     { tag: "@user" },
     async () => {
-      const profilePage = new ProfilePage(userPage);
-      await profilePage.goto();
       await profilePage.e2eA11y();
     }
   );

--- a/tests/playwright/utils/pageObjects/base.page.ts
+++ b/tests/playwright/utils/pageObjects/base.page.ts
@@ -86,7 +86,8 @@ export default class BasePage {
     };
 
     for (const size of Object.values(breakpoints)) {
-      this.page.setViewportSize({ width: size[0], height: size[1] });
+      await this.page.setViewportSize({ width: size[0], height: size[1] });
+      await this.title.waitFor({ state: "visible" });
       const results = await new AxeBuilder({ page: this.page })
         .withTags([
           "wcag2a",


### PR DESCRIPTION
### Description
Playwright accessibility tests were not waiting long enough to actually test the page contents.

- Slight cleanup of a few specs


### Related ticket(s)
CMDCT-4665

---
### How to test
- Pull down branch
- Navigate to `/tests`
- Run `yarn test:e2e-ui`
- In the Playwright UI, run all tests, they should pass

Also, if you look at the [playwright action for this PR](https://github.com/Enterprise-CMCS/macpro-mdct-mcr/actions/runs/15116057326?pr=12194), they have all passed.
