### PR TITLE
CMDCT-4956: Fix plan compliance count labels

### DIFF
--- a/services/app-api/forms/naaar.json
+++ b/services/app-api/forms/naaar.json
@@ -1672,8 +1672,8 @@
                   "subsection": "Select non-compliant or exception standards for 42 C.F.R. § 438.68"
                 },
                 "totals": {
-                  "exceptions": "“N” indicates a standard for which the plan is non-compliant. Total count:",
-                  "standards": "“E” indicates a standard for which the plan has been granted an exception. Total count:"
+                  "nonCompliant": "“N” indicates a standard for which the plan is non-compliant. Total count:",
+                  "exceptions": "“E” indicates a standard for which the plan has been granted an exception. Total count:"
                 }
               }
             },

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -113,7 +113,7 @@ export interface EntityDetailsTableVerbiage
   extends EntityDetailsMultiformVerbiage {
   totals?: {
     exceptions?: string;
-    standards?: string;
+    nonCompliant?: string;
   };
 }
 

--- a/services/ui-src/src/components/overlays/PlanComplianceTableOverlay.tsx
+++ b/services/ui-src/src/components/overlays/PlanComplianceTableOverlay.tsx
@@ -230,10 +230,13 @@ export const PlanComplianceTableOverlay = ({
         />
         <Box sx={sx.counts}>
           <Text sx={sx.count}>
-            {displayCount(tableVerbiage.totals?.exceptions, exceptionsCount)}
+            {displayCount(
+              tableVerbiage.totals?.nonCompliant,
+              nonComplianceCount
+            )}
           </Text>
           <Text sx={sx.count}>
-            {displayCount(tableVerbiage.totals?.standards, nonComplianceCount)}
+            {displayCount(tableVerbiage.totals?.exceptions, exceptionsCount)}
           </Text>
         </Box>
         <Box sx={sx.tableContainer}>

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -115,7 +115,7 @@ export interface EntityDetailsTableVerbiage
   extends EntityDetailsMultiformVerbiage {
   totals?: {
     exceptions?: string;
-    standards?: string;
+    nonCompliant?: string;
   };
 }
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Plan compliance counts for non-compliant and exceptions were switched. This fixes the display and also updates the verbiage to be more specific.

Note: will only work on new reports

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4956

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[deployed env](https://d2xng8vewv8kr3.cloudfront.net/)
- Seed or create and fill a NAAAR (can use "test NAAAR" in deployed env)
- Enter plan compliance, select No for 438.68, and view the compliance standards table
- Verify that when a standard is an exception, the exceptions count increments
- Verify that when a standard is non-compliant, the non-compliant count increments
- Verify the count display changes when you change the answer, including not selecting either checkbox

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
