### PR TITLE
CMDCT-4853: fix add standards logic

### DIFF
--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -52,6 +52,7 @@ import addIconSVG from "assets/icons/icon_add_gray.svg";
 export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [pageError, setPageError] = useState<ErrorVerbiage>();
+  const [canAddStandards, setCanAddStandards] = useState<boolean>(false);
   const [selectedIsCustomEntity, setSelectedIsCustomEntity] =
     useState<boolean>(false);
   const { isOpen, onClose, onOpen } = useDisclosure();
@@ -69,6 +70,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
 
   const existingStandards =
     entityType === EntityType.STANDARDS && entities.length > 0;
+  const providerTypeSelected = report?.fieldData?.providerTypes?.length > 0;
 
   // check if there are ILOS and associated plans
   const isMcparReport = route.path.includes("mcpar");
@@ -98,7 +100,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
     return result?.length === DEFAULT_ANALYSIS_METHODS.length;
   };
 
-  // error alert appears if analysis methods are completed without any utilized
+  // analysis methods: error alert appears if analysis methods are completed without any utilized
   useEffect(() => {
     if (
       completedAnalysisMethods() &&
@@ -109,6 +111,20 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
       setPageError(undefined);
     }
   }, [completedAnalysisMethods, atLeastOneRequiredAnalysisMethodIsUtilized]);
+
+  // standards: add button disabled if analysis methods are incomplete, complete without any utilized, or no provider types are selected
+  useEffect(() => {
+    if (
+      !completedAnalysisMethods() ||
+      (completedAnalysisMethods() &&
+        !atLeastOneRequiredAnalysisMethodIsUtilized) ||
+      !providerTypeSelected
+    ) {
+      setCanAddStandards(false);
+    } else {
+      setCanAddStandards(true);
+    }
+  }, [atLeastOneRequiredAnalysisMethodIsUtilized, providerTypeSelected]);
 
   const formParams = {
     route,
@@ -287,7 +303,7 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
       );
     } else if (
       (isAnalysisMethodsPage && !hasPlans) ||
-      (isReportingOnStandards && !completedAnalysisMethods())
+      (isReportingOnStandards && !canAddStandards)
     ) {
       return (
         <Box sx={sx.missingEntity}>
@@ -309,16 +325,12 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
       leftIcon={
         <Image
           sx={sx.buttonIcons}
-          src={
-            atLeastOneRequiredAnalysisMethodIsUtilized
-              ? addIconWhite
-              : addIconSVG
-          }
+          src={canAddStandards ? addIconWhite : addIconSVG}
           alt="Add"
         />
       }
       onClick={() => openRowDrawer()}
-      disabled={!atLeastOneRequiredAnalysisMethodIsUtilized}
+      disabled={!canAddStandards}
     >
       {verbiage.addEntityButtonText}
     </Button>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
We had a bug where you could add standards even with only one default analysis method filled out. This fixes that bug.

Compare with separating some logic out of `DrawerReportPage` https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12286


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4853

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[deployed env](https://d1293nmy1ufsxd.cloudfront.net/)
- Log in as a state user
- Create a NAAAR
- Go to the standards page and ensure the missing data text shows and the add button is disabled
- Play around with adding/unadding provider types and analysis methods
- Ensure you can only add a standard once you have at least one provider type and at least one applicable analysis method with all of them filled out

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

- [x] Product: This work has been reviewed and approved by product owner, if necessary

---