### PR TITLE
Fix colors (mdct prefix)

### DIFF
--- a/services/ui-src/src/components/drawers/ReportDrawer.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawer.tsx
@@ -103,7 +103,7 @@ const sx = {
   },
   footerBox: {
     marginTop: "2rem",
-    borderTop: "1.5px solid var(--chakra-colors-palette-gray_light)",
+    borderTop: "1.5px solid var(--mdct-colors-palette-gray_light)",
   },
   buttonFlex: {
     justifyContent: "space-between",

--- a/services/ui-src/src/components/menus/Sidebar.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.tsx
@@ -196,7 +196,7 @@ const sx = {
     position: "fixed",
   },
   topBox: {
-    borderBottom: "1px solid var(--chakra-colors-palette-gray_lighter)",
+    borderBottom: "1px solid var(--mdct-colors-palette-gray_lighter)",
   },
   title: {
     fontSize: "xl",
@@ -240,7 +240,7 @@ const sx = {
     position: "relative",
     align: "center",
     role: "group",
-    borderBottom: "1px solid var(--chakra-colors-palette-gray_lighter)",
+    borderBottom: "1px solid var(--mdct-colors-palette-gray_lighter)",
     fontSize: "0.875rem",
     ".ds-c-icon--arrow": {
       position: "absolute",

--- a/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
@@ -204,7 +204,7 @@ function entityRowStyling(canAddEntities: boolean) {
     minHeight: "3.25rem",
     padding: "0.5rem",
     paddingLeft: "1rem",
-    borderBottom: "1.5px solid var(--chakra-colors-palette-gray_lighter)",
+    borderBottom: "1.5px solid var(--mdct-colors-palette-gray_lighter)",
     "&:last-of-type": {
       borderBottom: canAddEntities ?? "none",
     },

--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -452,7 +452,7 @@ function dashboardTitleStyling(canAddEntities: boolean) {
   return {
     paddingLeft: canAddEntities && "3.5rem",
     paddingBottom: "0.75rem",
-    borderBottom: "1.5px solid var(--chakra-colors-palette-gray_lighter)",
+    borderBottom: "1.5px solid var(--mdct-colors-palette-gray_lighter)",
     color: "palette.gray_medium",
     fontSize: "lg",
     fontWeight: "bold",

--- a/services/ui-src/src/styles/index.scss
+++ b/services/ui-src/src/styles/index.scss
@@ -36,10 +36,10 @@ li::marker {
 }
 
 a {
-  color: var(--chakra-colors-palette-white);
+  color: var(--mdct-colors-palette-white);
   transition: all 0.3s ease !important;
   &:hover {
-    color: var(--chakra-colors-palette-gray_light);
+    color: var(--mdct-colors-palette-gray_light);
   }
   &:visited {
     color: inherit;
@@ -50,7 +50,7 @@ a {
 
 .ds-c-usa-banner__header {
   width: 100%;
-  max-width: var(--chakra-sizes-appMax);
+  max-width: var(--mdct-sizes-appMax);
 
   @media (min-width: 544px) {
     padding-inline: 1rem;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
When we switched our theme prefix to `mdct` the chakra colors stopped working. Switching them over to `mdct` fixes that!

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Compare Analysis methods table in this branch to main (borders do not show on main)