### PR TITLE
CMDCT-4690: Remove Percentage Mask from Geomapping Fields

### DIFF
--- a/services/ui-src/src/constants.ts
+++ b/services/ui-src/src/constants.ts
@@ -223,7 +223,6 @@ export const GeomappingChildJson = [
                         validation: "numberNotLessThanZeroOptional",
                         props: {
                           label: "Q1 (optional)",
-                          mask: "percentage",
                           decimalPlacesToRoundTo: 0,
                         },
                       },
@@ -233,7 +232,6 @@ export const GeomappingChildJson = [
                         validation: "numberNotLessThanZeroOptional",
                         props: {
                           label: "Q2 (optional)",
-                          mask: "percentage",
                           decimalPlacesToRoundTo: 0,
                         },
                       },
@@ -243,7 +241,6 @@ export const GeomappingChildJson = [
                         validation: "numberNotLessThanZeroOptional",
                         props: {
                           label: "Q3 (optional)",
-                          mask: "percentage",
                           decimalPlacesToRoundTo: 0,
                         },
                       },
@@ -253,7 +250,6 @@ export const GeomappingChildJson = [
                         validation: "numberNotLessThanZeroOptional",
                         props: {
                           label: "Q4 (optional)",
-                          mask: "percentage",
                           decimalPlacesToRoundTo: 0,
                         },
                       },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
BOs have requested we remove the percentage mask from the `Actual maximum time` fields under `Geomapping`

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4690

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
N/A

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
