### PR TITLE
Clean up console warnings

### DIFF
--- a/services/ui-src/src/components/modals/AddEditReportModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 // components
 import { AddEditReportModal, ReportContext } from "components";
@@ -279,9 +285,11 @@ describe("<AddEditProgramModal />", () => {
     test(
       "Edit modal hydrates with report info and disables fields",
       async () => {
-        const result = render(modalComponentWithSelectedReport);
-        await new Promise((resolve) => setTimeout(resolve, 500));
-        const form = result.getByTestId("add-edit-report-form");
+        await act(async () => {
+          await render(modalComponentWithSelectedReport);
+          await new Promise((resolve) => setTimeout(resolve, 500));
+        });
+        const form = screen.getByTestId("add-edit-report-form");
         const copyFieldDataSourceId = form.querySelector(
           "[name='copyFieldDataSourceId']"
         )!;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR cleans up the `Warning: An update to ForwardRef(Form) inside a test was not wrapped in act(...).` warnings that show when running Jest.

<!-- ### Related ticket(s) -->
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
<!-- CMDCT- -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. In `ui-src`, run `yarn test`
2. No `Warning: An update to ForwardRef(Form) inside a test was not wrapped in act(...).` warnings should be present
3. Other error/warnings are handled in https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12207

<!-- ### Notes -->
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
