### PR TITLE
Change seeded access measure values

### DIFF
--- a/tests/seeds/fixtures/mcpar.ts
+++ b/tests/seeds/fixtures/mcpar.ts
@@ -377,8 +377,8 @@ export const fillMcpar = (programIsPCCM?: Choice[]): SeedFillReportShape => {
           id: crypto.randomUUID(),
           accessMeasure_applicableRegion: [
             {
-              key: "accessMeasure_applicableRegion-X47v2Ee5kkaBERBjXFWGXw",
-              value: "Urban",
+              key: "accessMeasure_applicableRegion-aZ4JmR9kfLKZEqQje3N1R1",
+              value: "Statewide",
             },
           ],
           accessMeasure_generalCategory: [
@@ -396,8 +396,8 @@ export const fillMcpar = (programIsPCCM?: Choice[]): SeedFillReportShape => {
           ],
           accessMeasure_oversightMethodFrequency: [
             {
-              key: "accessMeasure_oversightMethodFrequency-tOF04LLPa026mJlHmk0RaA",
-              value: "At procurement",
+              key: "accessMeasure_oversightMethodFrequency-vtAjpZENepsmacGCddGdyt",
+              value: "Weekly",
             },
           ],
           accessMeasure_population: [


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Update MCPAR accessMeasure seed with valid `accessMeasure_applicableRegion` and `accessMeasure_oversightMethodFrequency` values.

<!-- ### Related ticket(s) -->
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
<!-- CMDCT- -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Run MCR locally
2. Run `yarn db:seed` and create a filled MCPAR
3. Go to section `C: Program-Level Indicators` > `Availability & Accessibility` -> `Access Measures`
4. The seeded access measure should have all fields filled correctly

<!-- ### Notes -->
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->
<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!--_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
