### PR TITLE
Cmdct 5193 - refactor EntityCardBottomSection

### DIFF
--- a/services/ui-src/src/components/cards/EntityCard/AccessMeasuresSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/AccessMeasuresSection.test.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { AccessMeasuresSection } from "./AccessMeasuresSection";
+import { mockNotAnswered } from "utils/testing/mockEntities";
+
+const baseProps = {
+  sx: {},
+  notAnswered: mockNotAnswered,
+  providerText: jest.fn(() => "Provider: Details"),
+};
+
+describe("AccessMeasuresSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders all fields with correct data and printVersion off", () => {
+    render(
+      <AccessMeasuresSection
+        {...baseProps}
+        printVersion={false}
+        formattedEntityData={{
+          provider: "ACME",
+          region: "North",
+          population: "Urban",
+          monitoringMethods: ["Method A", "Method B"],
+          methodFrequency: "Monthly",
+        }}
+      />
+    );
+
+    expect(baseProps.providerText).toHaveBeenCalled();
+
+    const expectedTexts = [
+      "Provider",
+      "Region",
+      "Population",
+      "Monitoring Methods",
+      "Frequency of oversight methods",
+      "Provider: Details",
+      "North",
+      "Urban",
+      "Method A, Method B",
+      "Monthly",
+    ];
+
+    expectedTexts.forEach((text) => {
+      expect(screen.getByText(text)).toBeInTheDocument();
+    });
+  });
+
+  test("prefixes labels with version numbers when printVersion is true", () => {
+    render(
+      <AccessMeasuresSection
+        {...baseProps}
+        printVersion={true}
+        formattedEntityData={{
+          provider: "ACME",
+          region: "North",
+          population: "Urban",
+          monitoringMethods: ["X"],
+          methodFrequency: "Weekly",
+        }}
+      />
+    );
+
+    const expectedLabels = [
+      "C2.V.4 Provider",
+      "C2.V.5 Region",
+      "C2.V.6 Population",
+      "C2.V.7 Monitoring Methods",
+      "C2.V.8 Frequency of oversight methods",
+    ];
+
+    expectedLabels.forEach((label) => {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    });
+  });
+
+  test("renders notAnswered fallback when data is missing and printVersion is true", () => {
+    render(
+      <AccessMeasuresSection
+        {...baseProps}
+        printVersion={true}
+        formattedEntityData={{
+          provider: undefined,
+          region: "",
+          population: null,
+          monitoringMethods: null,
+          methodFrequency: undefined,
+        }}
+      />
+    );
+
+    const fallbacks = screen.getAllByTestId("not-answered");
+    expect(fallbacks.length).toBeGreaterThanOrEqual(4);
+  });
+
+  test("applies 'error' class when key fields are missing", () => {
+    const { container } = render(
+      <AccessMeasuresSection
+        {...baseProps}
+        printVersion={true}
+        formattedEntityData={{
+          provider: "",
+          region: null,
+          population: "",
+          monitoringMethods: [],
+          methodFrequency: "",
+        }}
+      />
+    );
+
+    const errorContainer = container.querySelector(".error");
+    expect(errorContainer).toBeInTheDocument();
+  });
+
+  test("does NOT apply 'error' class when all key fields are present", () => {
+    const { container } = render(
+      <AccessMeasuresSection
+        {...baseProps}
+        printVersion={false}
+        formattedEntityData={{
+          provider: "ACME",
+          region: "North",
+          population: "Urban",
+          monitoringMethods: ["M1"],
+          methodFrequency: "Quarterly",
+        }}
+      />
+    );
+
+    const errorContainer = container.querySelector(".error");
+    expect(errorContainer).not.toBeInTheDocument();
+  });
+});

