### PR TITLE
CMDCT-4794: NAAAR content updates (Section 18)

### DIFF
--- a/services/ui-src/src/constants.ts
+++ b/services/ui-src/src/constants.ts
@@ -408,7 +408,7 @@ export const PlanProviderChildJson = [
     validation: "checkboxOneOptional",
     props: {
       label: "Frequency of compliance findings (optional)",
-      hint: "Instructions",
+      hint: "States may report additional details on the results produced from using geomapping, plan provider directory reviews, and secret shopper results. If the state uses one of these  methods to determine compliance, additional fields will be provided to report results by quarter or year. If the results fields provided are not applicable to the state’s compliance findings for this standard, or if the state uses different analyses methods for this standard, you can leave these fields and use the “Plan Deficiencies Description” free text box in the next question to describe the results of the analyses.",
       choices: [
         {
           id: "sxC5M4JJz9qNCdNxJgQmJV",
@@ -423,6 +423,7 @@ export const PlanProviderChildJson = [
                   {
                     id: "gRCpgad2dhXDrmucTw8cnu",
                     label: "Minimum number of network providers",
+                    hint: "Report the minimum number of plan network providers.",
                     children: [
                       {
                         id: "q1NumberOfNetworkProviders",
@@ -469,6 +470,7 @@ export const PlanProviderChildJson = [
                   {
                     id: "a8kZrrUYcfUrnTM8UuHNmi",
                     label: "Provider to enrollee ratio",
+                    hint: "Report the calculated plan provider to enrollee ratio.",
                     children: [
                       {
                         id: "q1ProviderToEnrolleeRatio",
@@ -530,6 +532,7 @@ export const PlanProviderChildJson = [
                   {
                     id: "j4ch2jWhesE7SHQZYQmvJV",
                     label: "Minimum number of network providers",
+                    hint: "Report the minimum number of plan network providers.",
                     children: [
                       {
                         id: "annualMinimumNumberOfNetworkProviders",
@@ -555,6 +558,7 @@ export const PlanProviderChildJson = [
                   {
                     id: "dSHQvqgfa7YYoRBvSKkahW",
                     label: "Provider to enrollee ratio",
+                    hint: "Report findings on the calculated plan provider to enrollee ratio.",
                     children: [
                       {
                         id: "annualProvidertoEnrolleeRatio",

--- a/services/ui-src/src/constants.ts
+++ b/services/ui-src/src/constants.ts
@@ -408,7 +408,7 @@ export const PlanProviderChildJson = [
     validation: "checkboxOneOptional",
     props: {
       label: "Frequency of compliance findings (optional)",
-      hint: "States may report additional details on the results produced from using geomapping, plan provider directory reviews, and secret shopper results. If the state uses one of these  methods to determine compliance, additional fields will be provided to report results by quarter or year. If the results fields provided are not applicable to the state’s compliance findings for this standard, or if the state uses different analyses methods for this standard, you can leave these fields and use the “Plan Deficiencies Description” free text box in the next question to describe the results of the analyses.",
+      hint: "States may report additional details on the results produced from using geomapping, plan provider directory reviews, and secret shopper results. If the state uses one of these methods to determine compliance, additional fields will be provided to report results by quarter or year. If the results fields provided are not applicable to the state’s compliance findings for this standard, or if the state uses different analyses methods for this standard, you can leave these fields and use the “Plan Deficiencies Description” free text box in the next question to describe the results of the analyses.",
       choices: [
         {
           id: "sxC5M4JJz9qNCdNxJgQmJV",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Update the `Plan provider directory review` content to match [Figma](https://www.figma.com/design/onF6Zqevqn6LcGNmxBEcw8/MCR-NAAAR-and-MCPAR?node-id=791-42202&t=fKvTcbYn6JxDj8Lk-4), for reference this is a screenshot of how it looks on the deployed environment / locally:

![Screenshot 2025-06-17 at 2 11 33 PM](https://github.com/user-attachments/assets/3543f922-21b1-483a-be34-23951271e04c)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4794

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [val release](?expand=1&template=val-deployment.md)_ | _[production release](?expand=1&template=production-deployment.md)_
