### PR TITLE
Refactor reusable dashboard components and improve accessibility

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
@@ -344,7 +344,7 @@ describe("<DashboardTable />", () => {
       render(dashboardViewWithReports);
       await waitFor(async () => {
         const archiveProgramButton = screen.getByRole("button", {
-          name: "Archive",
+          name: /Archive/,
         });
         expect(archiveProgramButton).toBeVisible();
         await userEvent.click(archiveProgramButton);
@@ -363,7 +363,7 @@ describe("<DashboardTable />", () => {
       });
       render(dashboardViewWithReports);
       const archiveProgramButton = screen.getByRole("button", {
-        name: "Unarchive",
+        name: /Unarchive/,
       });
       expect(archiveProgramButton).toBeVisible();
       await userEvent.click(archiveProgramButton);
@@ -383,7 +383,7 @@ describe("<DashboardTable />", () => {
       });
       render(dashboardViewWithReports);
       const archiveProgramButton = screen.getByRole("button", {
-        name: "Archive",
+        name: /Archive/,
       });
       expect(archiveProgramButton).toBeVisible();
       await userEvent.click(archiveProgramButton);
@@ -405,7 +405,7 @@ describe("<DashboardTable />", () => {
       await waitFor(() => {
         expect(
           screen.queryByRole("button", {
-            name: "Archive",
+            name: /Archive/,
           })
         ).not.toBeInTheDocument();
       });
@@ -420,7 +420,7 @@ describe("<DashboardTable />", () => {
       await waitFor(() => {
         expect(
           screen.queryByRole("button", {
-            name: "Archive",
+            name: /Archive/,
           })
         ).not.toBeInTheDocument();
       });
@@ -435,7 +435,7 @@ describe("<DashboardTable />", () => {
       await waitFor(() => {
         expect(
           screen.queryByRole("button", {
-            name: "Archive",
+            name: /Archive/,
           })
         ).not.toBeInTheDocument();
       });

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTableUtils.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTableUtils.tsx
@@ -53,15 +53,13 @@ export interface DateFieldProps {
 export interface AdminActionButtonProps {
   report: ReportMetadataShape;
   reportType: string;
-  reportId: string | undefined;
-  archiving?: boolean;
-  releasing?: boolean;
   sxOverride: AnyObject;
+  reportId?: string;
 }
 
 export interface AdminReleaseActionButtonProps extends AdminActionButtonProps {
-  releasing?: boolean;
   releaseReport: Function;
+  releasing?: boolean;
 }
 
 export interface AdminArchiveActionButtonProps extends AdminActionButtonProps {
@@ -164,6 +162,7 @@ export const DateFields = ({ report, reportType }: DateFieldProps) => {
 
 export const AdminReleaseButton = ({
   report,
+  reportType,
   reportId,
   releasing,
   releaseReport,
@@ -172,6 +171,13 @@ export const AdminReleaseButton = ({
   return (
     <Button
       variant="link"
+      aria-label={
+        reportType !== ReportType.MLR
+          ? `Unlock ${report.programName} due ${convertDateUtcToEt(
+              report.dueDate
+            )} report`
+          : `Unlock ${report.programName} report`
+      }
       disabled={report?.locked === false || report?.archived === true}
       sx={sxOverride.adminActionButton}
       onClick={() => releaseReport(report)}
@@ -183,24 +189,27 @@ export const AdminReleaseButton = ({
 
 export const AdminArchiveButton = ({
   report,
+  reportType,
   reportId,
   archiveReport,
   archiving,
   sxOverride,
 }: AdminArchiveActionButtonProps) => {
+  const buttonText = report?.archived ? "Unarchive" : "Archive";
   return (
     <Button
       variant="link"
       sx={sxOverride.adminActionButton}
       onClick={() => archiveReport(report)}
+      aria-label={
+        reportType !== ReportType.MLR
+          ? `${buttonText} ${report.programName} due ${convertDateUtcToEt(
+              report.dueDate
+            )} report`
+          : `${buttonText} ${report.programName} report`
+      }
     >
-      {archiving && reportId === report.id ? (
-        <Spinner size="md" />
-      ) : report?.archived ? (
-        "Unarchive"
-      ) : (
-        "Archive"
-      )}
+      {archiving && reportId === report.id ? <Spinner size="md" /> : buttonText}
     </Button>
   );
 };

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.test.tsx
@@ -23,7 +23,12 @@ import {
   mockMcparReportStore,
   mockMlrLockedReportStore,
 } from "utils/testing/setupJest";
-import { useBreakpoint, makeMediaQueryClasses, useStore } from "utils";
+import {
+  useBreakpoint,
+  makeMediaQueryClasses,
+  useStore,
+  convertDateUtcToEt,
+} from "utils";
 // verbiage
 import mcparVerbiage from "verbiage/pages/mcpar/mcpar-dashboard";
 
@@ -135,6 +140,8 @@ const noAlteredByReportStore = {
 
 describe("<MobileDashboardTable />", () => {
   describe("Test Dashboard view (with reports, mobile view)", () => {
+    const { dueDate: utcDueDate, programName } = mockMcparReportStore.report!;
+    const dueDate = convertDateUtcToEt(utcDueDate);
     beforeEach(() => {
       mockedUseStore.mockReturnValue({
         ...mockStateUserStore,
@@ -169,7 +176,7 @@ describe("<MobileDashboardTable />", () => {
     test("Clicking 'Edit' button on a report navigates to first page of report", async () => {
       mockMcparReportContext.fetchReport.mockReturnValueOnce(mockMcparReport);
       const enterReportButton = screen.getAllByRole("button", {
-        name: "Edit",
+        name: `Edit ${programName} due ${dueDate} report`,
       })[0];
       expect(enterReportButton).toBeVisible();
       await userEvent.click(enterReportButton);
@@ -180,7 +187,9 @@ describe("<MobileDashboardTable />", () => {
     });
 
     test("Clicking 'Edit Program' icon opens the AddEditProgramModal", async () => {
-      const addReportButton = screen.getAllByAltText("Edit Report")[0];
+      const addReportButton = screen.getAllByAltText(
+        `Edit ${programName} due ${dueDate} report submission set-up information`
+      )[0];
       expect(addReportButton).toBeVisible();
       await userEvent.click(addReportButton);
       await waitFor(async () => {
@@ -254,7 +263,7 @@ describe("<MobileDashboardTable />", () => {
       });
       render(dashboardViewWithReports);
       const archiveProgramButton = screen.getByRole("button", {
-        name: "Archive",
+        name: /Archive/,
       });
       expect(archiveProgramButton).toBeVisible();
       await userEvent.click(archiveProgramButton);
@@ -274,7 +283,7 @@ describe("<MobileDashboardTable />", () => {
       });
       render(dashboardViewWithReports);
       const archiveProgramButton = screen.getByRole("button", {
-        name: "Unarchive",
+        name: /Unarchive/,
       });
       expect(archiveProgramButton).toBeVisible();
       await userEvent.click(archiveProgramButton);
@@ -294,7 +303,7 @@ describe("<MobileDashboardTable />", () => {
       });
       render(dashboardViewWithReports);
       const archiveProgramButton = screen.getByRole("button", {
-        name: "Archive",
+        name: /Archive/,
       });
       expect(archiveProgramButton).toBeVisible();
       await userEvent.click(archiveProgramButton);
@@ -316,7 +325,7 @@ describe("<MobileDashboardTable />", () => {
       await waitFor(() => {
         expect(
           screen.queryByRole("button", {
-            name: "Archive",
+            name: /Archive/,
           })
         ).not.toBeInTheDocument();
       });
@@ -331,7 +340,7 @@ describe("<MobileDashboardTable />", () => {
       await waitFor(() => {
         expect(
           screen.queryByRole("button", {
-            name: "Archive",
+            name: /Archive/,
           })
         ).not.toBeInTheDocument();
       });
@@ -346,7 +355,7 @@ describe("<MobileDashboardTable />", () => {
       await waitFor(() => {
         expect(
           screen.queryByRole("button", {
-            name: "Archive",
+            name: /Archive/,
           })
         ).not.toBeInTheDocument();
       });

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
@@ -1,18 +1,18 @@
 // components
-import { Box, Button, Flex, Image, Text, Spinner } from "@chakra-ui/react";
+import { Box, Flex, Text } from "@chakra-ui/react";
 // types
 import { ReportMetadataShape, ReportType } from "types";
 // utils
 import { convertDateUtcToEt } from "utils";
 import {
-  AdminArchiveActionButtonProps,
-  AdminReleaseActionButtonProps,
+  ActionButton,
+  AdminArchiveButton,
+  AdminReleaseButton,
   DashboardTableProps,
   DateFieldProps,
+  EditReportButton,
   getStatus,
 } from "./DashboardTableUtils";
-// assets
-import editIcon from "assets/icons/icon_edit_square_gray.png";
 
 export const MobileDashboardTable = ({
   reportsByState,
@@ -38,15 +38,12 @@ export const MobileDashboardTable = ({
           </Text>
           <Flex alignContent="flex-start">
             {isStateLevelUser && !report?.locked && (
-              <Box sx={sxOverride.editReport}>
-                <button onClick={() => openAddEditReportModal(report)}>
-                  <Image
-                    src={editIcon}
-                    data-testid="mobile-edit-report"
-                    alt="Edit Report"
-                  />
-                </button>
-              </Box>
+              <EditReportButton
+                report={report}
+                reportType={report.reportType}
+                openAddEditReportModal={openAddEditReportModal}
+                sxOverride={sxOverride}
+              />
             )}
             <Text sx={sxOverride.programNameText}>{report.programName}</Text>
           </Flex>
@@ -86,24 +83,20 @@ export const MobileDashboardTable = ({
         )}
         <Flex alignContent="flex-start" gap={2}>
           <Box sx={sxOverride.editReportButtonCell}>
-            <Button
-              variant="outline"
-              onClick={() => enterSelectedReport(report)}
-              isDisabled={report?.archived}
-            >
-              {entering && reportId == report.id ? (
-                <Spinner size="md" />
-              ) : isStateLevelUser && !report?.locked ? (
-                "Edit"
-              ) : (
-                "View"
-              )}
-            </Button>
+            <ActionButton
+              report={report}
+              reportType={reportType}
+              reportId={reportId}
+              isStateLevelUser={isStateLevelUser}
+              entering={entering}
+              enterSelectedReport={enterSelectedReport}
+            />
           </Box>
           {isAdmin && (
             <Box sx={sxOverride.adminActionCell}>
               <AdminReleaseButton
                 report={report}
+                reportType={reportType}
                 reportId={reportId}
                 releaseReport={releaseReport}
                 releasing={releasing}
@@ -111,6 +104,7 @@ export const MobileDashboardTable = ({
               />
               <AdminArchiveButton
                 report={report}
+                reportType={reportType}
                 reportId={reportId}
                 archiveReport={archiveReport}
                 archiving={archiving}
@@ -142,54 +136,6 @@ const DateFields = ({ report, reportType }: DateFieldProps) => {
     </>
   );
 };
-
-const AdminReleaseButton = ({
-  report,
-  reportId,
-  releasing,
-  releaseReport,
-  sxOverride,
-}: MobileAdminReleaseActionButtonProps) => {
-  return (
-    <Button
-      variant="link"
-      disabled={report.locked === false || report.archived === true}
-      sx={sxOverride.adminActionButton}
-      onClick={() => releaseReport(report)}
-    >
-      {releasing && reportId === report.id ? <Spinner size="md" /> : "Unlock"}
-    </Button>
-  );
-};
-
-const AdminArchiveButton = ({
-  report,
-  reportId,
-  archiveReport,
-  archiving,
-  sxOverride,
-}: MobileAdminArchiveActionButtonProps) => {
-  return (
-    <Button
-      variant="link"
-      sx={sxOverride.adminActionButton}
-      onClick={() => archiveReport(report)}
-    >
-      {archiving && reportId === report.id ? (
-        <Spinner size="md" />
-      ) : report?.archived ? (
-        "Unarchive"
-      ) : (
-        "Archive"
-      )}
-    </Button>
-  );
-};
-
-interface MobileAdminReleaseActionButtonProps
-  extends Omit<AdminReleaseActionButtonProps, "reportType"> {}
-interface MobileAdminArchiveActionButtonProps
-  extends Omit<AdminArchiveActionButtonProps, "reportType"> {}
 
 const sx = {
   mobileTable: {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
We had some buttons defined for mobile and desktop dashboards that were identical (and already in a utility file!). 
- Make use of those buttons in the mobile view
- Improve screen reader names for the buttons

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[deployed env](https://docm8syadocuj.cloudfront.net/)
- Unit and e2e tests pass
- Test out the dashboard for any report as a state user and an admin
  - Verify all buttons have accessible names
  - Verify desktop and mobile views are the same
  - Verify all buttons work and do what is expected

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