--- a/services/ui-src/src/components/cards/EntityCard/AccessMeasuresSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/AccessMeasuresSection.test.tsx
@@ -20,7 +20,7 @@ describe("AccessMeasuresSection", () => {
         {...baseProps}
         printVersion={false}
         formattedEntityData={{
-          provider: "ACME",
+          provider: "Physician",
           region: "North",
           population: "Urban",
           monitoringMethods: ["Method A", "Method B"],
@@ -55,7 +55,7 @@ describe("AccessMeasuresSection", () => {
         {...baseProps}
         printVersion={true}
         formattedEntityData={{
-          provider: "ACME",
+          provider: "Physician",
           region: "North",
           population: "Urban",
           monitoringMethods: ["X"],
@@ -115,13 +115,13 @@ describe("AccessMeasuresSection", () => {
     expect(errorContainer).toBeInTheDocument();
   });
 
-  test("does NOT apply 'error' class when all key fields are present", () => {
+  test("does not apply 'error' class when all key fields are present", () => {
     const { container } = render(
       <AccessMeasuresSection
         {...baseProps}
         printVersion={false}
         formattedEntityData={{
-          provider: "ACME",
+          provider: "Physician",
           region: "North",
           population: "Urban",
           monitoringMethods: ["M1"],

--- a/services/ui-src/src/components/cards/EntityCard/AccessMeasuresSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/AccessMeasuresSection.test.tsx
@@ -20,7 +20,7 @@ describe("AccessMeasuresSection", () => {
         {...baseProps}
         printVersion={false}
         formattedEntityData={{
-          provider: "Physician",
+          provider: "Hospital",
           region: "North",
           population: "Urban",
           monitoringMethods: ["Method A", "Method B"],
@@ -55,7 +55,7 @@ describe("AccessMeasuresSection", () => {
         {...baseProps}
         printVersion={true}
         formattedEntityData={{
-          provider: "Physician",
+          provider: "Hospital",
           region: "North",
           population: "Urban",
           monitoringMethods: ["X"],
@@ -121,7 +121,7 @@ describe("AccessMeasuresSection", () => {
         {...baseProps}
         printVersion={false}
         formattedEntityData={{
-          provider: "Physician",
+          provider: "Hospital",
           region: "North",
           population: "Urban",
           monitoringMethods: ["M1"],

--- a/services/ui-src/src/components/cards/EntityCard/AccessMeasuresSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/AccessMeasuresSection.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { AccessMeasuresSection } from "./AccessMeasuresSection";
 import { mockNotAnswered } from "utils/testing/mockEntities";
+import { testA11y } from "utils/testing/commonTests";
 
 const baseProps = {
   sx: {},
@@ -9,25 +10,27 @@ const baseProps = {
   providerText: jest.fn(() => "Provider: Details"),
 };
 
+const accessMeasuresSectionComponent = (
+  <AccessMeasuresSection
+    {...baseProps}
+    printVersion={false}
+    formattedEntityData={{
+      provider: "Hospital",
+      region: "North",
+      population: "Urban",
+      monitoringMethods: ["Method A", "Method B"],
+      methodFrequency: "Monthly",
+    }}
+  />
+);
+
 describe("AccessMeasuresSection", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   test("renders all fields with correct data and printVersion off", () => {
-    render(
-      <AccessMeasuresSection
-        {...baseProps}
-        printVersion={false}
-        formattedEntityData={{
-          provider: "Hospital",
-          region: "North",
-          population: "Urban",
-          monitoringMethods: ["Method A", "Method B"],
-          methodFrequency: "Monthly",
-        }}
-      />
-    );
+    render(accessMeasuresSectionComponent);
 
     expect(baseProps.providerText).toHaveBeenCalled();
 
@@ -116,21 +119,11 @@ describe("AccessMeasuresSection", () => {
   });
 
   test("does not apply 'error' class when all key fields are present", () => {
-    const { container } = render(
-      <AccessMeasuresSection
-        {...baseProps}
-        printVersion={false}
-        formattedEntityData={{
-          provider: "Hospital",
-          region: "North",
-          population: "Urban",
-          monitoringMethods: ["M1"],
-          methodFrequency: "Quarterly",
-        }}
-      />
-    );
+    const { container } = render(accessMeasuresSectionComponent);
 
     const errorContainer = container.querySelector(".error");
     expect(errorContainer).not.toBeInTheDocument();
   });
+
+  testA11y(accessMeasuresSectionComponent);
 });

--- a/services/ui-src/src/components/cards/EntityCard/AccessMeasuresSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/AccessMeasuresSection.tsx
@@ -1,0 +1,74 @@
+import { Box, Flex, Text } from "@chakra-ui/react";
+import { ReactNode } from "react";
+import { SxObject } from "types";
+
+export const AccessMeasuresSection = ({
+  formattedEntityData,
+  printVersion,
+  notAnswered,
+  providerText,
+  sx,
+}: Props) => {
+  return (
+    <>
+      <Box
+        sx={sx.highlightContainer}
+        className={
+          !formattedEntityData?.provider ||
+          !formattedEntityData.region ||
+          !formattedEntityData.population
+            ? "error"
+            : ""
+        }
+      >
+        <Flex>
+          <Box sx={sx.highlightSection}>
+            <Text sx={sx.subtitle}>
+              {`${printVersion ? "C2.V.4 " : ""}Provider`}
+            </Text>
+            <Text sx={sx.subtext}>{providerText()}</Text>
+          </Box>
+          <Box sx={sx.highlightSection}>
+            <Text sx={sx.subtitle}>
+              {`${printVersion ? "C2.V.5 " : ""}Region`}
+            </Text>
+            <Text sx={sx.subtext}>
+              {formattedEntityData?.region || (printVersion && notAnswered)}
+            </Text>
+          </Box>
+          <Box sx={sx.highlightSection}>
+            <Text sx={sx.subtitle}>
+              {`${printVersion ? "C2.V.6 " : ""}Population`}
+            </Text>
+            <Text sx={sx.subtext}>
+              {formattedEntityData?.population || (printVersion && notAnswered)}
+            </Text>
+          </Box>
+        </Flex>
+      </Box>
+
+      <Text sx={sx.subtitle}>
+        {`${printVersion ? "C2.V.7 " : ""}Monitoring Methods`}
+      </Text>
+      <Text sx={sx.subtext}>
+        {formattedEntityData?.monitoringMethods?.join(", ") ||
+          (printVersion && notAnswered)}
+      </Text>
+
+      <Text sx={sx.subtitle}>
+        {`${printVersion ? "C2.V.8 " : ""}Frequency of oversight methods`}
+      </Text>
+      <Text sx={sx.subtext}>
+        {formattedEntityData.methodFrequency || (printVersion && notAnswered)}
+      </Text>
+    </>
+  );
+};
+
+interface Props {
+  formattedEntityData: any;
+  printVersion?: boolean;
+  notAnswered: ReactNode;
+  providerText: () => string;
+  sx: SxObject;
+}

--- a/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
@@ -159,7 +159,6 @@ export const EntityCard = ({
         {entityStarted || entityCompleted || printVersion ? (
           <EntityCardBottomSection
             entityType={entityType}
-            verbiage={verbiage}
             formattedEntityData={{
               ...formattedEntityData,
               isPartiallyComplete: entityStarted && !entityCompleted,

--- a/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
@@ -159,6 +159,7 @@ export const EntityCard = ({
         {entityStarted || entityCompleted || printVersion ? (
           <EntityCardBottomSection
             entityType={entityType}
+            verbiage={verbiage}
             formattedEntityData={{
               ...formattedEntityData,
               isPartiallyComplete: entityStarted && !entityCompleted,

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.test.tsx
@@ -8,10 +8,6 @@ const baseProps = {
     providerDetails: "Extra Details",
   },
   printVersion: true,
-  verbiage: {
-    entityMissingResponseMessage: "Missing message",
-    entityEmptyResponseMessage: "Empty message",
-  },
 };
 
 describe("EntityCardBottomSection", () => {

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { EntityCardBottomSection } from "./EntityCardBottomSection";
+import { EntityType } from "types";
+
+const baseProps = {
+  formattedEntityData: { provider: "TEST", providerDetails: "Extra Details" },
+  printVersion: true,
+  verbiage: {
+    entityMissingResponseMessage: "Missing message",
+    entityEmptyResponseMessage: "Empty message",
+  },
+};
+
+describe("EntityCardBottomSection", () => {
+  test("renders AccessMeasuresSection when entityType is ACCESS_MEASURES", () => {
+    render(
+      <EntityCardBottomSection
+        {...baseProps}
+        entityType={EntityType.ACCESS_MEASURES}
+      />
+    );
+    expect(screen.getByText("C2.V.4 Provider")).toBeInTheDocument();
+  });
+
+  test("renders SanctionsSection when entityType is SANCTIONS", () => {
+    render(
+      <EntityCardBottomSection
+        {...baseProps}
+        entityType={EntityType.SANCTIONS}
+      />
+    );
+    expect(screen.getByText("Sanction details")).toBeInTheDocument();
+  });
+
+  test("renders QualityMeasuresSection when entityType is QUALITY_MEASURES", () => {
+    render(
+      <EntityCardBottomSection
+        {...baseProps}
+        entityType={EntityType.QUALITY_MEASURES}
+      />
+    );
+    expect(screen.getByText("Measure results")).toBeInTheDocument();
+  });
+
+  test("renders StandardsSection when entityType is STANDARDS", () => {
+    render(
+      <EntityCardBottomSection
+        {...baseProps}
+        entityType={EntityType.STANDARDS}
+      />
+    );
+    expect(screen.getByText("Provider type(s)")).toBeInTheDocument();
+  });
+
+  test("renders fallback Text when entityType is unknown", () => {
+    render(
+      <EntityCardBottomSection
+        {...baseProps}
+        entityType={"UNKNOWN_TYPE" as EntityType}
+      />
+    );
+    expect(screen.getByText("UNKNOWN_TYPE")).toBeInTheDocument();
+  });
+});

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.test.tsx
@@ -3,7 +3,10 @@ import { EntityCardBottomSection } from "./EntityCardBottomSection";
 import { EntityType } from "types";
 
 const baseProps = {
-  formattedEntityData: { provider: "TEST", providerDetails: "Extra Details" },
+  formattedEntityData: {
+    provider: "Hospital",
+    providerDetails: "Extra Details",
+  },
   printVersion: true,
   verbiage: {
     entityMissingResponseMessage: "Missing message",

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.tsx
@@ -1,7 +1,11 @@
 // components
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Text } from "@chakra-ui/react";
 // types
 import { AnyObject, EntityType } from "types";
+import { AccessMeasuresSection } from "./AccessMeasuresSection";
+import { QualityMeasuresSection } from "./QualityMeasuresSection";
+import { SanctionsSection } from "./SanctionsSection";
+import { StandardsSection } from "./StandardsSection";
 
 export const EntityCardBottomSection = ({
   entityType,
@@ -30,186 +34,36 @@ export const EntityCardBottomSection = ({
   switch (entityType) {
     case EntityType.ACCESS_MEASURES:
       return (
-        <>
-          <Box
-            sx={sx.highlightContainer}
-            className={
-              !formattedEntityData?.provider ||
-              !formattedEntityData.region ||
-              !formattedEntityData.population
-                ? "error"
-                : ""
-            }
-          >
-            <Flex>
-              <Box sx={sx.highlightSection}>
-                <Text sx={sx.subtitle}>
-                  {`${printVersion ? "C2.V.4 " : ""}Provider`}
-                </Text>
-                <Text sx={sx.subtext}>{providerText()}</Text>
-              </Box>
-              <Box sx={sx.highlightSection}>
-                <Text sx={sx.subtitle}>
-                  {`${printVersion ? "C2.V.5 " : ""}Region`}
-                </Text>
-                <Text sx={sx.subtext}>
-                  {formattedEntityData?.region || (printVersion && notAnswered)}
-                </Text>
-              </Box>
-              <Box sx={sx.highlightSection}>
-                <Text sx={sx.subtitle}>
-                  {`${printVersion ? "C2.V.6 " : ""}Population`}
-                </Text>
-                <Text sx={sx.subtext}>
-                  {formattedEntityData?.population ||
-                    (printVersion && notAnswered)}
-                </Text>
-              </Box>
-            </Flex>
-          </Box>
-          <Text sx={sx.subtitle}>
-            {`${printVersion ? "C2.V.7 " : ""}Monitoring Methods`}
-          </Text>
-          <Text sx={sx.subtext}>
-            {formattedEntityData?.monitoringMethods?.join(", ") ||
-              (printVersion && notAnswered)}
-          </Text>
-          <Text sx={sx.subtitle}>
-            {`${printVersion ? "C2.V.8 " : ""}Frequency of oversight methods`}
-          </Text>
-          <Text sx={sx.subtext}>
-            {formattedEntityData.methodFrequency ||
-              (printVersion && notAnswered)}
-          </Text>
-        </>
+        <AccessMeasuresSection
+          formattedEntityData={formattedEntityData}
+          printVersion={printVersion}
+          notAnswered={notAnswered}
+          providerText={providerText}
+          sx={sx}
+        />
       );
     case EntityType.SANCTIONS:
       return (
-        <>
-          <Text sx={sx.subtitle}>Sanction details</Text>
-          <Box
-            sx={sx.highlightContainer}
-            className={
-              !formattedEntityData?.noncomplianceInstances ||
-              !formattedEntityData?.dollarAmount ||
-              !formattedEntityData?.assessmentDate ||
-              !formattedEntityData?.remediationCompleted ||
-              !formattedEntityData?.correctiveActionPlan
-                ? "error"
-                : ""
-            }
-          >
-            <Flex>
-              <Box sx={sx.highlightSection}>
-                <Text sx={sx.subtitle}>
-                  {`${
-                    printVersion ? "D3.VIII.5 " : ""
-                  }Instances of non-compliance`}
-                </Text>
-                <Text sx={sx.subtext}>
-                  {formattedEntityData?.noncomplianceInstances ||
-                    (printVersion && notAnswered)}
-                </Text>
-              </Box>
-              <Box sx={sx.highlightSection}>
-                <Text sx={sx.subtitle}>
-                  {`${printVersion ? "D3.VIII.6 " : ""}Sanction amount`}
-                </Text>
-                <Text sx={sx.subtext}>
-                  {formattedEntityData?.dollarAmount ||
-                    (printVersion && notAnswered)}
-                </Text>
-              </Box>
-            </Flex>
-            <Flex>
-              <Box sx={sx.highlightSection}>
-                <Text sx={sx.subtitle}>
-                  {`${printVersion ? "D3.VIII.7 " : ""}Date assessed`}
-                </Text>
-                <Text sx={sx.subtext}>
-                  {formattedEntityData?.assessmentDate ||
-                    (printVersion && notAnswered)}
-                </Text>
-              </Box>
-              <Box sx={sx.highlightSection}>
-                <Text sx={sx.subtitle}>
-                  {`${
-                    printVersion ? "D3.VIII.8 " : ""
-                  }Remediation date non-compliance was corrected`}
-                </Text>
-                <Text sx={sx.subtext}>
-                  {[
-                    formattedEntityData?.remediationCompleted,
-                    formattedEntityData?.remediationDate,
-                  ].join(" ") ||
-                    (printVersion && notAnswered)}
-                </Text>
-              </Box>
-            </Flex>
-            <Text sx={sx.subtitle}>
-              {`${printVersion ? "D3.VIII.9 " : ""}Corrective action plan`}
-            </Text>
-            <Text sx={sx.subtext}>
-              {formattedEntityData?.correctiveActionPlan ||
-                (printVersion && notAnswered)}
-            </Text>
-          </Box>
-        </>
+        <SanctionsSection
+          formattedEntityData={formattedEntityData}
+          printVersion={!!printVersion}
+          notAnswered={notAnswered}
+          sx={sx}
+        />
       );
     case EntityType.QUALITY_MEASURES:
       return (
-        <>
-          <Text sx={sx.resultsHeader}>Measure results</Text>
-          {formattedEntityData?.isPartiallyComplete && (
-            <Text sx={sx.missingResponseMessage}>
-              {verbiage?.entityMissingResponseMessage ||
-                (printVersion && notAnswered)}
-            </Text>
-          )}
-          {formattedEntityData?.perPlanResponses?.map(
-            (plan: { name: string; response: string }) => (
-              <Box
-                key={plan.name + plan.response}
-                sx={sx.highlightContainer}
-                className={!plan.response ? "error" : ""}
-              >
-                <Flex>
-                  <Box sx={sx.highlightSection}>
-                    <Text sx={sx.subtitle}>{plan.name}</Text>
-                    {printVersion && !plan.response ? (
-                      notAnswered
-                    ) : (
-                      <Text sx={sx.subtext}>
-                        {plan.response || verbiage?.entityEmptyResponseMessage}
-                      </Text>
-                    )}
-                  </Box>
-                </Flex>
-              </Box>
-            )
-          )}
-        </>
+        <QualityMeasuresSection
+          formattedEntityData={formattedEntityData}
+          printVersion={!!printVersion}
+          notAnswered={notAnswered}
+          verbiage={verbiage}
+          sx={sx}
+        />
       );
     case EntityType.STANDARDS:
       return (
-        <Box sx={{ ...sx.highlightContainer, padding: "0.5rem" }}>
-          <Text sx={{ ...sx.subtitle, marginTop: "0" }}>Provider type(s)</Text>
-          <Text sx={sx.subtext}>{formattedEntityData.provider}</Text>
-          <Flex>
-            <Box sx={sx.standardDetailsBoxes}>
-              <Text sx={sx.subtitle}>Analysis method(s)</Text>
-              <Text sx={sx.subtext}>{formattedEntityData.analysisMethods}</Text>
-            </Box>
-            <Box sx={sx.standardDetailsBoxes}>
-              <Text sx={sx.subtitle}>Region</Text>
-              <Text sx={sx.subtext}>{formattedEntityData.region}</Text>
-            </Box>
-            <Box sx={sx.standardDetailsBoxes}>
-              <Text sx={sx.subtitle}>Population</Text>
-              <Text sx={sx.subtext}>{formattedEntityData.population}</Text>
-            </Box>
-          </Flex>
-        </Box>
+        <StandardsSection formattedEntityData={formattedEntityData} sx={sx} />
       );
     default:
       return <Text>{entityType}</Text>;

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.tsx
@@ -11,6 +11,7 @@ export const EntityCardBottomSection = ({
   entityType,
   formattedEntityData,
   printVersion,
+  verbiage,
 }: Props) => {
   const notAnswered = (
     <Text as="span" sx={sx.notAnswered}>
@@ -56,6 +57,7 @@ export const EntityCardBottomSection = ({
           formattedEntityData={formattedEntityData}
           printVersion={!!printVersion}
           notAnswered={notAnswered}
+          verbiage={verbiage}
           sx={sx}
         />
       );
@@ -72,6 +74,10 @@ interface Props {
   entityType: EntityType;
   formattedEntityData: AnyObject;
   printVersion?: boolean;
+  verbiage?: {
+    entityMissingResponseMessage?: string;
+    entityEmptyResponseMessage?: string;
+  };
 }
 
 const sx = {

--- a/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCardBottomSection.tsx
@@ -1,17 +1,16 @@
 // components
 import { Text } from "@chakra-ui/react";
-// types
-import { AnyObject, EntityType } from "types";
 import { AccessMeasuresSection } from "./AccessMeasuresSection";
 import { QualityMeasuresSection } from "./QualityMeasuresSection";
 import { SanctionsSection } from "./SanctionsSection";
 import { StandardsSection } from "./StandardsSection";
+// types
+import { AnyObject, EntityType } from "types";
 
 export const EntityCardBottomSection = ({
   entityType,
   formattedEntityData,
   printVersion,
-  verbiage,
 }: Props) => {
   const notAnswered = (
     <Text as="span" sx={sx.notAnswered}>
@@ -57,7 +56,6 @@ export const EntityCardBottomSection = ({
           formattedEntityData={formattedEntityData}
           printVersion={!!printVersion}
           notAnswered={notAnswered}
-          verbiage={verbiage}
           sx={sx}
         />
       );
@@ -74,10 +72,6 @@ interface Props {
   entityType: EntityType;
   formattedEntityData: AnyObject;
   printVersion?: boolean;
-  verbiage?: {
-    entityMissingResponseMessage?: string;
-    entityEmptyResponseMessage?: string;
-  };
 }
 
 const sx = {

--- a/services/ui-src/src/components/cards/EntityCard/QualityMeasuresSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/QualityMeasuresSection.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { QualityMeasuresSection } from "./QualityMeasuresSection";
+import { mockNotAnswered } from "utils/testing/mockEntities";
+
+describe("QualityMeasuresSection", () => {
+  test("renders the header", () => {
+    render(
+      <QualityMeasuresSection
+        formattedEntityData={{ perPlanResponses: [] }}
+        printVersion={false}
+        notAnswered={mockNotAnswered}
+        sx={{}}
+      />
+    );
+
+    expect(screen.getByText("Measure results")).toBeInTheDocument();
+  });
+
+  test("renders custom missing response message when provided", () => {
+    render(
+      <QualityMeasuresSection
+        formattedEntityData={{ isPartiallyComplete: true }}
+        printVersion={false}
+        notAnswered={mockNotAnswered}
+        verbiage={{ entityMissingResponseMessage: "Custom missing message" }}
+        sx={{}}
+      />
+    );
+
+    expect(screen.getByText("Custom missing message")).toBeInTheDocument();
+  });
+
+  test("renders plan responses correctly", () => {
+    const data = {
+      perPlanResponses: [
+        { name: "Plan A", response: "Response A" },
+        { name: "Plan B", response: "" },
+        { name: "Plan C", response: "Response C" },
+      ],
+    };
+
+    render(
+      <QualityMeasuresSection
+        formattedEntityData={data}
+        printVersion={false}
+        notAnswered={mockNotAnswered}
+        sx={{}}
+      />
+    );
+
+    // Plan names rendered
+    expect(screen.getByText("Plan A")).toBeInTheDocument();
+    expect(screen.getByText("Plan B")).toBeInTheDocument();
+    expect(screen.getByText("Plan C")).toBeInTheDocument();
+
+    // Responses rendered or empty message
+    expect(screen.getByText("Response A")).toBeInTheDocument();
+    expect(screen.getByText("Response C")).toBeInTheDocument();
+
+    const planBResponse = screen.getAllByText("", { exact: true })[0];
+    expect(planBResponse).toBeInTheDocument();
+
+    // 'error' class applied to plan with empty response
+    const errorContainers = document.querySelectorAll(".error");
+    expect(errorContainers.length).toBe(1);
+  });
+
+  test("shows notAnswered placeholder when printVersion is true and response is missing", () => {
+    const data = {
+      perPlanResponses: [
+        { name: "Plan A", response: "" },
+        { name: "Plan B", response: "Some response" },
+      ],
+    };
+
+    render(
+      <QualityMeasuresSection
+        formattedEntityData={data}
+        printVersion={true}
+        notAnswered={mockNotAnswered}
+        sx={{}}
+      />
+    );
+
+    expect(screen.getByTestId("not-answered")).toBeInTheDocument();
+    expect(screen.getByText("Some response")).toBeInTheDocument();
+  });
+
+  test("renders entityEmptyResponseMessage when response is empty and printVersion is false", () => {
+    const data = {
+      perPlanResponses: [{ name: "Plan A", response: "" }],
+    };
+
+    render(
+      <QualityMeasuresSection
+        formattedEntityData={data}
+        printVersion={false}
+        notAnswered={mockNotAnswered}
+        verbiage={{ entityEmptyResponseMessage: "No response provided" }}
+        sx={{}}
+      />
+    );
+
+    expect(screen.getByText("No response provided")).toBeInTheDocument();
+  });
+});

--- a/services/ui-src/src/components/cards/EntityCard/QualityMeasuresSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/QualityMeasuresSection.test.tsx
@@ -2,17 +2,20 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { QualityMeasuresSection } from "./QualityMeasuresSection";
 import { mockNotAnswered } from "utils/testing/mockEntities";
+import { testA11y } from "utils/testing/commonTests";
+
+const qualityMeasuresSectionComponent = (
+  <QualityMeasuresSection
+    formattedEntityData={{ perPlanResponses: [] }}
+    printVersion={false}
+    notAnswered={mockNotAnswered}
+    sx={{}}
+  />
+);
 
 describe("QualityMeasuresSection", () => {
   test("renders the header", () => {
-    render(
-      <QualityMeasuresSection
-        formattedEntityData={{ perPlanResponses: [] }}
-        printVersion={false}
-        notAnswered={mockNotAnswered}
-        sx={{}}
-      />
-    );
+    render(qualityMeasuresSectionComponent);
 
     expect(screen.getByText("Measure results")).toBeInTheDocument();
   });
@@ -101,4 +104,6 @@ describe("QualityMeasuresSection", () => {
 
     expect(screen.getByText("No response provided")).toBeInTheDocument();
   });
+
+  testA11y(qualityMeasuresSectionComponent);
 });

--- a/services/ui-src/src/components/cards/EntityCard/QualityMeasuresSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/QualityMeasuresSection.test.tsx
@@ -49,19 +49,16 @@ describe("QualityMeasuresSection", () => {
       />
     );
 
-    // Plan names rendered
     expect(screen.getByText("Plan A")).toBeInTheDocument();
     expect(screen.getByText("Plan B")).toBeInTheDocument();
     expect(screen.getByText("Plan C")).toBeInTheDocument();
-
-    // Responses rendered or empty message
     expect(screen.getByText("Response A")).toBeInTheDocument();
     expect(screen.getByText("Response C")).toBeInTheDocument();
 
     const planBResponse = screen.getAllByText("", { exact: true })[0];
     expect(planBResponse).toBeInTheDocument();
 
-    // 'error' class applied to plan with empty response
+    // 'error' class is on plan with empty response
     const errorContainers = document.querySelectorAll(".error");
     expect(errorContainers.length).toBe(1);
   });
@@ -83,7 +80,7 @@ describe("QualityMeasuresSection", () => {
       />
     );
 
-    expect(screen.getByTestId("not-answered")).toBeInTheDocument();
+    expect(screen.getByText("Not answered")).toBeInTheDocument();
     expect(screen.getByText("Some response")).toBeInTheDocument();
   });
 

--- a/services/ui-src/src/components/cards/EntityCard/QualityMeasuresSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/QualityMeasuresSection.tsx
@@ -1,0 +1,65 @@
+import { ReactNode } from "react";
+import { Box, Flex, Text } from "@chakra-ui/react";
+import { SxObject } from "types";
+
+export const QualityMeasuresSection = ({
+  formattedEntityData,
+  printVersion,
+  notAnswered,
+  verbiage,
+  sx,
+}: Props) => {
+  return (
+    <>
+      <Text sx={sx.resultsHeader}>Measure results</Text>
+
+      {formattedEntityData?.isPartiallyComplete && (
+        <Text sx={sx.missingResponseMessage}>
+          {verbiage?.entityMissingResponseMessage ||
+            (printVersion && notAnswered)}
+        </Text>
+      )}
+
+      {formattedEntityData?.perPlanResponses?.map((plan) => (
+        <Box
+          key={plan.name + plan.response}
+          sx={sx.highlightContainer}
+          className={!plan.response ? "error" : ""}
+        >
+          <Flex>
+            <Box sx={sx.highlightSection}>
+              <Text sx={sx.subtitle}>{plan.name}</Text>
+
+              {printVersion && !plan.response ? (
+                notAnswered
+              ) : (
+                <Text sx={sx.subtext}>
+                  {plan.response || verbiage?.entityEmptyResponseMessage}
+                </Text>
+              )}
+            </Box>
+          </Flex>
+        </Box>
+      ))}
+    </>
+  );
+};
+
+interface PlanResponse {
+  name: string;
+  response: string;
+}
+
+interface Props {
+  formattedEntityData: {
+    isPartiallyComplete?: boolean;
+    perPlanResponses?: PlanResponse[];
+  };
+  printVersion: boolean;
+  notAnswered: ReactNode;
+  verbiage?: {
+    entityMissingResponseMessage?: string;
+    entityEmptyResponseMessage?: string;
+  };
+  sx: SxObject;
+}

--- a/services/ui-src/src/components/cards/EntityCard/SanctionsSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/SanctionsSection.test.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { SanctionsSection } from "./SanctionsSection";
+import {
+  mockNotAnswered,
+  mockSanctionsFullData,
+  mockSanctionsPartialData,
+} from "utils/testing/mockEntities";
+
+describe("SanctionsSection", () => {
+  test("renders all labels without version numbers when printVersion is false", () => {
+    render(
+      <SanctionsSection
+        formattedEntityData={mockSanctionsFullData}
+        printVersion={false}
+        notAnswered={mockNotAnswered}
+        sx={{}}
+      />
+    );
+
+    const labels = [
+      "Sanction details",
+      "Instances of non-compliance",
+      "Sanction amount",
+      "Date assessed",
+      "Remediation date non-compliance was corrected",
+      "Corrective action plan",
+    ];
+
+    labels.forEach((label) => {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("$5,000")).toBeInTheDocument();
+    expect(screen.getByText("2025-05-01")).toBeInTheDocument();
+    expect(screen.getByText("Yes 2025-06-01")).toBeInTheDocument();
+    expect(screen.getByText("Plan A")).toBeInTheDocument();
+  });
+
+  test("prefixes labels when printVersion is true", () => {
+    render(
+      <SanctionsSection
+        formattedEntityData={mockSanctionsFullData}
+        printVersion={true}
+        notAnswered={mockNotAnswered}
+        sx={{}}
+      />
+    );
+
+    const versionedLabels = [
+      "D3.VIII.5 Instances of non-compliance",
+      "D3.VIII.6 Sanction amount",
+      "D3.VIII.7 Date assessed",
+      "D3.VIII.8 Remediation date non-compliance was corrected",
+      "D3.VIII.9 Corrective action plan",
+    ];
+
+    versionedLabels.forEach((label) => {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    });
+  });
+
+  test("shows 'notAnswered' for missing fields when printVersion is true", () => {
+    render(
+      <SanctionsSection
+        formattedEntityData={mockSanctionsPartialData}
+        printVersion={true}
+        notAnswered={mockNotAnswered}
+        sx={{}}
+      />
+    );
+
+    const notAnsweredEls = screen.getAllByTestId("not-answered");
+    expect(notAnsweredEls.length).toBeGreaterThan(0);
+  });
+
+  test("adds 'error' class when required fields are missing", () => {
+    const { container } = render(
+      <SanctionsSection
+        formattedEntityData={mockSanctionsPartialData}
+        printVersion={false}
+        notAnswered={mockNotAnswered}
+        sx={{}}
+      />
+    );
+
+    const errorBox = container.querySelector(".error");
+    expect(errorBox).toBeInTheDocument();
+  });
+
+  test("does NOT add 'error' class when all required fields are present", () => {
+    const { container } = render(
+      <SanctionsSection
+        formattedEntityData={mockSanctionsFullData}
+        printVersion={false}
+        notAnswered={mockNotAnswered}
+        sx={{}}
+      />
+    );
+
+    const errorBox = container.querySelector(".error");
+    expect(errorBox).not.toBeInTheDocument();
+  });
+});

--- a/services/ui-src/src/components/cards/EntityCard/SanctionsSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/SanctionsSection.test.tsx
@@ -6,17 +6,20 @@ import {
   mockSanctionsFullData,
   mockSanctionsPartialData,
 } from "utils/testing/mockEntities";
+import { testA11y } from "utils/testing/commonTests";
+
+const SanctionsSectionComponentFullData = (
+  <SanctionsSection
+    formattedEntityData={mockSanctionsFullData}
+    printVersion={false}
+    notAnswered={mockNotAnswered}
+    sx={{}}
+  />
+);
 
 describe("SanctionsSection", () => {
   test("renders all labels without version numbers when printVersion is false", () => {
-    render(
-      <SanctionsSection
-        formattedEntityData={mockSanctionsFullData}
-        printVersion={false}
-        notAnswered={mockNotAnswered}
-        sx={{}}
-      />
-    );
+    render(SanctionsSectionComponentFullData);
 
     const labels = [
       "Sanction details",
@@ -90,16 +93,11 @@ describe("SanctionsSection", () => {
   });
 
   test("does NOT add 'error' class when all required fields are present", () => {
-    const { container } = render(
-      <SanctionsSection
-        formattedEntityData={mockSanctionsFullData}
-        printVersion={false}
-        notAnswered={mockNotAnswered}
-        sx={{}}
-      />
-    );
+    const { container } = render(SanctionsSectionComponentFullData);
 
     const errorBox = container.querySelector(".error");
     expect(errorBox).not.toBeInTheDocument();
   });
+
+  testA11y(SanctionsSectionComponentFullData);
 });

--- a/services/ui-src/src/components/cards/EntityCard/SanctionsSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/SanctionsSection.tsx
@@ -1,0 +1,99 @@
+import { ReactNode } from "react";
+import { Box, Flex, Text } from "@chakra-ui/react";
+import { SxObject } from "types";
+
+export const SanctionsSection = ({
+  formattedEntityData,
+  printVersion,
+  notAnswered,
+  sx,
+}: Props) => {
+  const {
+    noncomplianceInstances,
+    dollarAmount,
+    assessmentDate,
+    remediationCompleted,
+    remediationDate,
+    correctiveActionPlan,
+  } = formattedEntityData;
+
+  const isError =
+    !noncomplianceInstances ||
+    !dollarAmount ||
+    !assessmentDate ||
+    !remediationCompleted ||
+    !correctiveActionPlan;
+
+  return (
+    <>
+      <Text sx={sx.subtitle}>Sanction details</Text>
+
+      <Box sx={sx.highlightContainer} className={isError ? "error" : ""}>
+        <Flex>
+          <Box sx={sx.highlightSection}>
+            <Text sx={sx.subtitle}>
+              {`${printVersion ? "D3.VIII.5 " : ""}Instances of non-compliance`}
+            </Text>
+            <Text sx={sx.subtext}>
+              {noncomplianceInstances || (printVersion && notAnswered)}
+            </Text>
+          </Box>
+
+          <Box sx={sx.highlightSection}>
+            <Text sx={sx.subtitle}>
+              {`${printVersion ? "D3.VIII.6 " : ""}Sanction amount`}
+            </Text>
+            <Text sx={sx.subtext}>
+              {dollarAmount || (printVersion && notAnswered)}
+            </Text>
+          </Box>
+        </Flex>
+
+        <Flex>
+          <Box sx={sx.highlightSection}>
+            <Text sx={sx.subtitle}>
+              {`${printVersion ? "D3.VIII.7 " : ""}Date assessed`}
+            </Text>
+            <Text sx={sx.subtext}>
+              {assessmentDate || (printVersion && notAnswered)}
+            </Text>
+          </Box>
+
+          <Box sx={sx.highlightSection}>
+            <Text sx={sx.subtitle}>
+              {`${
+                printVersion ? "D3.VIII.8 " : ""
+              }Remediation date non-compliance was corrected`}
+            </Text>
+            <Text sx={sx.subtext}>
+              {remediationCompleted || remediationDate
+                ? `${remediationCompleted || ""} ${remediationDate || ""}`
+                : printVersion && notAnswered}
+            </Text>
+          </Box>
+        </Flex>
+
+        <Text sx={sx.subtitle}>
+          {`${printVersion ? "D3.VIII.9 " : ""}Corrective action plan`}
+        </Text>
+        <Text sx={sx.subtext}>
+          {correctiveActionPlan || (printVersion && notAnswered)}
+        </Text>
+      </Box>
+    </>
+  );
+};
+
+interface Props {
+  formattedEntityData: {
+    noncomplianceInstances?: string;
+    dollarAmount?: string;
+    assessmentDate?: string;
+    remediationCompleted?: string;
+    remediationDate?: string;
+    correctiveActionPlan?: string;
+  };
+  printVersion: boolean;
+  notAnswered: ReactNode;
+  sx: SxObject;
+}

--- a/services/ui-src/src/components/cards/EntityCard/StandardsSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/StandardsSection.test.tsx
@@ -34,11 +34,14 @@ describe("StandardsSection", () => {
 
   test("handles missing optional fields gracefully", () => {
     render(
-      <StandardsSection formattedEntityData={{ provider: "Clinic" }} sx={{}} />
+      <StandardsSection
+        formattedEntityData={{ provider: "Physician" }}
+        sx={{}}
+      />
     );
 
     expect(screen.getByText("Provider type(s)")).toBeInTheDocument();
-    expect(screen.getByText("Clinic")).toBeInTheDocument();
+    expect(screen.getByText("Physician")).toBeInTheDocument();
     // Missing fields shouldn't throw errors, and should not render values
     expect(screen.queryByText("Quantitative")).not.toBeInTheDocument();
     expect(screen.queryByText("North")).not.toBeInTheDocument();

--- a/services/ui-src/src/components/cards/EntityCard/StandardsSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/StandardsSection.test.tsx
@@ -35,13 +35,13 @@ describe("StandardsSection", () => {
   test("handles missing optional fields gracefully", () => {
     render(
       <StandardsSection
-        formattedEntityData={{ provider: "Physician" }}
+        formattedEntityData={{ provider: "Hospital" }}
         sx={{}}
       />
     );
 
     expect(screen.getByText("Provider type(s)")).toBeInTheDocument();
-    expect(screen.getByText("Physician")).toBeInTheDocument();
+    expect(screen.getByText("Hospital")).toBeInTheDocument();
     // Missing fields shouldn't throw errors, and should not render values
     expect(screen.queryByText("Quantitative")).not.toBeInTheDocument();
     expect(screen.queryByText("North")).not.toBeInTheDocument();

--- a/services/ui-src/src/components/cards/EntityCard/StandardsSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/StandardsSection.test.tsx
@@ -2,12 +2,14 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { StandardsSection } from "./StandardsSection";
 import { mockStandardsFullData } from "utils/testing/mockEntities";
+import { testA11y } from "utils/testing/commonTests";
 
+const standardsSectionComponent = (
+  <StandardsSection formattedEntityData={mockStandardsFullData} sx={{}} />
+);
 describe("StandardsSection", () => {
   test("renders all labels", () => {
-    render(
-      <StandardsSection formattedEntityData={mockStandardsFullData} sx={{}} />
-    );
+    render(standardsSectionComponent);
 
     const labels = [
       "Provider type(s)",
@@ -22,9 +24,7 @@ describe("StandardsSection", () => {
   });
 
   test("renders all values from formattedEntityData", () => {
-    render(
-      <StandardsSection formattedEntityData={mockStandardsFullData} sx={{}} />
-    );
+    render(standardsSectionComponent);
 
     expect(screen.getByText("Hospital")).toBeInTheDocument();
     expect(screen.getByText("Quantitative")).toBeInTheDocument();
@@ -47,4 +47,6 @@ describe("StandardsSection", () => {
     expect(screen.queryByText("North")).not.toBeInTheDocument();
     expect(screen.queryByText("Urban")).not.toBeInTheDocument();
   });
+
+  testA11y(standardsSectionComponent);
 });

--- a/services/ui-src/src/components/cards/EntityCard/StandardsSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/StandardsSection.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { StandardsSection } from "./StandardsSection";
+import { mockStandardsFullData } from "utils/testing/mockEntities";
+
+describe("StandardsSection", () => {
+  test("renders all labels", () => {
+    render(
+      <StandardsSection formattedEntityData={mockStandardsFullData} sx={{}} />
+    );
+
+    const labels = [
+      "Provider type(s)",
+      "Analysis method(s)",
+      "Region",
+      "Population",
+    ];
+
+    labels.forEach((label) => {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    });
+  });
+
+  test("renders all values from formattedEntityData", () => {
+    render(
+      <StandardsSection formattedEntityData={mockStandardsFullData} sx={{}} />
+    );
+
+    expect(screen.getByText("Hospital")).toBeInTheDocument();
+    expect(screen.getByText("Quantitative")).toBeInTheDocument();
+    expect(screen.getByText("North")).toBeInTheDocument();
+    expect(screen.getByText("Urban")).toBeInTheDocument();
+  });
+
+  test("handles missing optional fields gracefully", () => {
+    render(
+      <StandardsSection formattedEntityData={{ provider: "Clinic" }} sx={{}} />
+    );
+
+    expect(screen.getByText("Provider type(s)")).toBeInTheDocument();
+    expect(screen.getByText("Clinic")).toBeInTheDocument();
+    // Missing fields shouldn't throw errors, and should not render values
+    expect(screen.queryByText("Quantitative")).not.toBeInTheDocument();
+    expect(screen.queryByText("North")).not.toBeInTheDocument();
+    expect(screen.queryByText("Urban")).not.toBeInTheDocument();
+  });
+});

--- a/services/ui-src/src/components/cards/EntityCard/StandardsSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/StandardsSection.tsx
@@ -1,0 +1,38 @@
+import { Box, Flex, Text } from "@chakra-ui/react";
+import { SxObject } from "types";
+
+export const StandardsSection = ({ formattedEntityData, sx }: Props) => {
+  return (
+    <Box sx={{ ...sx.highlightContainer, padding: "0.5rem" }}>
+      <Text sx={{ ...sx.subtitle, marginTop: "0" }}>Provider type(s)</Text>
+      <Text sx={sx.subtext}>{formattedEntityData.provider}</Text>
+
+      <Flex>
+        <Box sx={sx.standardDetailsBoxes}>
+          <Text sx={sx.subtitle}>Analysis method(s)</Text>
+          <Text sx={sx.subtext}>{formattedEntityData.analysisMethods}</Text>
+        </Box>
+
+        <Box sx={sx.standardDetailsBoxes}>
+          <Text sx={sx.subtitle}>Region</Text>
+          <Text sx={sx.subtext}>{formattedEntityData.region}</Text>
+        </Box>
+
+        <Box sx={sx.standardDetailsBoxes}>
+          <Text sx={sx.subtitle}>Population</Text>
+          <Text sx={sx.subtext}>{formattedEntityData.population}</Text>
+        </Box>
+      </Flex>
+    </Box>
+  );
+};
+
+interface Props {
+  formattedEntityData: {
+    provider?: string;
+    analysisMethods?: string;
+    region?: string;
+    population?: string;
+  };
+  sx: SxObject;
+}

--- a/services/ui-src/src/utils/testing/mockEntities.tsx
+++ b/services/ui-src/src/utils/testing/mockEntities.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+import { Text } from "@chakra-ui/react";
 import { EntityShape } from "types";
 
 export const mockAccessMeasuresEntity = {
@@ -227,3 +229,32 @@ export const mockNaaarStandards: EntityShape[] = [
     "standard_applicableRegion-otherText": "Mock Other Region",
   },
 ];
+
+export const mockSanctionsFullData = {
+  noncomplianceInstances: "2",
+  dollarAmount: "$5,000",
+  assessmentDate: "2025-05-01",
+  remediationCompleted: "Yes",
+  remediationDate: "2025-06-01",
+  correctiveActionPlan: "Plan A",
+};
+
+export const mockSanctionsPartialData = {
+  dollarAmount: "$5,000",
+  assessmentDate: "2025-05-01",
+  remediationCompleted: "",
+  remediationDate: "",
+};
+
+export const mockStandardsFullData = {
+  provider: "Hospital",
+  analysisMethods: "Quantitative",
+  region: "North",
+  population: "Urban",
+};
+
+export const mockNotAnswered = (
+  <Text as="span" data-testid="not-answered">
+    Not answered
+  </Text>
+);


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

Refactor of the switch statement in `EntityCardBottomSection` so that each entity is pulled into its own component. Also includes tests.

### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-5193
CMDCT-5200
CMDCT-5201
CMDCT-5202

---

### How to test

https://dk3rivcj9t78r.cloudfront.net/
Access Measures, Sanctions, and Quality Measures are all in the MCPAR report (both the report and the PDF). Standards are in the NAAAR, you'll see them in this card version in the PDF

### Notes

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->

_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
