### PR TITLE
CMDCT-5253: Replace all instances of BOOTSTRAP_BROKER_STRING_TLS with brokerString

### DIFF
--- a/deployment/stacks/api.ts
+++ b/deployment/stacks/api.ts
@@ -111,7 +111,7 @@ export function createApiComponents(props: CreateApiComponentsProps) {
 
   const environment = {
     NODE_OPTIONS: "--enable-source-maps",
-    BOOTSTRAP_BROKER_STRING_TLS: brokerString,
+    brokerString: brokerString,
     STAGE: stage,
     MCPAR_FORM_BUCKET: mcparFormBucket.bucketName,
     MLR_FORM_BUCKET: mlrFormBucket.bucketName,

--- a/deployment/stacks/api.ts
+++ b/deployment/stacks/api.ts
@@ -111,7 +111,7 @@ export function createApiComponents(props: CreateApiComponentsProps) {
 
   const environment = {
     NODE_OPTIONS: "--enable-source-maps",
-    brokerString: brokerString,
+    brokerString,
     STAGE: stage,
     MCPAR_FORM_BUCKET: mcparFormBucket.bucketName,
     MLR_FORM_BUCKET: mlrFormBucket.bucketName,

--- a/services/app-api/utils/kafka/kafka-source-lib.test.ts
+++ b/services/app-api/utils/kafka/kafka-source-lib.test.ts
@@ -144,16 +144,16 @@ describe("Test Kafka Lib", () => {
   beforeAll(() => {
     tempStage = process.env.stage;
     tempNamespace = process.env.topicNamespace;
-    tempBrokers = process.env.BOOTSTRAP_BROKER_STRING_TLS;
+    tempBrokers = process.env.brokerString;
 
     process.env.stage = stage;
     process.env.topicNamespace = namespace;
-    process.env.BOOTSTRAP_BROKER_STRING_TLS = brokerString;
+    process.env.brokerString = brokerString;
   });
   afterAll(() => {
     process.env.stage = tempStage;
     process.env.topicNamespace = tempNamespace;
-    process.env.BOOTSTRAP_BROKER_STRING_TLS = tempBrokers;
+    process.env.brokerString = tempBrokers;
   });
 
   beforeEach(() => {
@@ -250,7 +250,7 @@ describe("Test Kafka Lib", () => {
   });
 
   test("Skips handler in local environment", async () => {
-    process.env.BOOTSTRAP_BROKER_STRING_TLS = "localstack";
+    process.env.brokerString = "localstack";
 
     const sourceLib = new KafkaSourceLib("mcr", "v0", [table], [bucket]);
     await sourceLib.handler(dynamoEvent);
@@ -259,7 +259,7 @@ describe("Test Kafka Lib", () => {
   });
 
   test("Throws error for missing broker string", () => {
-    delete process.env.BOOTSTRAP_BROKER_STRING_TLS;
+    delete process.env.brokerString;
 
     expect(() => {
       new KafkaSourceLib("mcr", "v0", [table], [bucket]);

--- a/services/app-api/utils/kafka/kafka-source-lib.ts
+++ b/services/app-api/utils/kafka/kafka-source-lib.ts
@@ -55,7 +55,7 @@ class KafkaSourceLib {
     tables: SourceTopicMapping[],
     buckets: SourceBucketTopicMapping[]
   ) {
-    if (!process.env.BOOTSTRAP_BROKER_STRING_TLS) {
+    if (!process.env.brokerString) {
       throw new Error("Missing Broker Config. ");
     }
     // Setup vars
@@ -68,7 +68,7 @@ class KafkaSourceLib {
     this.tables = tables;
     this.buckets = buckets;
 
-    const brokerStrings = process.env.BOOTSTRAP_BROKER_STRING_TLS;
+    const brokerStrings = process.env.brokerString;
     kafka = new Kafka({
       clientId: `mcr-${this.stage}`,
       brokers: brokerStrings!.split(","),
@@ -213,7 +213,7 @@ class KafkaSourceLib {
   }
 
   async handler(event: any) {
-    if (process.env.BOOTSTRAP_BROKER_STRING_TLS === "localstack") {
+    if (process.env.brokerString === "localstack") {
       return;
     }
 


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

CMDCT-5253: Replace all instances of BOOTSTRAP_BROKER_STRING_TLS with brokerString

### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-5253

---

### How to test

<!-- Step-by-step instructions on how to test, if necessary -->

### Notes

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->

_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
