### PR TITLE
CMDCT-4577: Add numberSuppressible to schema and suppressionText to constants

### DIFF
--- a/services/app-api/utils/constants/constants.ts
+++ b/services/app-api/utils/constants/constants.ts
@@ -172,3 +172,5 @@ export const DEFAULT_ANALYSIS_METHODS = [
   "Review of Grievances Related to Access",
   "Encounter Data Analysis",
 ];
+
+export const suppressionText = "Suppressed for data privacy purposes";

--- a/services/app-api/utils/testing/mocks/mockSchemaValidation.ts
+++ b/services/app-api/utils/testing/mocks/mockSchemaValidation.ts
@@ -1,0 +1,91 @@
+import { validNAValues as validNACompletionValues } from "../../validation/completionSchemas";
+import { validNAValues } from "../../validation/schemaMap";
+
+export const goodNumberTestCases = [
+  "",
+  "123",
+  "123.00",
+  "123..00",
+  "1,230",
+  "1,2,30",
+  "1230",
+  "123450123..,,,.123123123123",
+  ...validNAValues,
+];
+export const badNumberTestCases = ["abc", "N", "!@#!@%"];
+
+export const goodNumberCompletionTestCases = [
+  "123",
+  "123.00",
+  "123..00",
+  "1,230",
+  "1,2,30",
+  "1230",
+  "123450123..,,,.123123123123",
+  ...validNACompletionValues,
+];
+export const badNumberCompletionTestCases = ["abc", "N", "", "!@#!@%"];
+
+export const zeroTest = ["0", "0.0"];
+
+export const goodPositiveNumberTestCases = [
+  "123",
+  "123.00",
+  "123..00",
+  "1,230",
+  "1,2,30",
+  "1230",
+  "123450123..,,,.123123123123",
+];
+
+export const negativeNumberTestCases = [
+  "-123",
+  "-123.00",
+  "-123..00",
+  "-1,230",
+  "-1,2,30",
+  "-1230",
+  "-123450123..,,,.123123123123",
+];
+
+export const goodRatioTestCases = [
+  "1:1",
+  "123:123",
+  "1,234:1.12",
+  "0:1",
+  "1:10,000",
+];
+
+export const badRatioTestCases = [
+  ":",
+  ":1",
+  "1:",
+  "1",
+  "1234",
+  "abc",
+  "N/A",
+  "abc:abc",
+  ":abc",
+  "abc:",
+  "%@#$!ASDF",
+];
+
+export const goodDateTestCases = ["01/01/1990", "12/31/2020", "01012000"];
+export const badDateTestCases = ["01-01-1990", "13/13/1990", "12/32/1990"];
+
+export const goodValidNumberTestCases = [1, "1", "100000", "1,000,000"];
+export const badValidNumberTestCases = ["N/A", "number", "foo"];
+
+export const goodDropdownTestCases = [
+  undefined,
+  { label: "Select", value: "" },
+  { label: "Select", value: "Actual value" },
+];
+
+export const badDropdownTestCases = [
+  "",
+  { label: "", value: "" },
+  { label: "", value: "Actual value" },
+  1,
+  null,
+];

