### PR TITLE
CMDCT-4914: NAAAR - only add analysis methods for new reports

### DIFF
--- a/services/ui-src/src/components/modals/AddEditReportModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.test.tsx
@@ -18,6 +18,7 @@ import {
 } from "utils/testing/setupJest";
 import { convertDateUtcToEt, useStore } from "utils";
 import { testA11y } from "utils/testing/commonTests";
+import { DEFAULT_ANALYSIS_METHODS } from "../../constants";
 
 const mockCreateReport = jest.fn();
 const mockUpdateReport = jest.fn();
@@ -383,6 +384,12 @@ describe("<AddEditProgramModal />", () => {
         expect(mockFetchReportsByState).toHaveBeenCalledTimes(1);
         expect(mockCloseHandler).toHaveBeenCalledTimes(1);
       });
+      // should add default analysis methods for new reports
+      expect(mockCreateReport.mock.calls[0][2].fieldData).toEqual(
+        expect.objectContaining({
+          analysisMethods: DEFAULT_ANALYSIS_METHODS,
+        })
+      );
     });
 
     test("Edit modal hydrates with report info and disables fields", async () => {
@@ -429,6 +436,8 @@ describe("<AddEditProgramModal />", () => {
         expect(mockFetchReportsByState).toHaveBeenCalledTimes(1);
         expect(mockCloseHandler).toHaveBeenCalledTimes(1);
       });
+      // should not update analysis methods for existing reports
+      expect(mockUpdateReport.mock.calls[0][1].fieldData).toEqual({});
     });
   });
 

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -144,7 +144,7 @@ export const AddEditReportModal = ({
   };
 
   // NAAAR report payload
-  const prepareNaaarPayload = (formData: any) => {
+  const prepareNaaarPayload = (formData: any, isNewReport: boolean) => {
     const programName = formData["programName"];
     const copyFieldDataSourceId = formData["copyFieldDataSourceId"];
     const dueDate = calculateDueDate(formData["reportingPeriodEndDate"]);
@@ -176,9 +176,11 @@ export const AddEditReportModal = ({
         previousRevisions: [],
         naaarReport,
       },
-      fieldData: {
-        analysisMethods: DEFAULT_ANALYSIS_METHODS,
-      },
+      fieldData: isNewReport
+        ? {
+            analysisMethods: DEFAULT_ANALYSIS_METHODS,
+          }
+        : {},
     };
   };
 
@@ -191,7 +193,7 @@ export const AddEditReportModal = ({
     if (reportType === "MCPAR") {
       dataToWrite = prepareMcparPayload(formData);
     } else if (reportType === "NAAAR") {
-      dataToWrite = prepareNaaarPayload(formData);
+      dataToWrite = prepareNaaarPayload(formData, !selectedReport?.id);
     } else {
       dataToWrite = prepareMlrPayload(formData);
     }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
NAAAR Analysis methods were getting overwritten upon report name update because our naaar payload, for update and create, was setting `analysisMethods` in fieldData to the default, thus overwriting existing answers.

Now it only adds the methods if it is a new report.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4914

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Create a NAAAR
- Verify all default analysis methods are populated in the report
- Add/edit some analysis methods
- Go to the NAAAR dashboard and change something about the report (edit button on the left side of the dashboard table)
- Re-enter the report and verify all the data you entered previously is still there

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

- [ ] Product: This work has been reviewed and approved by product owner, if necessary

---