### PR TITLE
Fix tar-fs vulnerability

### DIFF
--- a/awsSdkUpgrader.cjs
+++ b/awsSdkUpgrader.cjs
@@ -1,0 +1,53 @@
+const { execSync } = require("node:child_process");
+const { readdirSync, readFileSync } = require("node:fs");
+const path = require("node:path");
+
+const result = execSync(
+  "cd services/app-api && yarn info @aws-sdk/client-dynamodb version && cd -"
+).toString();
+// const latestSdkVersionNumber = result.split("\n")[1].trim();
+const latestSdkVersionNumber = "3.758.0";
+const versionMatch = /^3\.(\d+)\.0$/.exec(latestSdkVersionNumber);
+if (!versionMatch) {
+  throw new Error(
+    `Unexpected @aws-sdk version number: ${latestSdkVersionNumber}`
+  );
+}
+const minorVersion = versionMatch[1];
+execSync(`git checkout -b bump-sdk-${minorVersion}`);
+
+const serviceDirectories = readdirSync("services", { withFileTypes: true })
+  .filter((info) => info.isDirectory())
+  .map((info) => path.join("services", info.name));
+
+for (let directory of serviceDirectories) {
+  const service = JSON.parse(
+    readFileSync(path.join(directory, "package.json"), "utf8")
+  );
+  const dependencies = service.dependencies ?? {};
+  const packagesToUpgrade = Object.keys(dependencies)
+    .filter((key) => key.startsWith("@aws-sdk/"))
+    .map((packageName) => `${packageName}@^${latestSdkVersionNumber}`)
+    .join(" ");
+  if (packagesToUpgrade) {
+    const dependencyUpgradeCommand = `cd ${directory} && yarn upgrade ${packagesToUpgrade} && cd -`;
+    console.log(dependencyUpgradeCommand);
+    execSync(dependencyUpgradeCommand);
+  }
+
+  const devDependencies = service.devDependencies ?? {};
+  const devPackagesToUpgrade = Object.keys(devDependencies)
+    .filter((key) => key.startsWith("@aws-sdk/"))
+    .map((packageName) => `${packageName}@^${latestSdkVersionNumber}`)
+    .join(" ");
+  if (devPackagesToUpgrade) {
+    const devDependencyUpgradeCommand = `cd ${directory} && yarn upgrade --dev ${devPackagesToUpgrade} && cd -`;
+    console.log(devDependencyUpgradeCommand);
+    execSync(devDependencyUpgradeCommand);
+  }
+}
+
+execSync(
+  `git commit -am 'Bump AWS SDK version numbers to ${latestSdkVersionNumber}'`
+);
+execSync(`git push`);

--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -72,7 +72,7 @@
     "babel-jest": "^29.7.0",
     "jest-axe": "^6.0.0",
     "jest-launchdarkly-mock": "^2.0.3",
-    "pa11y": "^9.0.0",
+    "pa11y": "^9.0.1",
     "pa11y-runner-htmlcs": "^2.0.1",
     "patch-package": "^6.4.7",
     "postinstall-postinstall": "^2.1.0",
@@ -85,7 +85,8 @@
     "nwsapi": "^2.2.5",
     "xml2js": "^0.5.0",
     "json5": "2.2.3",
-    "proxy-agent": "^6.3.0"
+    "proxy-agent": "^6.3.0",
+    "tar-fs": "3.1.1"
   },
   "jest": {
     "coverageReporters": [

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -4279,9 +4279,6 @@
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/@smithy/abort-controller/-/abort-controller-3.1.5.tgz#ca7a86a3c6b20fabe59667143f58d9e198616d14"
   integrity sha512-DhNPnqTqPoG8aZ5dWkFOgsuY+i0GQ3CI6hMmvCoduNsnU9gUZWZBwGfDQsTTB7NvFPkom1df7jMIJWU90kuXXg==
-  dependencies:
-    "@smithy/types" "^3.5.0"
-    tslib "^2.6.2"
 
 "@smithy/config-resolver@^3.0.5", "@smithy/config-resolver@^3.0.9":
   version "3.0.9"
@@ -8103,10 +8100,10 @@ pa11y-runner-htmlcs@^2.0.1:
   dependencies:
     html_codesniffer "^2.5.1"
 
-pa11y@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/pa11y/-/pa11y-9.0.0.tgz#3ec16a9d441b126d963a7823cf83f89e1bfdd20a"
-  integrity sha512-IGOctP9ETUGZ+ygzX7co6p4BhImdtQ0HDHFMdjyReUXb3dzmR14HeHCUja88bCTnnnl2/FG17h6zZeD5GjQvSg==
+pa11y@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/pa11y/-/pa11y-9.0.1.tgz#385a5d9835c22fca4d7f8feade425c68a45923ff"
+  integrity sha512-S0UReAkHQuGsjVDUNUKPREms3IyR/Dfrk6U2HMrjQ71LIdADmDJXrDOBOD05UroCn8Ns9jg2NgZeFuLj50Sl4w==
   dependencies:
     axe-core "~4.10.3"
     bfj "~9.1.2"
@@ -9195,10 +9192,10 @@ tabbable@^6.2.0:
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
   integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
 
-tar-fs@^3.0.8:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.9.tgz#d570793c6370d7078926c41fa422891566a0b617"
-  integrity sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==
+tar-fs@3.1.1, tar-fs@^3.0.8:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.1.1.tgz#4f164e59fb60f103d472360731e8c6bb4a7fe9ef"
+  integrity sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==
   dependencies:
     pump "^3.0.0"
     tar-stream "^3.1.5"


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

[Dependebot has flagged a sec-vulnerability](https://github.com/Enterprise-CMCS/macpro-mdct-carts/security/dependabot/950) and we've get a fix in the same day! This is specifically the tar-fs package which is a sub-package for pa11y. Interestingly pa11y did launch an update iteself about 50 minutes ago, however, they upgraded their version of tar to a still affected one. Soooooo we'll just force it to be the patched version for now :). I've also removed an unused dependency thats been set to resolved for a couple years now.

### How to test

<!-- Step-by-step instructions on how to test, if necessary -->
pa11y is used by our testing sweet. So if the tests pass, we pass!

### Notes

pa11y: 9.0.0 -> 9.0.1
tar-fs: forced 3.1.1

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