--- a/services/app-api/utils/validation/completionSchemaMap.ts
+++ b/services/app-api/utils/validation/completionSchemaMap.ts
@@ -7,6 +7,7 @@ export const completionSchemaMap: any = {
   numberOptional: schema.numberOptional(),
   numberNotLessThanOne: schema.numberNotLessThanOne(),
   numberNotLessThanZero: schema.numberNotLessThanZero(),
+  numberSuppressible: schema.numberSuppressible(),
   ratio: schema.ratio(),
   email: schema.email(),
   emailOptional: schema.emailOptional(),

--- a/services/app-api/utils/validation/completionSchemas.test.ts
+++ b/services/app-api/utils/validation/completionSchemas.test.ts
@@ -5,139 +5,134 @@ import {
   validNumber,
   numberNotLessThanOne,
   numberNotLessThanZero,
-  validNAValues,
   dropdownOptional,
+  numberSuppressible,
 } from "./completionSchemas";
+// constants
+import { suppressionText } from "../constants/constants";
+// utils
+import {
+  badDropdownTestCases,
+  badNumberCompletionTestCases,
+  badRatioTestCases,
+  badValidNumberTestCases,
+  goodDropdownTestCases,
+  goodNumberCompletionTestCases,
+  goodPositiveNumberTestCases,
+  goodRatioTestCases,
+  goodValidNumberTestCases,
+  negativeNumberTestCases,
+  zeroTest,
+} from "../testing/mocks/mockSchemaValidation";
 
 describe("Schemas", () => {
-  const goodNumberTestCases = [
-    "123",
-    "123.00",
-    "123..00",
-    "1,230",
-    "1,2,30",
-    "1230",
-    "123450123..,,,.123123123123",
-    ...validNAValues,
-  ];
-  const badNumberTestCases = ["abc", "N", "", "!@#!@%"];
-
-  const zeroTest = ["0", "0.0"];
-
-  const goodPositiveNumberTestCases = [
-    "123",
-    "123.00",
-    "123..00",
-    "1,230",
-    "1,2,30",
-    "1230",
-    "123450123..,,,.123123123123",
-  ];
-
-  const negativeNumberTestCases = [
-    "-123",
-    "-123.00",
-    "-123..00",
-    "-1,230",
-    "-1,2,30",
-    "-1230",
-    "-123450123..,,,.123123123123",
-  ];
-
-  const goodRatioTestCases = [
-    "1:1",
-    "123:123",
-    "1,234:1.12",
-    "0:1",
-    "1:10,000",
-  ];
-
-  const badRatioTestCases = [
-    ":",
-    ":1",
-    "1:",
-    "1",
-    "1234",
-    "abc",
-    "N/A",
-    "abc:abc",
-    ":abc",
-    "abc:",
-    "%@#$!ASDF",
-  ];
-
-  const goodValidNumberTestCases = [1, "1", "100000", "1,000,000"];
-
-  const badValidNumberTestCases = ["N/A", "number", "foo"];
-
-  const testSchema = async (
+  const testSchema = async <T>(
     schemaToUse: MixedSchema,
-    testCases: Array<any>,
+    testCases: T[],
     expectedReturn: boolean
   ) => {
-    for (let testCase of testCases) {
-      let test = await schemaToUse.isValid(testCase);
+    for (const testCase of testCases) {
+      const test = await schemaToUse.isValid(testCase);
       expect(test).toEqual(expectedReturn);
     }
   };
 
+  const testAnySchema = (
+    schemaToUse: MixedSchema,
+    testCases: Array<any>,
+    expectedReturn: boolean
+  ) => {
+    testSchema<any>(schemaToUse, testCases, expectedReturn);
+  };
+
+  const testNumberSchema = (
+    schemaToUse: MixedSchema,
+    testCases: string[],
+    expectedReturn: boolean
+  ) => {
+    testSchema<string>(schemaToUse, testCases, expectedReturn);
+  };
+
+  const testTextSchema = (
+    schemaToUse: MixedSchema,
+    testCases: Array<string | undefined>,
+    expectedReturn: boolean
+  ) => {
+    testSchema<string | undefined>(schemaToUse, testCases, expectedReturn);
+  };
+
+  const testValidNumber = (
+    schemaToUse: MixedSchema,
+    testCases: Array<string | number>,
+    expectedReturn: boolean
+  ) => {
+    testSchema<string | number>(schemaToUse, testCases, expectedReturn);
+  };
+
   test("Evaluate Number Schema using number scheme", () => {
-    testSchema(number(), goodNumberTestCases, true);
-    testSchema(number(), badNumberTestCases, false);
+    testNumberSchema(number(), goodNumberCompletionTestCases, true);
+    testNumberSchema(number(), badNumberCompletionTestCases, false);
   });
 
   // testing numberNotLessThanOne scheme
   test("Evaluate Number Schema using numberNotLessThanOne scheme", () => {
-    testSchema(numberNotLessThanOne(), goodPositiveNumberTestCases, true);
-    testSchema(numberNotLessThanOne(), badNumberTestCases, false);
+    testNumberSchema(numberNotLessThanOne(), goodPositiveNumberTestCases, true);
+    testNumberSchema(
+      numberNotLessThanOne(),
+      badNumberCompletionTestCases,
+      false
+    );
   });
 
   test("Test zero values using numberNotLessThanOne scheme", () => {
-    testSchema(numberNotLessThanOne(), zeroTest, false);
+    testNumberSchema(numberNotLessThanOne(), zeroTest, false);
   });
 
   test("Test negative values using numberNotLessThanOne scheme", () => {
-    testSchema(numberNotLessThanOne(), negativeNumberTestCases, false);
+    testNumberSchema(numberNotLessThanOne(), negativeNumberTestCases, false);
   });
 
   // testing numberNotLessThanZero scheme
   test("Evaluate Number Schema using numberNotLessThanZero scheme", () => {
-    testSchema(numberNotLessThanZero(), goodPositiveNumberTestCases, true);
-    testSchema(numberNotLessThanZero(), badNumberTestCases, false);
+    testNumberSchema(
+      numberNotLessThanZero(),
+      goodPositiveNumberTestCases,
+      true
+    );
+    testNumberSchema(
+      numberNotLessThanZero(),
+      badNumberCompletionTestCases,
+      false
+    );
   });
 
   test("Test zero values using numberNotLessThanZero scheme", () => {
-    testSchema(numberNotLessThanZero(), zeroTest, true);
+    testNumberSchema(numberNotLessThanZero(), zeroTest, true);
   });
 
   test("Test negative values using numberNotLessThanZero scheme", () => {
-    testSchema(numberNotLessThanZero(), negativeNumberTestCases, false);
+    testNumberSchema(numberNotLessThanZero(), negativeNumberTestCases, false);
   });
 
   test("Evaluate Number Schema using ratio scheme", () => {
-    testSchema(ratio(), goodRatioTestCases, true);
-    testSchema(ratio(), badRatioTestCases, false);
+    testNumberSchema(ratio(), goodRatioTestCases, true);
+    testNumberSchema(ratio(), badRatioTestCases, false);
   });
 
   test("Test validNumber schema", () => {
-    testSchema(validNumber(), goodValidNumberTestCases, true);
-    testSchema(validNumber(), badValidNumberTestCases, false);
+    testValidNumber(validNumber(), goodValidNumberTestCases, true);
+    testValidNumber(validNumber(), badValidNumberTestCases, false);
   });
 
   test("Test DropdownOptional schema", () => {
-    const goodDropdownTestCases = [
-      undefined,
-      { label: "Select", value: "" },
-      { label: "Select", value: "Actual value" },
-    ];
-    const badDropdownTestCases = [
-      "",
-      { label: "", value: "" },
-      { label: "", value: "Actual value" },
-      1,
-      null,
-    ];
-    testSchema(dropdownOptional(), goodDropdownTestCases, true);
-    testSchema(dropdownOptional(), badDropdownTestCases, false);
+    testAnySchema(dropdownOptional(), goodDropdownTestCases, true);
+    testAnySchema(dropdownOptional(), badDropdownTestCases, false);
+  });
+
+  test("Test numberSuppressible schema", () => {
+    testValidNumber(numberSuppressible(), goodValidNumberTestCases, true);
+    testValidNumber(numberSuppressible(), badValidNumberTestCases, false);
+    testTextSchema(numberSuppressible(), [suppressionText], true);
+    testTextSchema(numberSuppressible(), ["badText", undefined], false);
   });
 });

--- a/services/app-api/utils/validation/completionSchemas.ts
+++ b/services/app-api/utils/validation/completionSchemas.ts
@@ -6,6 +6,9 @@ import {
   string,
   number as yupNumber,
 } from "yup";
+// constants
+import { suppressionText } from "../constants/constants";
+// types
 import { Choice } from "../types";
 
 export const error = {
@@ -114,6 +117,19 @@ const valueCleaningNumberSchema = (value: string, charsToReplace: RegExp) => {
 
 export const number = () => numberSchema().required();
 export const numberOptional = () => numberSchema().notRequired().nullable();
+
+export const numberSuppressible = () =>
+  string()
+    .required(error.REQUIRED_GENERIC)
+    .test({
+      test: (value) => {
+        if (value === suppressionText) {
+          return true;
+        }
+        return value ? validNumberRegex.test(value) : false;
+      },
+      message: error.INVALID_NUMBER,
+    });
 
 const validNumberSchema = () =>
   string().test({

--- a/services/app-api/utils/validation/schemaMap.test.ts
+++ b/services/app-api/utils/validation/schemaMap.test.ts
@@ -1,5 +1,4 @@
 import { MixedSchema } from "yup/lib/mixed";
-import { AnyObject } from "yup/lib/types";
 import {
   number,
   ratio,
@@ -9,74 +8,27 @@ import {
   validNumber,
   numberNotLessThanOne,
   numberNotLessThanZero,
-  validNAValues,
+  numberSuppressible,
 } from "./schemaMap";
 import {} from "./validation";
+// constants
+import { suppressionText } from "../constants/constants";
+// utils
+import {
+  badDateTestCases,
+  badNumberTestCases,
+  badRatioTestCases,
+  badValidNumberTestCases,
+  goodDateTestCases,
+  goodNumberTestCases,
+  goodPositiveNumberTestCases,
+  goodRatioTestCases,
+  goodValidNumberTestCases,
+  negativeNumberTestCases,
+  zeroTest,
+} from "../testing/mocks/mockSchemaValidation";
 
 describe("Schemas", () => {
-  const goodNumberTestCases = [
-    "",
-    "123",
-    "123.00",
-    "123..00",
-    "1,230",
-    "1,2,30",
-    "1230",
-    "123450123..,,,.123123123123",
-    ...validNAValues,
-  ];
-  const badNumberTestCases = ["abc", "N", "!@#!@%"];
-
-  const zeroTest = ["0", "0.0"];
-
-  const goodPositiveNumberTestCases = [
-    "123",
-    "123.00",
-    "123..00",
-    "1,230",
-    "1,2,30",
-    "1230",
-    "123450123..,,,.123123123123",
-  ];
-
-  const negativeNumberTestCases = [
-    "-123",
-    "-123.00",
-    "-123..00",
-    "-1,230",
-    "-1,2,30",
-    "-1230",
-    "-123450123..,,,.123123123123",
-  ];
-
-  const goodRatioTestCases = [
-    "1:1",
-    "123:123",
-    "1,234:1.12",
-    "0:1",
-    "1:10,000",
-  ];
-
-  const badRatioTestCases = [
-    ":",
-    ":1",
-    "1:",
-    "1",
-    "1234",
-    "abc",
-    "N/A",
-    "abc:abc",
-    ":abc",
-    "abc:",
-    "%@#$!ASDF",
-  ];
-
-  const goodDateTestCases = ["01/01/1990", "12/31/2020", "01012000"];
-  const badDateTestCases = ["01-01-1990", "13/13/1990", "12/32/1990"];
-
-  const goodValidNumberTestCases = [1, "1", "100000", "1,000,000"];
-  const badValidNumberTestCases = ["N/A", "number", "foo"];
-
   // nested
   const fieldValidationObject = {
     type: "text",
@@ -87,15 +39,31 @@ describe("Schemas", () => {
     type: "string",
   };
 
-  const testSchema = (
-    schemaToUse: MixedSchema<any, AnyObject, any>,
-    testCases: Array<string | AnyObject>,
+  const testSchema = <T>(
+    schemaToUse: MixedSchema,
+    testCases: T[],
     expectedReturn: boolean
   ) => {
-    for (let testCase of testCases) {
-      let test = schemaToUse.isValidSync(testCase);
+    for (const testCase of testCases) {
+      const test = schemaToUse.isValidSync(testCase);
       expect(test).toEqual(expectedReturn);
     }
+  };
+
+  const testNumberSchema = (
+    schemaToUse: MixedSchema,
+    testCases: string[],
+    expectedReturn: boolean
+  ) => {
+    testSchema<string>(schemaToUse, testCases, expectedReturn);
+  };
+
+  const testTextSchema = (
+    schemaToUse: MixedSchema,
+    testCases: Array<string | undefined>,
+    expectedReturn: boolean
+  ) => {
+    testSchema<string | undefined>(schemaToUse, testCases, expectedReturn);
   };
 
   const testValidNumber = (
@@ -103,53 +71,54 @@ describe("Schemas", () => {
     testCases: Array<string | number>,
     expectedReturn: boolean
   ) => {
-    for (let testCase of testCases) {
-      let test = schemaToUse.isValidSync(testCase);
-      expect(test).toEqual(expectedReturn);
-    }
+    testSchema<string | number>(schemaToUse, testCases, expectedReturn);
   };
 
   test("Evaluate Number Schema using number scheme", () => {
-    testSchema(number(), goodNumberTestCases, true);
-    testSchema(number(), badNumberTestCases, false);
+    testNumberSchema(number(), goodNumberTestCases, true);
+    testNumberSchema(number(), badNumberTestCases, false);
   });
 
   // testing numberNotLessThanOne scheme
   test("Evaluate Number Schema using numberNotLessThanOne scheme", () => {
-    testSchema(numberNotLessThanOne(), goodPositiveNumberTestCases, true);
-    testSchema(numberNotLessThanOne(), badNumberTestCases, false);
+    testNumberSchema(numberNotLessThanOne(), goodPositiveNumberTestCases, true);
+    testNumberSchema(numberNotLessThanOne(), badNumberTestCases, false);
   });
 
   test("Test zero values using numberNotLessThanOne scheme", () => {
-    testSchema(numberNotLessThanOne(), zeroTest, false);
+    testNumberSchema(numberNotLessThanOne(), zeroTest, false);
   });
 
   test("Test negative values using numberNotLessThanOne scheme", () => {
-    testSchema(numberNotLessThanOne(), negativeNumberTestCases, false);
+    testNumberSchema(numberNotLessThanOne(), negativeNumberTestCases, false);
   });
 
   // testing numberNotLessThanZero scheme
   test("Evaluate Number Schema using numberNotLessThanZero scheme", () => {
-    testSchema(numberNotLessThanZero(), goodPositiveNumberTestCases, true);
-    testSchema(numberNotLessThanZero(), badNumberTestCases, false);
+    testNumberSchema(
+      numberNotLessThanZero(),
+      goodPositiveNumberTestCases,
+      true
+    );
+    testNumberSchema(numberNotLessThanZero(), badNumberTestCases, false);
   });
 
   test("Test zero values using numberNotLessThanZero scheme", () => {
-    testSchema(numberNotLessThanZero(), zeroTest, true);
+    testNumberSchema(numberNotLessThanZero(), zeroTest, true);
   });
 
   test("Test negative values using numberNotLessThanZero scheme", () => {
-    testSchema(numberNotLessThanZero(), negativeNumberTestCases, false);
+    testNumberSchema(numberNotLessThanZero(), negativeNumberTestCases, false);
   });
 
   test("Evaluate Number Schema using ratio scheme", () => {
-    testSchema(ratio(), goodRatioTestCases, true);
-    testSchema(ratio(), badRatioTestCases, false);
+    testNumberSchema(ratio(), goodRatioTestCases, true);
+    testNumberSchema(ratio(), badRatioTestCases, false);
   });
 
   test("Evaluate Date Schema using date scheme", () => {
-    testSchema(date(), goodDateTestCases, true);
-    testSchema(date(), badDateTestCases, false);
+    testNumberSchema(date(), goodDateTestCases, true);
+    testNumberSchema(date(), badDateTestCases, false);
   });
 
   test("Evaluate End Date Schema using date scheme", () => {
@@ -158,7 +127,7 @@ describe("Schemas", () => {
   });
 
   test("Test Nested Schema using nested scheme", () => {
-    testSchema(
+    testTextSchema(
       nested(() => validationSchema, fieldValidationObject.parentFieldName, ""),
       ["string"],
       true
@@ -168,5 +137,12 @@ describe("Schemas", () => {
   test("Test validNumber schema", () => {
     testValidNumber(validNumber(), goodValidNumberTestCases, true);
     testValidNumber(validNumber(), badValidNumberTestCases, false);
+  });
+
+  test("Test numberSuppressible schema", () => {
+    testValidNumber(numberSuppressible(), goodValidNumberTestCases, true);
+    testValidNumber(numberSuppressible(), badValidNumberTestCases, false);
+    testTextSchema(numberSuppressible(), [suppressionText], true);
+    testTextSchema(numberSuppressible(), ["badText", undefined], false);
   });
 });

--- a/services/app-api/utils/validation/schemaMap.ts
+++ b/services/app-api/utils/validation/schemaMap.ts
@@ -7,6 +7,8 @@ import {
   string,
   StringSchema,
 } from "yup";
+// constants
+import { suppressionText } from "../constants/constants";
 
 const error = {
   REQUIRED_GENERIC: "A response is required",
@@ -88,6 +90,19 @@ export const numberNotLessThanZero = () =>
     });
 
 export const numberOptional = () => number();
+
+export const numberSuppressible = () =>
+  string()
+    .required(error.REQUIRED_GENERIC)
+    .test({
+      test: (value) => {
+        if (value === suppressionText) {
+          return true;
+        }
+        return value ? validNumberRegex.test(value) : false;
+      },
+      message: error.INVALID_NUMBER,
+    });
 
 const validNumberSchema = () =>
   string().test({
@@ -264,6 +279,7 @@ export const schemaMap: any = {
   number: number(),
   numberNotLessThanOne: numberNotLessThanOne(),
   numberOptional: numberOptional(),
+  numberSuppressible: numberSuppressible(),
   objectArray: objectArray(),
   radio: radio(),
   radioOptional: radioOptional(),

--- a/services/ui-src/src/constants.ts
+++ b/services/ui-src/src/constants.ts
@@ -674,3 +674,5 @@ export const SecretShopperAppointmentAvailabilityChildJson = [
     },
   },
 ];
+
+export const suppressionText = "Suppressed for data privacy purposes";

--- a/services/ui-src/src/utils/testing/mockSchemaValidation.tsx
+++ b/services/ui-src/src/utils/testing/mockSchemaValidation.tsx
@@ -1,0 +1,77 @@
+import { validNAValues } from "utils";
+
+export const goodNumberTestCases = [
+  "123",
+  "123.00",
+  "123.00",
+  "1,230",
+  "1,2,30",
+  "1230",
+  "123450123,,,.123123123123",
+  ...validNAValues,
+];
+
+export const goodPositiveNumberTestCases = [
+  "123",
+  "123.00",
+  "123.00",
+  "1,230",
+  "1,2,30",
+  "1230",
+  "123450123,,,.123123123123",
+  ...validNAValues,
+];
+
+export const negativeNumberTestCases = [
+  "-123",
+  "-123.00",
+  "-123.00",
+  "-1,230",
+  "-1,2,30",
+  "-1230",
+  "-123450123,,,.123123123123",
+];
+
+export const zeroTest = ["0", "0.0"];
+
+export const badNumberTestCases = ["abc", "N", "", "!@#!@%"];
+
+export const goodRatioTestCases = [
+  "1:1",
+  "123:123",
+  "1,234:1.12",
+  "0:1",
+  "1:10,000",
+];
+export const badRatioTestCases = [
+  ":",
+  ":1",
+  "1:",
+  "1",
+  "1234",
+  "abc",
+  "N/A",
+  "abc:abc",
+  ":abc",
+  "abc:",
+  "%@#$!ASDF",
+];
+
+export const goodDateOptionalTestCases = ["", "01/01/2023", "05/15/2023"];
+
+export const badDateOptionalTestCases = [
+  1,
+  "Hello!",
+  "1/1/2",
+  "0/0/99",
+  "0/01/2023",
+  "42/42/4242",
+];
+
+export const goodValidNumberTestCases = [1, "1", "100000", "1,000,000"];
+
+export const badValidNumberTestCases = ["N/A", "number", "foo"];
+
+export const goodRequiredTextTestCases = ["a", " a ", ".", "string"];
+export const goodOptionalTextTestCases = ["", ...goodRequiredTextTestCases];
+export const badRequiredTextTestCases = ["", "   ", undefined];

--- a/services/ui-src/src/utils/validation/schemaMap.ts
+++ b/services/ui-src/src/utils/validation/schemaMap.ts
@@ -7,6 +7,7 @@ export const schemaMap: any = {
   numberOptional: schema.numberOptional(),
   numberNotLessThanOne: schema.numberNotLessThanOne(),
   numberNotLessThanZero: schema.numberNotLessThanZero(),
+  numberSuppressible: schema.numberSuppressible(),
   ratio: schema.ratio(),
   email: schema.email(),
   emailOptional: schema.emailOptional(),

--- a/services/ui-src/src/utils/validation/schemas.test.ts
+++ b/services/ui-src/src/utils/validation/schemas.test.ts
@@ -8,95 +8,45 @@ import {
   numberNotLessThanZero,
   text,
   textOptional,
-  validNAValues,
+  numberSuppressible,
 } from "./schemas";
+// constants
+import { suppressionText } from "../../constants";
+import {
+  badDateOptionalTestCases,
+  badNumberTestCases,
+  badRatioTestCases,
+  badRequiredTextTestCases,
+  badValidNumberTestCases,
+  goodDateOptionalTestCases,
+  goodNumberTestCases,
+  goodOptionalTextTestCases,
+  goodPositiveNumberTestCases,
+  goodRatioTestCases,
+  goodRequiredTextTestCases,
+  goodValidNumberTestCases,
+  negativeNumberTestCases,
+  zeroTest,
+} from "utils/testing/mockSchemaValidation";
 
 describe("Schemas", () => {
-  const goodNumberTestCases = [
-    "123",
-    "123.00",
-    "123.00",
-    "1,230",
-    "1,2,30",
-    "1230",
-    "123450123,,,.123123123123",
-    ...validNAValues,
-  ];
-
-  const goodPositiveNumberTestCases = [
-    "123",
-    "123.00",
-    "123.00",
-    "1,230",
-    "1,2,30",
-    "1230",
-    "123450123,,,.123123123123",
-    ...validNAValues,
-  ];
-
-  const negativeNumberTestCases = [
-    "-123",
-    "-123.00",
-    "-123.00",
-    "-1,230",
-    "-1,2,30",
-    "-1230",
-    "-123450123,,,.123123123123",
-  ];
-
-  const zeroTest = ["0", "0.0"];
-
-  const badNumberTestCases = ["abc", "N", "", "!@#!@%"];
-
-  const goodRatioTestCases = [
-    "1:1",
-    "123:123",
-    "1,234:1.12",
-    "0:1",
-    "1:10,000",
-  ];
-  const badRatioTestCases = [
-    ":",
-    ":1",
-    "1:",
-    "1",
-    "1234",
-    "abc",
-    "N/A",
-    "abc:abc",
-    ":abc",
-    "abc:",
-    "%@#$!ASDF",
-  ];
-
-  const goodDateOptionalTestCases = ["", "01/01/2023", "05/15/2023"];
-
-  const badDateOptionalTestCases = [
-    1,
-    "Hello!",
-    "1/1/2",
-    "0/0/99",
-    "0/01/2023",
-    "42/42/4242",
-  ];
-
-  const goodValidNumberTestCases = [1, "1", "100000", "1,000,000"];
-
-  const badValidNumberTestCases = ["N/A", "number", "foo"];
-
-  const goodRequiredTextTestCases = ["a", " a ", ".", "string"];
-  const goodOptionalTextTestCases = ["", ...goodRequiredTextTestCases];
-  const badRequiredTextTestCases = ["", "   ", undefined];
+  const testSchema = <T>(
+    schemaToUse: MixedSchema,
+    testCases: T[],
+    expectedReturn: boolean
+  ) => {
+    for (const testCase of testCases) {
+      const test = schemaToUse.isValidSync(testCase);
+      expect(test).toEqual(expectedReturn);
+    }
+  };
 
   const testNumberSchema = (
     schemaToUse: MixedSchema,
-    testCases: Array<string>,
+    testCases: string[],
     expectedReturn: boolean
   ) => {
-    for (let testCase of testCases) {
-      let test = schemaToUse.isValidSync(testCase);
-      expect(test).toEqual(expectedReturn);
-    }
+    testSchema<string>(schemaToUse, testCases, expectedReturn);
   };
 
   const testDateOptional = (
@@ -104,10 +54,11 @@ describe("Schemas", () => {
     testCases: Array<string | null | undefined | number>,
     expectedReturn: boolean
   ) => {
-    for (let testCase of testCases) {
-      let test = schemaToUse.isValidSync(testCase);
-      expect(test).toEqual(expectedReturn);
-    }
+    testSchema<string | null | undefined | number>(
+      schemaToUse,
+      testCases,
+      expectedReturn
+    );
   };
 
   const testValidNumber = (
@@ -115,21 +66,15 @@ describe("Schemas", () => {
     testCases: Array<string | number>,
     expectedReturn: boolean
   ) => {
-    for (let testCase of testCases) {
-      let test = schemaToUse.isValidSync(testCase);
-      expect(test).toEqual(expectedReturn);
-    }
+    testSchema<string | number>(schemaToUse, testCases, expectedReturn);
   };
 
-  const testText = (
+  const testTextSchema = (
     schemaToUse: MixedSchema,
     testCases: Array<string | undefined>,
     expectedReturn: boolean
   ) => {
-    for (let testCase of testCases) {
-      let test = schemaToUse.isValidSync(testCase);
-      expect(test).toEqual(expectedReturn);
-    }
+    testSchema<string | undefined>(schemaToUse, testCases, expectedReturn);
   };
 
   test("Evaluate Number Schema using number scheme", () => {
@@ -185,12 +130,19 @@ describe("Schemas", () => {
   });
 
   test("Test text schema", () => {
-    testText(text(), goodRequiredTextTestCases, true);
-    testText(text(), badRequiredTextTestCases, false);
+    testTextSchema(text(), goodRequiredTextTestCases, true);
+    testTextSchema(text(), badRequiredTextTestCases, false);
   });
 
   test("Test textOptional schema", () => {
-    testText(textOptional(), goodOptionalTextTestCases, true);
-    testText(textOptional(), ["   "], false);
+    testTextSchema(textOptional(), goodOptionalTextTestCases, true);
+    testTextSchema(textOptional(), ["   "], false);
+  });
+
+  test("Test numberSuppressible schema", () => {
+    testValidNumber(numberSuppressible(), goodValidNumberTestCases, true);
+    testValidNumber(numberSuppressible(), badValidNumberTestCases, false);
+    testTextSchema(numberSuppressible(), [suppressionText], true);
+    testTextSchema(numberSuppressible(), ["badText", undefined], false);
   });
 });

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -1,10 +1,15 @@
 import { array, boolean, mixed, object, string } from "yup";
-import { validationErrors as error } from "verbiage/errors";
+// constants
+import { suppressionText } from "../../constants";
+// types
 import { Choice } from "types";
+// utils
 import {
   checkStandardNumberInputAgainstRegexes,
   checkRatioInputAgainstRegexes,
 } from "utils/other/checkInputValidity";
+// verbiage
+import { validationErrors as error } from "verbiage/errors";
 
 // TEXT - Helpers
 const stringHasLength = (value?: string) => value?.length != 0;
@@ -65,6 +70,19 @@ export const number = () =>
     });
 
 export const numberOptional = () => numberSchema().notRequired().nullable();
+
+export const numberSuppressible = () =>
+  string()
+    .required(error.REQUIRED_GENERIC)
+    .test({
+      test: (value) => {
+        if (value === suppressionText) {
+          return true;
+        }
+        return value ? checkStandardNumberInputAgainstRegexes(value) : false;
+      },
+      message: error.INVALID_NUMBER,
+    });
 
 const validNumberSchema = () =>
   string().test({


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This is part 1 to add a `NumberSuppressible` component that allows a number or "Suppressed for data privacy purposes" as valid input. This PR adds the schema validation needed in `app-api` and `ui-src`, plus:

- Adds "Suppressed for data privacy purposes" constant 
- Refactors `testSchema` to reduce repeated code
- Extracts test cases to separate file

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4577

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Unit tests pass in `app-api` and `ui-src`

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

Part 2: https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12196

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- ---

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
