### PR TITLE
CMDCT-4917: NAAAR - ensure nested fields clear in plan compliance

### DIFF
--- a/services/ui-src/src/components/overlays/EntityDetailsMultiformOverlay.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsMultiformOverlay.tsx
@@ -84,12 +84,8 @@ export const EntityDetailsMultiformOverlay = ({
       planName: selectedEntity?.name,
     }) as EntityDetailsMultiformVerbiage;
 
-    const handleChildSubmit = (
-      enteredData: AnyObject,
-      updatedEntity?: AnyObject
-    ) => {
-      const entity = updatedEntity ?? selectedEntity;
-      setSelectedEntity({ ...entity, ...enteredData });
+    const handleChildSubmit = (enteredData: AnyObject) => {
+      setSelectedEntity({ ...selectedEntity, ...enteredData });
       onSubmit(enteredData, false);
     };
 
@@ -155,11 +151,15 @@ export const EntityDetailsMultiformOverlay = ({
             delete selectedEntity?.[key];
             delete updatedData[key];
           });
+          // enteredData has the full form data for 438.68 so keep only 438.68 stuff from enteredData and not from selectedEntity
+          nonComplianceKeys.forEach((key) => {
+            delete selectedEntity?.[key];
+          });
         }
 
-        // return new data and updated entity (in case we deleted keys from the entity)
-        handleChildSubmit(updatedData, selectedEntity);
+        setSelectedEntity(selectedEntity);
         setSelectedStandard(null);
+        handleChildSubmit(updatedData);
       };
 
       return (


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
For plan compliance 438.68 non-compliant standards we need to ensure the nested data entered under analysis methods does not persist when you change and save new answers.

Previously if someone entered or updated data within this section it saved the new data alongside the existing data. Fields like the text boxes would just overwrite themselves and not show any issues, but the nested fields would hold onto previously entered data even after changing the nested selections. Now when we save data under here we explicitly clear out _all_ previously entered answers for this section and only write the values in the form at the time of the latest save. Since this section saves on button click, it cannot be saved unless it passes validation. Also, since previous answers are hydrated, unchanged answers still get saved.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4917

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Seed a filled NAAAR locally or test using the Test NAAAR under `stateuser` in the [deployed env](https://d44jj4bydbdeo.cloudfront.net/)

- Go to NAAAR plan compliance
- Play around with the analysis methods nested fields under 438.68 non-compliant standards
- Verify:
  - Nested fields clear when you deselect then re-select their parent option
  - You can save the standard with any state of completion for the analysis methods nested fields
  - When you save, the database (redux devtools or network tab) only contains the fields you saved. There are no answers from previously filled out then deselected fields.
  - If you change your answers and save the form multiple times the latest data is the only data that shows in the UI and that exists in the db/report store

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

- [x] Product: This work has been reviewed and approved by product owner, if necessary

---