### PR TITLE
[CMDCT-4950] Add analysis methods guard for plans autosave

### DIFF
--- a/services/ui-src/src/utils/autosave/autosave.ts
+++ b/services/ui-src/src/utils/autosave/autosave.ts
@@ -122,14 +122,17 @@ export const autosaveFieldData = async ({
   // if there are fields to save, create and send payload
   if (fieldsToSave.length) {
     const reportKeys = { reportType, id, state };
-    let dataToWrite = {} as AnyObject;
+    let dataToWrite = {
+      metadata: { status: ReportStatus.IN_PROGRESS, lastAlteredBy: userName },
+    } as AnyObject;
+
     if (
       entityContext &&
       entityContext.selectedEntity &&
       entityContext.entityType
     ) {
       dataToWrite = {
-        metadata: { status: ReportStatus.IN_PROGRESS, lastAlteredBy: userName },
+        ...dataToWrite,
         fieldData: {
           [entityContext.entityType]: entityContext.updateEntities(
             Object.fromEntries(fieldsToSave)
@@ -140,8 +143,8 @@ export const autosaveFieldData = async ({
       // create field data object
       const fieldData = Object.fromEntries(fieldsToSave);
       dataToWrite = {
-        metadata: { status: ReportStatus.IN_PROGRESS, lastAlteredBy: userName },
-        fieldData: fieldData,
+        ...dataToWrite,
+        fieldData,
       };
 
       // handle Prior Authorization case
@@ -161,20 +164,26 @@ export const autosaveFieldData = async ({
       }
     }
 
+    const hasEditedPlans = dataToWrite.fieldData.plans;
+    const hasAnalysisMethods =
+      reportFieldData?.analysisMethods &&
+      reportFieldData.analysisMethod.length > 0;
+
     // NAAAR plans were edited
     if (
       reportKeys.reportType === ReportType.NAAAR &&
-      dataToWrite.fieldData.plans
+      hasEditedPlans &&
+      hasAnalysisMethods
     ) {
       // All plans are submitted on individual edits
-      const plans = dataToWrite.fieldData.plans;
+      const plans = [...dataToWrite.fieldData.plans];
       const planNames = Object.fromEntries(
         plans.map((plan: AnyObject) => [
           `analysis_method_applicable_plans-${plan.id}`,
           plan.name,
         ])
       );
-      const analysisMethods = reportFieldData?.analysisMethods || [];
+      const analysisMethods = [...reportFieldData.analysisMethods];
 
       for (const analysisMethod of analysisMethods) {
         const applicablePlans = analysisMethod.analysis_method_applicable_plans;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
While working on https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12337, I came across this bug that could cause analysis methods to be deleted if autosave is implemented improperly on other NAAAR sections.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4950

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Run MCR locally
2. Create a filled NAAAR with yarn db:seed
3. Create a couple more plans and add them to any analysis methods
4. Delete a plan
5. Check that the plan was removed from the analysis method it was added to

<!-- ### Notes -->
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->

<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->

<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [val release](?expand=1&template=val-deployment.md)_ | _[production release](?expand=1&template=production-deployment.md)_ -->
