### PR TITLE
Safeguard for undefined values

### DIFF
--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -393,7 +393,7 @@ export const getNestedIlosResponses = (
 };
 
 export const getNestedAnalysisMethodsResponses = (entity: EntityShape) => {
-  const frequencyVal = entity.analysis_method_frequency[0].value;
+  const frequencyVal = entity.analysis_method_frequency?.[0]?.value;
   const frequency = otherSpecify(
     frequencyVal,
     entity["analysis_method_frequency-otherText"]
@@ -401,7 +401,7 @@ export const getNestedAnalysisMethodsResponses = (entity: EntityShape) => {
 
   const plans = entity?.analysis_method_applicable_plans;
   const utilizedPlans = plans
-    .map((entity: AnyObject) => entity.value)
+    ?.map((entity: AnyObject) => entity.value)
     .join(", ");
 
   const response = [


### PR DESCRIPTION
### Description
Hot fix for production issue where a user could not access the `/naaar/export` page because of an undefined value for analysis_method_frequency, causing the page to fail to render.

<img width="1034" height="188" alt="Screenshot 2025-10-07 at 10 47 56 AM" src="https://github.com/user-attachments/assets/6ce17810-d5eb-4542-8b60-edfaaa52eedd" />
