### PR TITLE
NAAAR fix standard core provider type seed/hydration

### DIFF
--- a/tests/seeds/fixtures/naaar.ts
+++ b/tests/seeds/fixtures/naaar.ts
@@ -199,7 +199,7 @@ export const fillNaaar = (): SeedFillReportShape => {
           standard_coreProviderType: [
             {
               key: "standard_coreProviderType-UZK4hxPVnuYGcIgNzYFHCk",
-              value: "Primary Care",
+              value: "Primary care",
             },
           ],
           [`standard_coreProviderType-${providerTypeId}-otherText`]:


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->


### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Run MCR locally and seed a filled NAAAR
- Go to standards and edit the standard
- Verify the core provider type radio and optional subfield hydrate
