### PR TITLE
remove unhelpful tests

### DIFF
--- a/tests/cypress/e2e/footer.cy.js
+++ b/tests/cypress/e2e/footer.cy.js
@@ -1,6 +1,5 @@
 // element selectors
 const helpLinkText = "Contact Us";
-const accessibilityStatementLinkText = "Accessibility Statement";
 
 beforeEach(() => {
   cy.authenticate("stateUser");
@@ -10,15 +9,5 @@ describe("Footer integration tests", () => {
   it("Footer help link navigates to /help", () => {
     cy.contains(helpLinkText).click();
     cy.location("pathname").should("match", /help/);
-  });
-
-  it("Footer accessibility statement link navigates to the right external URL", () => {
-    cy.get(
-      'a[href="https://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/CMSNondiscriminationNotice"]'
-    ).contains(accessibilityStatementLinkText);
-
-    cy.contains(accessibilityStatementLinkText).then((link) => {
-      cy.request(link.prop("href")).its("status").should("eq", 200);
-    });
   });
 });

--- a/tests/cypress/e2e/header.cy.js
+++ b/tests/cypress/e2e/header.cy.js
@@ -1,6 +1,3 @@
-// element selectors
-const accessibilityStatementLinkText = "Accessibility Statement";
-
 beforeEach(() => {
   cy.authenticate("stateUser");
 });
@@ -29,15 +26,5 @@ describe("Footer integration tests", () => {
     cy.wait(3000);
     cy.visit("/");
     cy.get("[data-testid='cognito-login-button']").should("be.visible");
-  });
-
-  it("Footer accessibility statement link navigates to the right external URL", () => {
-    cy.get(
-      'a[href="https://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/CMSNondiscriminationNotice"]'
-    ).contains(accessibilityStatementLinkText);
-
-    cy.contains(accessibilityStatementLinkText).then((link) => {
-      cy.request(link.prop("href")).its("status").should("eq", 200);
-    });
   });
 });


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description
Removing some tests that are checking for an absolute URL that 404s. We probably shouldn't have a test like this in our e2e suite anyway!