### PR TITLE
Cmdct 5058 - swap Input for TextField component

### DIFF
--- a/services/ui-src/src/components/logins/LoginCognito.tsx
+++ b/services/ui-src/src/components/logins/LoginCognito.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 // components
-import { Box, Button, Heading, Stack } from "@chakra-ui/react";
+import { Button, Heading, Stack } from "@chakra-ui/react";
 import { ErrorAlert } from "components";
 import { TextField } from "@cmsgov/design-system";
 // types
@@ -51,26 +51,22 @@ export const LoginCognito = () => {
       </Heading>
       <ErrorAlert error={error} sxOverride={sx.error} />
       <form onSubmit={(event) => handleLogin(event)}>
-        <Box sx={sx.label}>
-          <TextField
-            id="email"
-            name="email"
-            type="email"
-            label="Email"
-            value={fields.email}
-            onChange={handleFieldChange}
-          />
-        </Box>
-        <Box sx={sx.label}>
-          <TextField
-            id="password"
-            name="password"
-            type="password"
-            label="Password"
-            value={fields.password}
-            onChange={handleFieldChange}
-          />
-        </Box>
+        <TextField
+          id="email"
+          name="email"
+          type="email"
+          label="Email"
+          value={fields.email}
+          onChange={handleFieldChange}
+        />
+        <TextField
+          id="password"
+          name="password"
+          type="password"
+          label="Password"
+          value={fields.password}
+          onChange={handleFieldChange}
+        />
         <Button
           sx={sx.button}
           onClick={handleLogin}
@@ -92,11 +88,8 @@ const sx = {
   error: {
     marginY: "1rem",
   },
-  label: {
-    marginBottom: "1rem",
-  },
   button: {
-    marginTop: "1rem",
+    marginTop: "2rem",
     width: "100%",
   },
 };


### PR DESCRIPTION
### Description
from the card:
The cognito login page for MFP currently uses the Input component from the Chakra-UI library. To stay aligned with our design system, we should replace this component with the CMSDS version

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5058

---

### How to test
See that the login page input fields look like [this](https://design.cms.gov/storybook/?path=/story/components-textfield--single-line-field&globals=theme:core) and you can still login
### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [val release](?expand=1&template=val-deployment.md)_ | _[production release](?expand=1&template=production-deployment.md)_
