### PR TITLE
CMDCT-4959 adding s3 endpoint instead of relying on nat gateway

### DIFF
--- a/deployment/stacks/parent.ts
+++ b/deployment/stacks/parent.ts
@@ -45,6 +45,10 @@ export class ParentStack extends Stack {
     const vpc = ec2.Vpc.fromLookup(this, "Vpc", { vpcName });
     const kafkaAuthorizedSubnets = getSubnets(this, kafkaAuthorizedSubnetIds);
 
+    vpc.addGatewayEndpoint("S3Endpoint", {
+      service: ec2.GatewayVpcEndpointAwsService.S3,
+    });
+
     const customResourceRole = createCustomResourceRole(commonProps);
 
     const loggingBucket = s3.Bucket.fromBucketName(


### PR DESCRIPTION
### Description
Start using vpc endpoint for s3 from postFormName lambdas instead of nat gateway

### Related ticket(s)
CMDCT-4959

---

### How to test
You can look over these requests:
https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fapp-api-cmdct-4959-postMcparBucketData

One made with new code:
2025-07-25 15:41:42 (UTC)

One made with nat gateway disconnected when it failed without the s3 endpoint:
2025-07-25 15:33:15 (UTC)


### Notes
NA

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [val release](?expand=1&template=val-deployment.md)_ | _[production release](?expand=1&template=production-deployment.md)_
