### PR TITLE
CMDCT-4942: NAAAR - Fix standards button disabled

### DIFF
--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -52,7 +52,8 @@ import addIconSVG from "assets/icons/icon_add_gray.svg";
 
 export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
   const [submitting, setSubmitting] = useState<boolean>(false);
-  const [pageError, setPageError] = useState<ErrorVerbiage>();
+  const [analysisMethodsError, setAnalysisMethodsError] =
+    useState<ErrorVerbiage>();
   const [canAddStandards, setCanAddStandards] = useState<boolean>(false);
   const [selectedIsCustomEntity, setSelectedIsCustomEntity] =
     useState<boolean>(false);
@@ -98,30 +99,20 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
     return result?.length === DEFAULT_ANALYSIS_METHODS.length;
   };
 
-  // analysis methods: error alert appears if analysis methods are completed without any utilized
+  /*
+   * analysis methods: error alert appears if analysis methods are completed without any utilized
+   * standards: add button disabled if analysis methods are incomplete, complete without any utilized, or no provider types are selected
+   */
   useEffect(() => {
-    if (
-      completedAnalysisMethods() &&
-      !atLeastOneRequiredAnalysisMethodIsUtilized
-    ) {
-      setPageError(analysisMethodError);
-    } else {
-      setPageError(undefined);
-    }
-  }, [analysisMethods]);
+    const completed = completedAnalysisMethods();
+    const utilized = atLeastOneRequiredAnalysisMethodIsUtilized;
+    const completedNotUtilized = completed && !utilized;
 
-  // standards: add button disabled if analysis methods are incomplete, complete without any utilized, or no provider types are selected
-  useEffect(() => {
-    if (
-      !completedAnalysisMethods() ||
-      (completedAnalysisMethods() &&
-        !atLeastOneRequiredAnalysisMethodIsUtilized) ||
-      !providerTypeSelected
-    ) {
-      setCanAddStandards(false);
-    } else {
-      setCanAddStandards(true);
-    }
+    const errorMessage = completedNotUtilized ? analysisMethodError : undefined;
+    const enableAddStandards = completed && utilized && providerTypeSelected;
+
+    setAnalysisMethodsError(errorMessage);
+    setCanAddStandards(enableAddStandards);
   }, [analysisMethods, providerTypeSelected]);
 
   const formParams = {
@@ -343,7 +334,11 @@ export const DrawerReportPage = ({ route, validateOnRender }: Props) => {
         <ReportPageIntro text={verbiage.intro} hasIlos={hasIlos} />
       )}
       {isAnalysisMethodsPage && (
-        <ErrorAlert error={pageError} sxOverride={sx.pageErrorAlert} showIcon />
+        <ErrorAlert
+          error={analysisMethodsError}
+          sxOverride={sx.pageErrorAlert}
+          showIcon
+        />
       )}
       {displayErrorMessages()}
       {standardForm && (


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
I think the issue was the standards useEffect wasn't dependent on `completedAnalysisMethods` and thus wasn't updating even once you'd finished them. Now both standards and analysis methods useEffects depend on `analysisMethods` which will also affect the results of `completedAnalysisMethods` and `atLeastOneRequiredAnalysisMethodIsUtilized`. This may end up with more renders than we need, but I think it's a little cleaner.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4942

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Easiest to tell the difference when you compare to [dev](https://mdctmcrdev.cms.gov/) or [val](https://mdctmcrval.cms.gov/)
- Create a NAAAR
- Fill out plans, provider type coverage, and analysis methods
- Click the continue button to go from analysis methods to standards
- The add standards button is disabled
- Hard refresh OR go back to a previous page and then return to standards
- The button is enabled

Re-test in this [deployed env](https://d85kyoy6vw3j5.cloudfront.net/) and verify it's fixed

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

- [x] Product: This work has been reviewed and approved by product owner, if necessary

---