### PR TITLE
CMDCT-4668: Handling "Custom Method" in EntityCard 

### DIFF
--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -22,14 +22,17 @@ const getCheckboxValues = (
   label: string,
   customLabel?: string
 ) => {
-  return entity?.[label]?.map((method: AnyObject) =>
-    otherSpecify(
+  return entity?.[label]?.map((method: AnyObject) => {
+    if (method.value === "Custom method") {
+      return `Custom method - ${entity?.[`${label}-otherText`]}`;
+    }
+    return otherSpecify(
       method.value,
       entity?.[`${label}-otherText`],
       undefined,
       customLabel
-    )
-  );
+    );
+  });
 };
 
 const getReportingRateType = (entity: EntityShape | undefined) => {

--- a/services/ui-src/src/utils/testing/mockEntities.tsx
+++ b/services/ui-src/src/utils/testing/mockEntities.tsx
@@ -6,6 +6,7 @@ export const mockAccessMeasuresEntity = {
   accessMeasure_standardDescription: "mock-description",
   accessMeasure_standardType: [{ value: "mock-standard-type" }],
   "accessMeasure_standardType-otherText": "",
+  "accessMeasure_monitoringMethods-otherText": "mock-other-text",
   accessMeasure_providerType: [{ value: "mock-provider-type" }],
   accessMeasure_applicableRegion: [{ value: "Other, specify" }],
   "accessMeasure_applicableRegion-otherText": "mock-region-other-text",
@@ -31,7 +32,11 @@ export const mockCompletedAccessMeasuresFormattedEntityData = {
   provider: "mock-provider-type",
   region: "mock-region-other-text",
   population: "mock-population",
-  monitoringMethods: ["mock-monitoring-method-1", "mock-monitoring-method-2"],
+  monitoringMethods: [
+    "mock-monitoring-method-1",
+    "mock-monitoring-method-2",
+    "Custom method - mock-other-text",
+  ],
   methodFrequency: "mock-oversight-method-frequency",
 };
 

--- a/services/ui-src/src/utils/testing/mockEntities.tsx
+++ b/services/ui-src/src/utils/testing/mockEntities.tsx
@@ -13,6 +13,7 @@ export const mockAccessMeasuresEntity = {
   accessMeasure_monitoringMethods: [
     { value: "mock-monitoring-method-1" },
     { value: "mock-monitoring-method-2" },
+    { value: "Custom method" },
   ],
   accessMeasure_oversightMethodFrequency: [
     { value: "mock-oversight-method-frequency" },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Recently, the Access Measures section has been updated to include a new option `Custom Method` (replacing `Other, specify`) causing a bug where the field was not displaying as expected in the EntityCard component.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4688

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a new MCPAR
- Navigate to `/mcpar/program-level-indicators/availability-and-accessibility/access-measures`
- Add an access measure
- Enter details
- For **C2.V.7 Monitoring methods** select "Custom method" and enter any text

You should see the text you've entered formatted like the screenshot, both in the EntityCard and the export page:

<img width="709" alt="Screenshot 2025-05-21 at 2 52 08 PM" src="https://github.com/user-attachments/assets/68186e27-9683-4d1d-bf62-f5804e442f6f" />

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
