### PR TITLE
CMDCT-4935 - getting run local working

### DIFF
--- a/services/app-api/utils/dynamo/dynamodb-lib.test.ts
+++ b/services/app-api/utils/dynamo/dynamodb-lib.test.ts
@@ -11,13 +11,6 @@ import { mockClient } from "aws-sdk-client-mock";
 const dynamoClientMock = mockClient(DynamoDBDocumentClient);
 
 describe("Test DynamoDB Interaction API Build Structure", () => {
-  let originalUrl: string | undefined;
-  beforeAll(() => {
-    originalUrl = process.env.DYNAMODB_URL;
-  });
-  afterAll(() => {
-    process.env.DYNAMODB_URL = originalUrl;
-  });
   beforeEach(() => {
     dynamoClientMock.reset();
   });
@@ -70,14 +63,7 @@ describe("Test DynamoDB Interaction API Build Structure", () => {
 });
 
 describe("Checking Environment Variable Changes", () => {
-  test("Check if statement with DYNAMODB_URL set", () => {
-    process.env.DYNAMODB_URL = "mock url";
-    const config = getConfig();
-    expect(config).toHaveProperty("region", "localhost");
-  });
-
-  test("Check if statement with DYNAMODB_URL undefined", () => {
-    delete process.env.DYNAMODB_URL;
+  test("that config has region set", () => {
     const config = getConfig();
     expect(config).toHaveProperty("region", "us-east-1");
   });

--- a/services/app-api/utils/dynamo/dynamodb-lib.ts
+++ b/services/app-api/utils/dynamo/dynamodb-lib.ts
@@ -17,23 +17,12 @@ import { logger } from "../debugging/debug-lib";
 // types
 import { AnyObject } from "../types";
 
-const localConfig = {
-  endpoint: process.env.DYNAMODB_URL,
-  region: "localhost",
-  credentials: {
-    accessKeyId: "LOCALFAKEKEY", // pragma: allowlist secret
-    secretAccessKey: "LOCALFAKESECRET", // pragma: allowlist secret
-  },
-  logger,
-};
-
-const awsConfig = {
-  region: "us-east-1",
-  logger,
-};
-
 export const getConfig = () => {
-  return process.env.DYNAMODB_URL ? localConfig : awsConfig;
+  return {
+    region: "us-east-1",
+    logger,
+    endpoint: process.env.AWS_ENDPOINT_URL,
+  };
 };
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient(getConfig()));

--- a/services/app-api/utils/s3/s3-lib.test.ts
+++ b/services/app-api/utils/s3/s3-lib.test.ts
@@ -10,14 +10,6 @@ import { mockClient } from "aws-sdk-client-mock";
 const s3ClientMock = mockClient(S3Client);
 
 describe("Test s3Lib Interaction API Build Structure", () => {
-  let originalEndpoint: string | undefined;
-  beforeAll(() => {
-    originalEndpoint = process.env.S3_LOCAL_ENDPOINT;
-  });
-  afterAll(() => {
-    process.env.S3_LOCAL_ENDPOINT = originalEndpoint;
-  });
-
   beforeEach(() => {
     jest.clearAllMocks();
     s3ClientMock.reset();
@@ -47,14 +39,7 @@ describe("Test s3Lib Interaction API Build Structure", () => {
 
 describe("Checking Environment Variable Changes", () => {
   beforeEach(() => jest.resetModules());
-  test("Check if statement with S3_LOCAL_ENDPOINT set", () => {
-    process.env.S3_LOCAL_ENDPOINT = "mock endpoint";
-    const config = getConfig();
-    expect(config).toHaveProperty("region", "localhost");
-  });
-
-  test("Check if statement with S3_LOCAL_ENDPOINT undefined", () => {
-    delete process.env.S3_LOCAL_ENDPOINT;
+  test("that config has region set", () => {
     const config = getConfig();
     expect(config).toHaveProperty("region", "us-east-1");
   });

--- a/services/app-api/utils/s3/s3-lib.ts
+++ b/services/app-api/utils/s3/s3-lib.ts
@@ -9,24 +9,12 @@ import { logger } from "../debugging/debug-lib";
 import { buckets, error } from "../constants/constants";
 import { State } from "../types/other";
 
-const localConfig = {
-  endpoint: process.env.S3_LOCAL_ENDPOINT,
-  region: "localhost",
-  forcePathStyle: true,
-  credentials: {
-    accessKeyId: "S3RVER", // pragma: allowlist secret
-    secretAccessKey: "S3RVER", // pragma: allowlist secret
-  },
-  logger,
-};
-
-const awsConfig = {
-  region: "us-east-1",
-  logger,
-};
-
 export const getConfig = () => {
-  return process.env.S3_LOCAL_ENDPOINT ? localConfig : awsConfig;
+  return {
+    region: "us-east-1",
+    logger,
+    endpoint: process.env.AWS_ENDPOINT_URL,
+  };
 };
 const client = new S3Client(getConfig());
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -214,7 +214,7 @@ async function run_local() {
   process.env.AWS_DEFAULT_REGION = "us-east-1";
   process.env.AWS_ACCESS_KEY_ID = "localstack";
   process.env.AWS_SECRET_ACCESS_KEY = "localstack"; // pragma: allowlist secret
-  process.env.AWS_ENDPOINT_URL = "http://localhost:4566";
+  process.env.AWS_ENDPOINT_URL = "https://localhost.localstack.cloud:4566";
 
   await runner.run_command_and_output(
     "CDK local bootstrap",


### PR DESCRIPTION
### Description
Run local stopped working for unexplained reasons. This should fix it so that we can use Dynamo locally without errors. (They manifested as 502 for our own api calls to the back end)

### Related ticket(s)
CMDCT-4935

---
### How to test
Open app and look through console. Make sure things like user/banner/reports load.

### Notes
NA

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
