### PR TITLE
CMDCT-4577: Add NumberSuppressible component

### DIFF
--- a/services/app-api/forms/mcpar.json
+++ b/services/app-api/forms/mcpar.json
@@ -2160,8 +2160,8 @@
             "fields": [
               {
                 "id": "plan_enrollment",
-                "type": "number",
-                "validation": "number",
+                "type": "numberSuppressible",
+                "validation": "numberSuppressible",
                 "props": {
                   "label": "D1.I.1 Plan enrollment",
                   "hint": "Enter the average number of individuals enrolled in the plan per month during the reporting year (i.e., average member months).",
@@ -2171,8 +2171,8 @@
               },
               {
                 "id": "plan_medicaidEnrollmentSharePercentage",
-                "type": "number",
-                "validation": "number",
+                "type": "numberSuppressible",
+                "validation": "numberSuppressible",
                 "props": {
                   "label": "D1.I.2 Plan share of Medicaid",
                   "hint": "<p>What is the plan enrollment (within the specific program) as a percentage of the state’s total Medicaid enrollment?</p><ul><li>Numerator: Plan enrollment (D1.I.1)</li><li>Denominator: Statewide Medicaid enrollment (B.I.1)</li></ul>",
@@ -2181,8 +2181,8 @@
               },
               {
                 "id": "plan_medicaidManagedCareEnrollmentSharePercentage",
-                "type": "number",
-                "validation": "number",
+                "type": "numberSuppressible",
+                "validation": "numberSuppressible",
                 "props": {
                   "label": "D1.I.3 Plan share of any Medicaid managed care",
                   "hint": "<p>What is the plan enrollment (regardless of program) as a percentage of total Medicaid enrollment in any type of managed care?</p><ul><li>Numerator: Plan enrollment (D1.I.1)</li><li>Denominator: Statewide Medicaid managed care enrollment (B.I.2)</li></ul>",

--- a/services/ui-src/src/components/fields/ChoiceField.test.tsx
+++ b/services/ui-src/src/components/fields/ChoiceField.test.tsx
@@ -22,24 +22,42 @@ const mockGetValues = (returnValue: any) =>
     ...mockRhfMethods,
     getValues: jest.fn().mockReturnValue(returnValue),
   }));
+const mockOnChange = jest.fn();
 
-const ChoiceFieldComponent = (
-  <ChoiceField name="checkbox_choice" label="Checkbox A" hint="checkbox a" />
+const ChoiceFieldComponent = (inline = false) => (
+  <ChoiceField
+    name="checkbox_choice"
+    label="Checkbox A"
+    hint="checkbox a"
+    inline={inline}
+    onChange={mockOnChange}
+  />
 );
 
 describe("<ChoiceField />", () => {
-  test("ChoiceField renders as Checkbox", () => {
-    render(ChoiceFieldComponent);
-    const choice = screen.getByLabelText("Checkbox A");
+  test("ChoiceField renders as Checkbox with p tag", () => {
+    render(ChoiceFieldComponent());
+    const label = screen.getByText("Checkbox A");
+    const choice = screen.getByRole("checkbox", { name: "Checkbox A" });
+    expect(label.tagName).toBe("P");
+    expect(choice).toHaveAttribute("aria-labelledby", "checkbox_choice");
+  });
+
+  test("ChoiceField renders as Checkbox with label tag", () => {
+    render(ChoiceFieldComponent(true));
+    const label = screen.getByText("Checkbox A");
+    const choice = screen.getByRole("checkbox", { name: "Checkbox A" });
+    expect(label.tagName).toBe("LABEL");
     expect(choice).toBeVisible();
   });
 
   test("ChoiceField calls onChange function successfully", async () => {
-    render(ChoiceFieldComponent);
+    render(ChoiceFieldComponent());
     const choice = screen.getByLabelText("Checkbox A") as HTMLInputElement;
     expect(choice.checked).toBe(false);
     await userEvent.click(choice);
     expect(choice.checked).toBe(true);
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
   });
 
   describe("Test ChoiceField hydration functionality", () => {
@@ -56,7 +74,7 @@ describe("<ChoiceField />", () => {
 
     test("If only formFieldValue exists, displayValue is set to it", () => {
       mockGetValues(mockFormFieldValue);
-      render(ChoiceFieldComponent);
+      render(ChoiceFieldComponent());
       const choiceField: HTMLInputElement = screen.getByLabelText("Checkbox A");
       const displayValue = choiceField.value;
       expect(displayValue).toBeTruthy();
@@ -70,5 +88,5 @@ describe("<ChoiceField />", () => {
       expect(displayValue).toBeTruthy();
     });
   });
-  testA11y(ChoiceFieldComponent);
+  testA11y(ChoiceFieldComponent());
 });

--- a/services/ui-src/src/components/fields/ChoiceField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceField.tsx
@@ -14,7 +14,9 @@ export const ChoiceField = ({
   hint,
   sxOverride,
   styleAsOptional,
-  ...props
+  hydrate,
+  inline,
+  onChange,
 }: Props) => {
   const [checkboxState, setCheckboxState] = useState<boolean>(false);
 
@@ -26,10 +28,10 @@ export const ChoiceField = ({
   const onChangeHandler = async () => {
     form.setValue(name, !checkboxState, { shouldValidate: true });
     setCheckboxState(!checkboxState);
+    if (onChange) onChange(!checkboxState);
   };
 
   // set initial checkbox value to form state field value or hydration value
-  const hydrationValue = props?.hydrate;
   useEffect(() => {
     // if form state has value for field, set as checkbox value
     const fieldValue = form.getValues(name);
@@ -37,30 +39,34 @@ export const ChoiceField = ({
       setCheckboxState(fieldValue);
     }
     // else if hydration value exists, set as checkbox value and form field value
-    else if (hydrationValue) {
-      setCheckboxState(hydrationValue);
-      form.setValue(name, hydrationValue, { shouldValidate: true });
+    else if (hydrate) {
+      setCheckboxState(hydrate);
+      form.setValue(name, hydrate, { shouldValidate: true });
     }
-  }, [hydrationValue]);
+  }, [hydrate]);
 
   const labelText =
     label && styleAsOptional ? labelTextWithOptional(label) : label;
+  const inputLabel = inline ? labelText : null;
+  const legendLabel = inline ? null : labelText;
+  const ariaLabel = inline ? {} : { "aria-labelledby": name };
 
   return (
     <Box sx={{ ...sx, ...sxOverride }}>
-      <Text sx={sx.label} id="label">
-        {labelText}
-      </Text>
+      {legendLabel && (
+        <Text sx={sx.label} id={name}>
+          {legendLabel}
+        </Text>
+      )}
       <CmsdsChoice
         type="checkbox"
         name={name}
         hint={hint}
         onChange={onChangeHandler}
         checked={checkboxState}
-        aria-labelledby="label"
-        // required by component library, but unused
-        label={<></>}
+        label={inputLabel}
         value={checkboxState.toString()}
+        {...ariaLabel}
       />
     </Box>
   );
@@ -72,7 +78,9 @@ interface Props {
   hint: string;
   sxOverride?: AnyObject;
   styleAsOptional?: boolean;
-  [key: string]: any;
+  hydrate?: boolean;
+  inline?: boolean;
+  onChange?: Function;
 }
 
 const sx = {

--- a/services/ui-src/src/components/fields/NumberSuppressibleField.test.tsx
+++ b/services/ui-src/src/components/fields/NumberSuppressibleField.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useFormContext } from "react-hook-form";
+// components
+import { NumberSuppressibleField, ReportContext } from "components";
+// constants
+import { suppressionText } from "../../constants";
+// utils
+import {
+  mockMcparReportContext,
+  mockMcparReportStore,
+  mockStateUserStore,
+} from "utils/testing/setupJest";
+import { useStore } from "utils";
+import { testA11y } from "utils/testing/commonTests";
+
+const mockTrigger = jest.fn();
+const mockRhfMethods = {
+  register: () => {},
+  setValue: () => {},
+  getValues: jest.fn(),
+  trigger: mockTrigger,
+};
+const mockUseFormContext = useFormContext as unknown as jest.Mock<
+  typeof useFormContext
+>;
+jest.mock("react-hook-form", () => ({
+  useFormContext: jest.fn(() => mockRhfMethods),
+}));
+const mockGetValues = (returnValue: any) =>
+  mockUseFormContext.mockImplementation((): any => ({
+    ...mockRhfMethods,
+    getValues: jest.fn((name?: string) => {
+      if (name) {
+        return returnValue;
+      }
+      return [];
+    }),
+  }));
+
+jest.mock("utils/state/useStore");
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+mockedUseStore.mockReturnValue({
+  ...mockStateUserStore,
+  ...mockMcparReportStore,
+});
+
+const numberSuppressibleFieldComponent = (hydrate: string) => (
+  <ReportContext.Provider value={mockMcparReportContext}>
+    <NumberSuppressibleField
+      name="testNumberField"
+      hydrate={hydrate}
+      label="test-label"
+    />
+  </ReportContext.Provider>
+);
+
+describe("<NumberSuppressibleField />", () => {
+  beforeEach(() => {
+    mockGetValues(undefined);
+  });
+
+  test("disables textbox if suppressed checkbox is checked", async () => {
+    render(numberSuppressibleFieldComponent(""));
+    const choiceField = screen.getByRole("checkbox", { name: suppressionText });
+    const numberField = screen.getByRole("textbox", { name: "test-label" });
+    expect(choiceField).not.toBeChecked();
+    expect(numberField).not.toBeDisabled();
+
+    await userEvent.click(choiceField);
+    expect(choiceField).toBeChecked();
+    expect(numberField).toBeDisabled();
+  });
+
+  test("disables textbox and checks suppressed checkbox with suppressionText input", async () => {
+    render(numberSuppressibleFieldComponent(""));
+    const choiceField = screen.getByRole("checkbox", { name: suppressionText });
+    const numberField = screen.getByRole("textbox", { name: "test-label" });
+    expect(choiceField).not.toBeChecked();
+
+    await userEvent.type(numberField, suppressionText);
+    expect(choiceField).toBeChecked();
+    expect(numberField).toBeDisabled();
+  });
+
+  test("disables textbox and checks suppressed checkbox with suppressionText hydration", () => {
+    render(numberSuppressibleFieldComponent(suppressionText));
+    const choiceField = screen.getByRole("checkbox", { name: suppressionText });
+    const numberField = screen.getByRole("textbox", { name: "test-label" });
+    expect(choiceField).toBeChecked();
+    expect(numberField).toBeDisabled();
+  });
+
+  testA11y(numberSuppressibleFieldComponent(""), () => {
+    mockGetValues(undefined);
+  });
+});

--- a/services/ui-src/src/components/fields/NumberSuppressibleField.tsx
+++ b/services/ui-src/src/components/fields/NumberSuppressibleField.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+// components
+import { ChoiceField, NumberField } from "components";
+// constants
+import { suppressionText } from "../../constants";
+// utils
+import { NumberFieldProps } from "./NumberField";
+
+export const NumberSuppressibleField = ({
+  hydrate,
+  name,
+  ...props
+}: NumberFieldProps) => {
+  const [isSuppressed, setIsSuppressed] = useState(false);
+  const [numberHydrate, setNumberHydrate] = useState("");
+
+  const choiceOnChange = (checked: boolean) => {
+    setIsSuppressed(checked);
+  };
+
+  const numberOnChange = (value: string) => {
+    setIsSuppressed(value === suppressionText);
+  };
+
+  useEffect(() => {
+    if (hydrate === suppressionText) {
+      setIsSuppressed(true);
+      setNumberHydrate(hydrate);
+    } else {
+      setIsSuppressed(false);
+      setNumberHydrate(hydrate);
+    }
+  }, [hydrate]);
+
+  return (
+    <>
+      <NumberField
+        hydrate={numberHydrate}
+        name={name}
+        onChange={numberOnChange}
+        suppressed={isSuppressed}
+        suppressible={true}
+        {...props}
+      />
+      <ChoiceField
+        hint={""}
+        hydrate={isSuppressed}
+        inline={true}
+        label={suppressionText}
+        name={`${name}-suppressed`}
+        onChange={choiceOnChange}
+      />
+    </>
+  );
+};

--- a/services/ui-src/src/components/fields/NumberSuppressibleField.tsx
+++ b/services/ui-src/src/components/fields/NumberSuppressibleField.tsx
@@ -23,13 +23,8 @@ export const NumberSuppressibleField = ({
   };
 
   useEffect(() => {
-    if (hydrate === suppressionText) {
-      setIsSuppressed(true);
-      setNumberHydrate(hydrate);
-    } else {
-      setIsSuppressed(false);
-      setNumberHydrate(hydrate);
-    }
+    setIsSuppressed(hydrate === suppressionText);
+    setNumberHydrate(hydrate);
   }, [hydrate]);
 
   return (

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -57,6 +57,7 @@ export { DateField } from "./fields/DateField";
 export { DropdownField } from "./fields/DropdownField";
 export { DynamicField } from "./fields/DynamicField";
 export { NumberField } from "./fields/NumberField";
+export { NumberSuppressibleField } from "./fields/NumberSuppressibleField";
 export { RadioField } from "./fields/RadioField";
 export { TextField } from "./fields/TextField";
 export { TextAreaField } from "./fields/TextAreaField";

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -28,6 +28,7 @@ import {
 } from "types";
 // utils
 import {
+  cleanSuppressed,
   entityWasUpdated,
   filterFormData,
   getEntriesToClear,
@@ -154,6 +155,9 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
         state,
         id: report?.id,
       };
+
+      // Check if form has suppressed fields
+      cleanSuppressed(enteredData);
 
       const currentEntities = [...(report?.fieldData[entityType] || [])];
       let selectedEntityIndex = currentEntities.findIndex(

--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -1,4 +1,5 @@
 import {
+  cleanSuppressed,
   createRepeatedFields,
   defineProgramName,
   filterFormData,
@@ -11,6 +12,8 @@ import {
   setClearedEntriesToDefaultValue,
   sortFormErrors,
 } from "./forms";
+// constants
+import { suppressionText } from "../../constants";
 // types
 import { Choice, FormField } from "types";
 // utils
@@ -412,6 +415,21 @@ describe("utils/forms", () => {
         mockNestedFormField,
       ]);
       expect(result).toEqual(["mock-nested-field", "mock-text-field"]);
+    });
+  });
+
+  describe("cleanSuppressed()", () => {
+    it("removes suppressed keys from submitted data", () => {
+      const enteredData = {
+        mockFieldToSuppress: "123",
+        "mockFieldToSuppress-suppressed": true,
+      };
+      const expectedResult = {
+        mockFieldToSuppress: suppressionText,
+      };
+
+      const result = cleanSuppressed(enteredData);
+      expect(result).toEqual(expectedResult);
     });
   });
 });

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -6,11 +6,14 @@ import {
   DropdownField,
   DynamicField,
   NumberField,
+  NumberSuppressibleField,
   RadioField,
   TextField,
   TextAreaField,
   ChoiceField,
 } from "components";
+// constants
+import { suppressionText } from "../../constants";
 // types
 import {
   AnyObject,
@@ -25,6 +28,7 @@ import {
   isFieldElement,
   ReportType,
 } from "types";
+// utils
 import {
   SectionContent,
   SectionHeader,
@@ -53,6 +57,7 @@ export const formFieldFactory = (
     dropdown: DropdownField,
     dynamic: DynamicField,
     number: NumberField,
+    numberSuppressible: NumberSuppressibleField,
     radio: RadioField,
     text: TextField,
     textarea: TextAreaField,
@@ -366,4 +371,20 @@ export const defineProgramName = (
         "A choice was made in the program name selection field that isn't supported. Please add your choice to this function (defineProgramName) or fix the typo in the addEditModalJson file."
       );
   }
+};
+
+export const cleanSuppressed = (enteredData: AnyObject) => {
+  for (const [key, value] of Object.entries(enteredData)) {
+    if (!key.endsWith("-suppressed")) continue;
+
+    const fieldToSuppress = key.split("-suppressed")[0];
+    // Suppressed checkbox was checked, set text value to suppressionText
+    if (value === true) {
+      enteredData[fieldToSuppress] = suppressionText;
+    }
+    // Suppressed key is not saved
+    delete enteredData[key];
+  }
+
+  return enteredData;
 };

--- a/services/ui-src/src/utils/other/mask.test.ts
+++ b/services/ui-src/src/utils/other/mask.test.ts
@@ -1,9 +1,12 @@
+import { maskMap, applyMask } from "./mask";
+// constants
+import { suppressionText } from "../../constants";
+// utils
 import {
   convertToThousandsSeparatedString,
   convertToThousandsSeparatedRatioString,
   maskResponseData,
 } from "utils";
-import { maskMap, applyMask } from "./mask";
 
 const thousandsSeparatedMaskAcceptableTestCases = [
   // valid input, masked
@@ -166,6 +169,11 @@ describe("Test convertToCommaSeparatedRatioString", () => {
 });
 
 describe("Test maskResponseData", () => {
+  test("Don't mask suppressionText", () => {
+    const result = maskResponseData(suppressionText, "percentage");
+    expect(result).toEqual(suppressionText);
+  });
+
   test("Percentage mask works correctly", () => {
     const result = maskResponseData("12", "percentage");
     expect(result).toEqual("12%");

--- a/services/ui-src/src/utils/other/mask.tsx
+++ b/services/ui-src/src/utils/other/mask.tsx
@@ -1,3 +1,6 @@
+// constants
+import { suppressionText } from "../../constants";
+// utils
 import { validNAValues } from "utils";
 import { cleanStandardNumericalInput, cleanRatioInput } from "./clean";
 
@@ -20,7 +23,8 @@ export function maskResponseData(
 ): string {
   if (
     fieldResponseData === undefined ||
-    validNAValues.includes(fieldResponseData)
+    validNAValues.includes(fieldResponseData) ||
+    fieldResponseData === suppressionText
   )
     return fieldResponseData;
 

--- a/tests/cypress/e2e/mcpar/form.cy.js
+++ b/tests/cypress/e2e/mcpar/form.cy.js
@@ -267,6 +267,9 @@ const processField = (field) => {
           processField(childField)
         );
         break;
+      case "numberSuppressible":
+        cy.get(`[name="${field.id}-suppressed"]`).check();
+        break;
     }
   }
 };

--- a/tests/seeds/fixtures/mcpar.ts
+++ b/tests/seeds/fixtures/mcpar.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { suppressionText } from "../../../services/app-api/utils/constants/constants";
 import {
   Choice,
   ReportStatus,
@@ -348,7 +349,7 @@ export const fillMcpar = (programIsPCCM?: Choice[]): SeedFillReportShape => {
           plan_encounterDataSubmissionHipaaCompliancePercentage: numberInt(),
           plan_encounterDataSubmissionTimelinessCompliancePercentage:
             numberInt(),
-          plan_enrollment: numberInt(),
+          plan_enrollment: suppressionText,
           plan_ilosOfferedByPlan: [
             {
               key: "plan_ilosOfferedByPlan-1qdYiWh0SaO7IQ41NeOt0uJU",
@@ -368,8 +369,8 @@ export const fillMcpar = (programIsPCCM?: Choice[]): SeedFillReportShape => {
           plan_medianTimeToDecisionOnExpeditedPriorAuthorizationRequests:
             numberFloat(),
           plan_medianTimeToDecisionOnStandardPriorAuthorizations: numberFloat(),
-          plan_medicaidEnrollmentSharePercentage: numberInt(),
-          plan_medicaidManagedCareEnrollmentSharePercentage: numberInt(),
+          plan_medicaidEnrollmentSharePercentage: suppressionText,
+          plan_medicaidManagedCareEnrollmentSharePercentage: suppressionText,
           plan_medicalLossRatioPercentage: numberFloat(),
           plan_medicalLossRatioPercentageAggregationLevel: [
             {
@@ -587,9 +588,9 @@ export const fillMcparPCCM = (planId: string): SeedFillReportShape => {
         {
           id: planId,
           name: faker.animal.cat(),
-          plan_enrollment: numberInt(),
-          plan_medicaidEnrollmentSharePercentage: numberInt(),
-          plan_medicaidManagedCareEnrollmentSharePercentage: numberInt(),
+          plan_enrollment: suppressionText,
+          plan_medicaidEnrollmentSharePercentage: suppressionText,
+          plan_medicaidManagedCareEnrollmentSharePercentage: suppressionText,
         },
       ],
       sanctions: [createSanction(planId)],


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This is part 2 to add a `NumberSuppressible` component that allows a number or "Suppressed for data privacy purposes" as valid input. This PR adds the component plus:

- Refactors `NumberField` to allow suppression
- Refactors `ChoiceField` to allow label next to checkbox
- Updates fields in `mcpar.json` to use `numberSuppressible` type and validation  
- Updates export mask to show "Suppressed for data privacy purposes" in export PDF
- Updates MCPAR fixture to use `suppressionText`

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4577

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Run MCR locally
2. Run `yarn db:seed` to create a filled MCPAR
3. Go to `Section D: Plan-Level Indicators` -> `I. Program Characteristics`
4. Select a plan
5. Test that fields accept numbers or are suppressible

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

Part 1: https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12195

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- ---

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
