### PR TITLE
Fix AnyObject import and reorganize imports for DrawerReportEntityRows

### DIFF
--- a/services/ui-src/src/components/reports/DrawerReportEntityRows.test.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportEntityRows.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useStore } from "utils";
 import { DrawerReportPage } from "./DrawerReportPage";
 import { ReportContext } from "./ReportProvider";
+import { useStore } from "utils";
 import {
   mockAdminUserStore,
   mockAnalysisMethodEntityStore,

--- a/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportEntityRows.tsx
@@ -1,17 +1,21 @@
 import { Box, Button, Flex, Heading, Image, Text } from "@chakra-ui/react";
+// constants
+import { getDefaultAnalysisMethodIds } from "../../constants";
+// types
 import {
+  AnyObject,
   DrawerReportPageShape,
   EntityShape,
   FormField,
   FormJson,
   isFieldElement,
 } from "types";
-import { AnyObject } from "yup/lib/types";
+// utils
+import { getForm, isIlosCompleted, otherSpecify, useStore } from "utils";
+// assets
 import unfinishedIcon from "assets/icons/icon_error_circle_bright.png";
 import deleteIcon from "assets/icons/icon_cancel_x_circle.png";
 import completedIcon from "assets/icons/icon_check_circle.png";
-import { getForm, isIlosCompleted, otherSpecify, useStore } from "utils";
-import { getDefaultAnalysisMethodIds } from "../../constants";
 
 export const DrawerReportPageEntityRows = ({
   route,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Noticed we were importing `AnyObject` from `yup` instead of our own type, so I changed that and organized the imports

(assets should be first alphabetically but since we usually don't have it as an import category we tend to organize it toward the bottom...just following that pattern)