### PR TITLE
remove unused conditional in modaldrawer

### DIFF
--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.test.tsx
@@ -4,6 +4,8 @@ import userEvent from "@testing-library/user-event";
 import { ReportContext, ModalDrawerReportPage } from "components";
 // constants
 import { saveAndCloseText } from "../../constants";
+// types
+import { ModalDrawerReportPageShape } from "types";
 // utils
 import { useBreakpoint, useStore } from "utils";
 import {
@@ -13,10 +15,8 @@ import {
   mockStateUserStore,
   RouterWrappedComponent,
   mockMcparReportStore,
-  mockNaaarReportStore,
 } from "utils/testing/setupJest";
 import { testA11y } from "utils/testing/commonTests";
-import { EntityType, ModalDrawerReportPageShape } from "types";
 
 const mockUseNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
@@ -171,80 +171,6 @@ describe("<ModalDrawerReportPage />", () => {
       // there are 2 plans in the mock report context and 1 field to repeat, so 2 fields should render
       const renderedFields = screen.getAllByRole("textbox");
       expect(renderedFields.length).toEqual(2);
-    });
-  });
-
-  describe("Test ModalDrawerReportPage w/ Entity Table (NAAAR)", () => {
-    beforeEach(() => {
-      mockedUseStore.mockReturnValue({
-        ...mockStateUserStore,
-        ...mockNaaarReportStore,
-      });
-    });
-
-    test("renders Entity table for a NAAAR report", async () => {
-      const naaarRoute = {
-        ...mockModalDrawerReportPageJson,
-        entityType: EntityType.PLANS,
-      };
-      render(modalDrawerReportPageComponentWithEntities(naaarRoute));
-
-      const entityTable = screen.getByRole("table");
-      const entityCaption = entityTable.querySelector("caption");
-      const entityHeader = screen.getByRole("columnheader", {
-        name: "Mock table header",
-      });
-      const entityCell = screen.getByRole("gridcell", {
-        name: "plan 1 Select “Enter” to complete response.",
-      });
-
-      expect(entityTable).toBeVisible();
-      expect(entityCaption).toHaveTextContent("Mock table header");
-      expect(entityHeader).toBeVisible();
-      expect(entityCell).toBeVisible();
-    });
-
-    test("renders mobile Entity table for a NAAAR report", async () => {
-      mockUseBreakpoint.mockReturnValue({
-        isMobile: true,
-        isTablet: false,
-      });
-      const naaarRoute = {
-        ...mockModalDrawerReportPageJson,
-        entityType: EntityType.PLANS,
-      };
-      render(modalDrawerReportPageComponentWithEntities(naaarRoute));
-
-      const entityTable = screen.getByRole("table");
-      const entityCaption = entityTable.querySelector("caption");
-      const entityHeader = screen.queryByRole("columnheader", {
-        name: "Mock table header",
-      });
-      const entityCell = screen.getByText("plan 1");
-
-      expect(entityTable).toBeVisible();
-      expect(entityCaption).toHaveTextContent("Mock table header");
-      expect(entityHeader).toBeNull();
-      expect(entityCell).toBeVisible();
-    });
-
-    test("show error for missing plans in NAAAR report", async () => {
-      const noPlans = { ...mockNaaarReportStore };
-      delete noPlans.report?.fieldData.plans;
-
-      mockedUseStore.mockReturnValue({
-        ...mockStateUserStore,
-        ...noPlans,
-      });
-
-      const naaarRoute = {
-        ...mockModalDrawerReportPageJson,
-        entityType: EntityType.SANCTIONS,
-      };
-      render(modalDrawerReportPageComponentWithEntities(naaarRoute));
-
-      const missingMessage = screen.getByTestId("missingEntityMessage");
-      expect(missingMessage).toBeVisible();
     });
   });
 

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -9,8 +9,6 @@ import {
   ReportDrawer,
   ReportPageFooter,
   ReportPageIntro,
-  ResponsiveEntityRow,
-  Table,
 } from "components";
 // types
 import {
@@ -20,9 +18,7 @@ import {
   isFieldElement,
   EntityType,
   ModalDrawerReportPageShape,
-  ModalDrawerReportPageVerbiage,
   ReportStatus,
-  ReportType,
 } from "types";
 // utils
 import {
@@ -35,7 +31,6 @@ import {
   setClearedEntriesToDefaultValue,
   resetClearProp,
   parseCustomHtml,
-  useBreakpoint,
   getAddEditDrawerText,
 } from "utils";
 // assets
@@ -197,16 +192,6 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
           <Box sx={sx.missingEntityMessage} data-testid="missingEntityMessage">
             {parseCustomHtml(verbiage.missingEntityMessage || "")}
           </Box>
-        ) : report?.reportType === ReportType.NAAAR ? (
-          <Box>
-            {entityTable(
-              reportFieldDataEntities,
-              openAddEditEntityModal,
-              openDeleteEntityModal,
-              openOverlayOrDrawer,
-              verbiage
-            )}
-          </Box>
         ) : (
           <Box>
             <Button
@@ -305,45 +290,6 @@ interface Props {
   route: ModalDrawerReportPageShape;
   validateOnRender?: boolean;
 }
-
-const entityTable = (
-  entities: AnyObject,
-  openAddEditEntityModal: Function,
-  openDeleteEntityModal: Function,
-  openOverlayOrDrawer: Function,
-  verbiage: ModalDrawerReportPageVerbiage
-) => {
-  const { isTablet, isMobile } = useBreakpoint();
-  const tableHeaders = () => {
-    if (isTablet || isMobile)
-      return {
-        caption: verbiage.tableHeader,
-        headRow: [{ hiddenName: "Status" }, { hiddenName: "Content" }],
-      };
-    return {
-      caption: verbiage.tableHeader,
-      headRow: [
-        { hiddenName: "Status" },
-        verbiage.tableHeader!,
-        { hiddenName: "Action" },
-      ],
-    };
-  };
-  return (
-    <Table sx={sx.table} content={tableHeaders()}>
-      {entities.map((entity: EntityShape) => (
-        <ResponsiveEntityRow
-          key={entity.id}
-          entity={entity}
-          verbiage={verbiage}
-          openAddEditEntityModal={openAddEditEntityModal}
-          openDeleteEntityModal={openDeleteEntityModal}
-          openOverlayOrDrawer={openOverlayOrDrawer}
-        />
-      ))}
-    </Table>
-  );
-};
 
 const sx = {
   buttonIcons: {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->

I came across a conditional that I don’t think we ever render. In [ModalDrawerReportPage we have a conditional on reportType NAAAR](https://github.com/Enterprise-CMCS/macpro-mdct-mcr/blob/main/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx#L200-L209) that renders an [entityTable](https://github.com/Enterprise-CMCS/macpro-mdct-mcr/blob/main/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx#L309-L346) specified later in that file. Looking in naaar.json there are zero instances of "modalDrawer" pageType, so we could never hit this branch, right?
I also added a log statement in entityTable and ModalDrawerReportPage, went through every page in NAAAR, and it never logged. Can we remove this conditional?

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Verify we never render this page type in NAAAR

[deployed env](https://d3v5wecuqo94c1.cloudfront.net/)

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---