### PR TITLE
[CMDCT-5446]: Disabling fields if user checks not reporting

### DIFF
--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -2,7 +2,7 @@ import { ReactNode, useContext, useEffect, useState } from "react";
 import { FieldValues, useFormContext, UseFormReturn } from "react-hook-form";
 // components
 import { ChoiceList as CmsdsChoiceList } from "@cmsgov/design-system";
-import { Box, SystemStyleObject } from "@chakra-ui/react";
+import { Box, SystemStyleObject, Text } from "@chakra-ui/react";
 import { ReportContext, EntityContext } from "components";
 // types
 import {
@@ -35,6 +35,9 @@ export const ChoiceListField = ({
   sxOverride,
   styleAsOptional,
   clear,
+  disabledStateMessage,
+  disabledStateMessageId,
+  showDisabledStateMessage,
   ...props
 }: Props) => {
   const defaultValue: Choice[] = [];
@@ -316,6 +319,12 @@ export const ChoiceListField = ({
         onComponentBlur={onComponentBlurHandler}
         {...props}
       />
+
+      {showDisabledStateMessage && disabledStateMessageId && (
+        <Text id={disabledStateMessageId} sx={sx.disabledStateMessage}>
+          {disabledStateMessage}
+        </Text>
+      )}
     </Box>
   );
 };
@@ -332,6 +341,9 @@ interface Props {
   sxOverride?: SystemStyleObject;
   styleAsOptional?: boolean;
   clear?: boolean;
+  disabledStateMessage?: string;
+  disabledStateMessageId?: string;
+  showDisabledStateMessage?: boolean;
   [key: string]: any;
 }
 
@@ -342,6 +354,12 @@ const sx = {
   },
   ".ds-c-choice[type='checkbox']:checked:disabled::before": {
     boxShadow: "inset 0 0 4em 1em #A6A6A6;",
+  },
+
+  disabledStateMessage: {
+    marginTop: "spacer1",
+    fontSize: "sm",
+    color: "gray",
   },
 };
 

--- a/services/ui-src/src/components/forms/Form.test.tsx
+++ b/services/ui-src/src/components/forms/Form.test.tsx
@@ -125,4 +125,115 @@ describe("<Form />", () => {
   });
 
   testA11yAct(formComponent);
+
+  test("Selecting Not reporting + reason disables subsequent fields and wires aria-describedby", async () => {
+    mockedUseStore.mockReturnValue({
+      ...mockStateUserStore,
+      ...mockMcparReportStore,
+      report: {
+        ...(mockMcparReportStore as any).report,
+        status: ReportStatus.NOT_STARTED,
+      },
+    } as any);
+
+    const notReportingForm = {
+      id: "not-reporting-form",
+      fields: [
+        {
+          id: "measure_isReporting",
+          type: "checkbox",
+          validation: "checkboxOptional",
+          props: {
+            label: "D2.VII.6 Are you reporting results for this measure?",
+            choices: [
+              {
+                id: "37sMoqg5MNOb17KDCpTO1w",
+                label: "Not reporting",
+                children: [
+                  {
+                    id: "measure_isNotReportingReason",
+                    type: "radio",
+                    validation: {
+                      type: "radio",
+                      nested: true,
+                      parentFieldName: "measure_isReporting",
+                      parentOptionId: "37sMoqg5MNOb17KDCpTO1w",
+                    },
+                    props: {
+                      label: "Reason",
+                      choices: [
+                        { id: "reason1", label: "Reason 1" },
+                        { id: "reason2", label: "Reason 2" },
+                      ],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          id: "after_field",
+          type: "dropdown",
+          validation: "dropdown",
+          props: {
+            label: "After field",
+            options: [
+              { label: "Option A", value: "A" },
+              { label: "Option B", value: "B" },
+            ],
+          },
+        },
+      ],
+    } as any;
+
+    render(
+      <RouterWrappedComponent>
+        <Form
+          id={notReportingForm.id}
+          formJson={notReportingForm}
+          onSubmit={mockOnSubmit}
+          validateOnRender={false}
+          dontReset={false}
+        />
+      </RouterWrappedComponent>
+    );
+
+    const afterField = screen.getByLabelText(
+      "After field"
+    ) as HTMLSelectElement;
+    expect(afterField).toBeEnabled();
+
+    // Select Not reporting (child reason appears)
+    await act(async () => {
+      await userEvent.click(screen.getByLabelText("Not reporting"));
+    });
+    expect(afterField).toBeEnabled();
+
+    // Select a reason; now subsequent fields should disable
+    await act(async () => {
+      await userEvent.click(screen.getByLabelText("Reason 1"));
+    });
+
+    const disabledReasonId = `${notReportingForm.id}-not-reporting-disabled-reason`;
+    expect(
+      screen.getByText("Fields disabled because Not Reporting is selected")
+    ).toBeVisible();
+    expect(afterField).toBeDisabled();
+    expect(afterField.getAttribute("aria-describedby")).toContain(
+      disabledReasonId
+    );
+
+    // Child reason should NOT be disabled
+    expect(screen.getByLabelText("Reason 1")).toBeEnabled();
+
+    // Uncheck Not reporting; subsequent fields should enable again and message should disappear
+    await act(async () => {
+      await userEvent.click(screen.getByLabelText("Not reporting"));
+    });
+    expect(afterField).toBeEnabled();
+    expect(
+      screen.queryByText("Fields disabled because Not Reporting is selected")
+    ).toBeNull();
+  });
 });

--- a/services/ui-src/src/components/forms/Form.test.tsx
+++ b/services/ui-src/src/components/forms/Form.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 // components
 import { Form } from "components";
@@ -204,6 +204,12 @@ describe("<Form />", () => {
     ) as HTMLSelectElement;
     expect(afterField).toBeEnabled();
 
+    // User enters a value in a subsequent field first.
+    await act(async () => {
+      await userEvent.selectOptions(afterField, "B");
+    });
+    expect(afterField.value).toBe("B");
+
     // Select Not reporting (child reason appears)
     await act(async () => {
       await userEvent.click(screen.getByLabelText("Not reporting"));
@@ -215,12 +221,24 @@ describe("<Form />", () => {
       await userEvent.click(screen.getByLabelText("Reason 1"));
     });
 
+    // Subsequent fields should be cleared when disabled.
+    // The Form forces a remount of the field subtree, so re-query the element.
+    await waitFor(() => {
+      const currentAfterField = screen.getByLabelText(
+        "After field"
+      ) as HTMLSelectElement;
+      expect(currentAfterField.value).toBe("");
+    });
+
     const disabledReasonId = `${notReportingForm.id}-not-reporting-disabled-reason`;
     expect(
       screen.getByText("Fields disabled because Not Reporting is selected")
     ).toBeVisible();
-    expect(afterField).toBeDisabled();
-    expect(afterField.getAttribute("aria-describedby")).toContain(
+    const currentAfterField = screen.getByLabelText(
+      "After field"
+    ) as HTMLSelectElement;
+    expect(currentAfterField).toBeDisabled();
+    expect(currentAfterField.getAttribute("aria-describedby")).toContain(
       disabledReasonId
     );
 
@@ -231,7 +249,9 @@ describe("<Form />", () => {
     await act(async () => {
       await userEvent.click(screen.getByLabelText("Not reporting"));
     });
-    expect(afterField).toBeEnabled();
+    expect(
+      screen.getByLabelText("After field") as HTMLSelectElement
+    ).toBeEnabled();
     expect(
       screen.queryByText("Fields disabled because Not Reporting is selected")
     ).toBeNull();

--- a/services/ui-src/src/components/forms/Form.test.tsx
+++ b/services/ui-src/src/components/forms/Form.test.tsx
@@ -210,7 +210,7 @@ describe("<Form />", () => {
     });
     expect(afterField).toBeEnabled();
 
-    // Select a reason; now subsequent fields should disable
+    // Select a reason so subsequent fields disable
     await act(async () => {
       await userEvent.click(screen.getByLabelText("Reason 1"));
     });
@@ -227,7 +227,7 @@ describe("<Form />", () => {
     // Child reason should NOT be disabled
     expect(screen.getByLabelText("Reason 1")).toBeEnabled();
 
-    // Uncheck Not reporting; subsequent fields should enable again and message should disappear
+    // Uncheck Not reporting so subsequent fields enable again with the message disappearing
     await act(async () => {
       await userEvent.click(screen.getByLabelText("Not reporting"));
     });

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -26,112 +26,14 @@ import {
   formFieldFactory,
   hydrateFormFields,
   mapValidationTypesToSchema,
+  NOT_REPORTING_FIELD_ID,
+  NOT_REPORTING_REASON_FIELD_ID,
+  applyDisableAfterField,
+  hasSelectedOption,
+  isNotReportingSelected,
   sortFormErrors,
   useStore,
 } from "utils";
-
-const NOT_REPORTING_OPTION_ID = "37sMoqg5MNOb17KDCpTO1w";
-const NOT_REPORTING_FIELD_ID = "measure_isReporting";
-const NOT_REPORTING_REASON_FIELD_ID = "measure_isNotReportingReason";
-
-const mergeAriaDescribedBy = (
-  toAdd: string,
-  existing?: string
-): string | undefined => {
-  /*
-   * Our fields may already have an aria-describedby attribute with one or more IDs.
-   * We want to merge in the new ID without creating duplicates and while preserving
-   * any existing IDs. This function takes the existing aria-describedby value and
-   * the new ID to add, and returns a merged string of IDs.
-   */
-  const existingStr = typeof existing === "string" ? existing.trim() : "";
-  const existingIds = existingStr ? existingStr.split(/\s+/) : [];
-  const ids = new Set([...existingIds, toAdd]);
-  const merged = [...ids].join(" ").trim();
-  return merged.length > 0 ? merged : undefined;
-};
-
-const isNotReportingSelected = (value: unknown): boolean => {
-  if (!Array.isArray(value)) return false;
-  return value.some((opt: any) => {
-    const key = opt?.key;
-    if (typeof key !== "string") return false;
-    return (
-      key === NOT_REPORTING_OPTION_ID || key.endsWith(NOT_REPORTING_OPTION_ID)
-    );
-  });
-};
-
-const hasSelectedOption = (value: unknown): boolean => {
-  if (!Array.isArray(value)) return false;
-  return value.length > 0;
-};
-
-const applyDisableAfterField = (
-  fields: (FormField | FormLayoutElement)[],
-  params: {
-    triggerFieldId: string;
-    disableAfter: boolean;
-    disabledReasonId: string;
-  }
-) => {
-  console.log("Applying disable after field with params:", params);
-  console.log("Fields before applying disable:", fields);
-  const { triggerFieldId, disableAfter, disabledReasonId } = params;
-  const metaKey = "__notReportingDisableMeta";
-
-  const triggerIndex = fields.findIndex(
-    (field) => isFieldElement(field) && field.id === triggerFieldId
-  );
-  console.log("Trigger field index:", triggerIndex);
-  if (triggerIndex === -1) return;
-
-  for (let i = triggerIndex + 1; i < fields.length; i++) {
-    const field = fields[i];
-    if (!isFieldElement(field)) continue;
-
-    field.props ??= {};
-    const props: any = field.props;
-
-    /*
-     * Meta refers to information that will be stored directly on the field object
-     * to help keep track of the original disabled state and aria-describedby
-     * before we've modified them.
-     */
-    const meta: any = (field as any)[metaKey];
-
-    if (disableAfter) {
-      // Capture original disabled state and aria-describedby in meta if not already captured
-      if (!meta) {
-        (field as any)[metaKey] = {
-          originalDisabled: props.disabled,
-          originalAriaDescribedBy: props["aria-describedby"],
-        };
-      }
-      // Apply disabled state and merge aria-describedby with the disabled reason ID
-      props.disabled = true;
-      props["aria-describedby"] = mergeAriaDescribedBy(
-        disabledReasonId,
-        props["aria-describedby"]
-      );
-    } else if (meta) {
-      /*
-       * Restore original disabled state and aria-describedby from meta because if disableAfter
-       * is false and we've previously disabled the field, we want to revert to the original state
-       */
-      props.disabled = meta.originalDisabled;
-      props["aria-describedby"] = meta.originalAriaDescribedBy;
-      delete (field as any)[metaKey];
-      if (props.disabled === undefined) delete props.disabled;
-      if (props["aria-describedby"] === undefined)
-        delete props["aria-describedby"];
-      console.log(
-        "Cleaned up meta from field:",
-        JSON.parse(JSON.stringify(field))
-      );
-    }
-  }
-};
 
 export const Form = forwardRef<HTMLFormElement, Props>(function Form(
   {
@@ -176,13 +78,24 @@ export const Form = forwardRef<HTMLFormElement, Props>(function Form(
     ...(options as AnyObject),
   });
 
+  // Only subscribe to the Not Reporting fields if this form actually contains the trigger.
+  // This avoids unnecessary re-renders for unrelated forms.
+  const hasNotReportingTriggerField: boolean = fields.some(
+    (field: FormField | FormLayoutElement) =>
+      isFieldElement(field) && field.id === NOT_REPORTING_FIELD_ID
+  );
+
   const notReportingSelection = useWatch({
     control: form.control,
     name: NOT_REPORTING_FIELD_ID,
+    disabled: !hasNotReportingTriggerField,
+    defaultValue: [],
   });
   const notReportingReasonSelection = useWatch({
     control: form.control,
     name: NOT_REPORTING_REASON_FIELD_ID,
+    disabled: !hasNotReportingTriggerField,
+    defaultValue: [],
   });
 
   const notReportingChosen = isNotReportingSelected(notReportingSelection);
@@ -213,24 +126,26 @@ export const Form = forwardRef<HTMLFormElement, Props>(function Form(
 
     // If the user indicates they're not reporting and provides a reason,
     // disable every subsequent top-level field.
-    applyDisableAfterField(fieldsToRender, {
-      triggerFieldId: NOT_REPORTING_FIELD_ID,
-      disableAfter: disableFieldsAfterNotReporting,
-      disabledReasonId: notReportingDisabledReasonId,
-    });
+    if (hasNotReportingTriggerField) {
+      applyDisableAfterField(fieldsToRender, {
+        triggerFieldId: NOT_REPORTING_FIELD_ID,
+        disableAfter: disableFieldsAfterNotReporting,
+        disabledReasonId: notReportingDisabledReasonId,
+      });
 
-    // Render a single disabled-reason message under the Not reporting field.
-    const notReportingField = fieldsToRender.find(
-      (field) => isFieldElement(field) && field.id === NOT_REPORTING_FIELD_ID
-    ) as FormField | undefined;
-    if (notReportingField) {
-      notReportingField.props ??= {};
-      notReportingField.props.disabledStateMessageId =
-        notReportingDisabledReasonId;
-      notReportingField.props.disabledStateMessage =
-        "Fields disabled because Not Reporting is selected";
-      notReportingField.props.showDisabledStateMessage =
-        disableFieldsAfterNotReporting;
+      // Render a single disabled-reason message under the Not reporting field.
+      const notReportingField = fieldsToRender.find(
+        (field) => isFieldElement(field) && field.id === NOT_REPORTING_FIELD_ID
+      ) as FormField | undefined;
+      if (notReportingField) {
+        notReportingField.props ??= {};
+        notReportingField.props.disabledStateMessageId =
+          notReportingDisabledReasonId;
+        notReportingField.props.disabledStateMessage =
+          "Fields disabled because Not Reporting is selected";
+        notReportingField.props.showDisabledStateMessage =
+          disableFieldsAfterNotReporting;
+      }
     }
 
     return formFieldFactory(fieldsToRender, {

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -124,6 +124,16 @@ export const Form = forwardRef<HTMLFormElement, Props>(function Form(
   const renderFormFields = (fields: (FormField | FormLayoutElement)[]) => {
     const fieldsToRender = hydrateFormFields(fields, formData);
 
+    /*
+     * The following if statement is in response to this ticket: CMDCT-5446
+     * While this likely should be done by adding a special "disabled"
+     * property to each field in the form JSON, this was a quicker fix to
+     * implement the necessary logic without needing to update and watch
+     * across multiple files for the new property. If this logic needs to
+     * be applied to more forms in the future, it would likely be worth
+     * refactoring to add a new property to the form JSON.
+     */
+
     // If the user indicates they're not reporting and provides a reason,
     // disable every subsequent top-level field.
     if (hasNotReportingTriggerField) {
@@ -134,16 +144,16 @@ export const Form = forwardRef<HTMLFormElement, Props>(function Form(
       });
 
       // Render a single disabled-reason message under the Not reporting field.
-      const notReportingField = fieldsToRender.find(
+      const notReportingMessageField = fieldsToRender.find(
         (field) => isFieldElement(field) && field.id === NOT_REPORTING_FIELD_ID
       ) as FormField | undefined;
-      if (notReportingField) {
-        notReportingField.props ??= {};
-        notReportingField.props.disabledStateMessageId =
+      if (notReportingMessageField) {
+        notReportingMessageField.props ??= {};
+        notReportingMessageField.props.disabledStateMessageId =
           notReportingDisabledReasonId;
-        notReportingField.props.disabledStateMessage =
+        notReportingMessageField.props.disabledStateMessage =
           "Fields disabled because Not Reporting is selected";
-        notReportingField.props.showDisabledStateMessage =
+        notReportingMessageField.props.showDisabledStateMessage =
           disableFieldsAfterNotReporting;
       }
     }

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -137,11 +137,12 @@ export const Form = forwardRef<HTMLFormElement, Props>(function Form(
     // If the user indicates they're not reporting and provides a reason,
     // disable every subsequent top-level field.
     if (hasNotReportingTriggerField) {
-      applyDisableAfterField(fieldsToRender, {
-        triggerFieldId: NOT_REPORTING_FIELD_ID,
-        disableAfter: disableFieldsAfterNotReporting,
-        disabledReasonId: notReportingDisabledReasonId,
-      });
+      applyDisableAfterField(
+        fieldsToRender,
+        NOT_REPORTING_FIELD_ID,
+        disableFieldsAfterNotReporting,
+        notReportingDisabledReasonId
+      );
 
       // Render a single disabled-reason message under the Not reporting field.
       const notReportingMessageField = fieldsToRender.find(

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -1,4 +1,10 @@
-import { forwardRef, ReactNode, useLayoutEffect } from "react";
+import {
+  forwardRef,
+  ReactNode,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   FieldValues,
   FormProvider,
@@ -29,6 +35,9 @@ import {
   NOT_REPORTING_FIELD_ID,
   NOT_REPORTING_REASON_FIELD_ID,
   applyDisableAfterField,
+  applyClearedHydrationAfterField,
+  getClearedValueForField,
+  getFieldElementsAfterField,
   hasSelectedOption,
   isNotReportingSelected,
   sortFormErrors,
@@ -106,6 +115,44 @@ export const Form = forwardRef<HTMLFormElement, Props>(function Form(
     notReportingChosen && notReportingReasonChosen;
   const notReportingDisabledReasonId = `${id}-not-reporting-disabled-reason`;
 
+  // Used to force an update of the fields so that it reflects cleared values
+  // immediately.
+  const [notReportingClearEpoch, setNotReportingClearEpoch] = useState(0);
+  const prevDisableFieldsAfterNotReporting = useRef<boolean>(false);
+
+  useLayoutEffect(() => {
+    if (!hasNotReportingTriggerField) return;
+
+    // Only clear on the transition to "disabled".
+    if (
+      disableFieldsAfterNotReporting &&
+      !prevDisableFieldsAfterNotReporting.current
+    ) {
+      const fieldsToClear = getFieldElementsAfterField(
+        fields,
+        NOT_REPORTING_FIELD_ID
+      );
+
+      for (const field of fieldsToClear) {
+        const fieldName = field.groupId ?? field.id;
+        form.setValue(fieldName, getClearedValueForField(field), {
+          shouldValidate: false,
+          shouldDirty: true,
+        });
+        form.clearErrors(fieldName);
+      }
+
+      setNotReportingClearEpoch((v) => v + 1);
+    }
+
+    prevDisableFieldsAfterNotReporting.current = disableFieldsAfterNotReporting;
+  }, [
+    disableFieldsAfterNotReporting,
+    hasNotReportingTriggerField,
+    fields,
+    form,
+  ]);
+
   // will run if any validation errors exist on form submission
   const onErrorHandler: SubmitErrorHandler<FieldValues> = (
     errors: AnyObject
@@ -143,6 +190,12 @@ export const Form = forwardRef<HTMLFormElement, Props>(function Form(
         disableFieldsAfterNotReporting,
         notReportingDisabledReasonId
       );
+
+      // Prevent cleared/disabled fields from re-hydrating from saved formData while
+      // Not Reporting is active.
+      if (disableFieldsAfterNotReporting) {
+        applyClearedHydrationAfterField(fieldsToRender, NOT_REPORTING_FIELD_ID);
+      }
 
       // Render a single disabled-reason message under the Not reporting field.
       const notReportingMessageField = fieldsToRender.find(
@@ -189,7 +242,9 @@ export const Form = forwardRef<HTMLFormElement, Props>(function Form(
         ref={ref}
         {...props}
       >
-        <Box sx={sx}>{renderFormFields(fields)}</Box>
+        <Box sx={sx} key={`form-fields-${notReportingClearEpoch}`}>
+          {renderFormFields(fields)}
+        </Box>
         {children}
       </form>
     </FormProvider>

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -4,6 +4,7 @@ import {
   FormProvider,
   SubmitErrorHandler,
   useForm,
+  useWatch,
 } from "react-hook-form";
 import { useLocation } from "react-router";
 import { object as yupSchema } from "yup";
@@ -28,6 +29,109 @@ import {
   sortFormErrors,
   useStore,
 } from "utils";
+
+const NOT_REPORTING_OPTION_ID = "37sMoqg5MNOb17KDCpTO1w";
+const NOT_REPORTING_FIELD_ID = "measure_isReporting";
+const NOT_REPORTING_REASON_FIELD_ID = "measure_isNotReportingReason";
+
+const mergeAriaDescribedBy = (
+  toAdd: string,
+  existing?: string
+): string | undefined => {
+  /*
+   * Our fields may already have an aria-describedby attribute with one or more IDs.
+   * We want to merge in the new ID without creating duplicates and while preserving
+   * any existing IDs. This function takes the existing aria-describedby value and
+   * the new ID to add, and returns a merged string of IDs.
+   */
+  const existingStr = typeof existing === "string" ? existing.trim() : "";
+  const existingIds = existingStr ? existingStr.split(/\s+/) : [];
+  const ids = new Set([...existingIds, toAdd]);
+  const merged = [...ids].join(" ").trim();
+  return merged.length > 0 ? merged : undefined;
+};
+
+const isNotReportingSelected = (value: unknown): boolean => {
+  if (!Array.isArray(value)) return false;
+  return value.some((opt: any) => {
+    const key = opt?.key;
+    if (typeof key !== "string") return false;
+    return (
+      key === NOT_REPORTING_OPTION_ID || key.endsWith(NOT_REPORTING_OPTION_ID)
+    );
+  });
+};
+
+const hasSelectedOption = (value: unknown): boolean => {
+  if (!Array.isArray(value)) return false;
+  return value.length > 0;
+};
+
+const applyDisableAfterField = (
+  fields: (FormField | FormLayoutElement)[],
+  params: {
+    triggerFieldId: string;
+    disableAfter: boolean;
+    disabledReasonId: string;
+  }
+) => {
+  console.log("Applying disable after field with params:", params);
+  console.log("Fields before applying disable:", fields);
+  const { triggerFieldId, disableAfter, disabledReasonId } = params;
+  const metaKey = "__notReportingDisableMeta";
+
+  const triggerIndex = fields.findIndex(
+    (field) => isFieldElement(field) && field.id === triggerFieldId
+  );
+  console.log("Trigger field index:", triggerIndex);
+  if (triggerIndex === -1) return;
+
+  for (let i = triggerIndex + 1; i < fields.length; i++) {
+    const field = fields[i];
+    if (!isFieldElement(field)) continue;
+
+    field.props ??= {};
+    const props: any = field.props;
+
+    /*
+     * Meta refers to information that will be stored directly on the field object
+     * to help keep track of the original disabled state and aria-describedby
+     * before we've modified them.
+     */
+    const meta: any = (field as any)[metaKey];
+
+    if (disableAfter) {
+      // Capture original disabled state and aria-describedby in meta if not already captured
+      if (!meta) {
+        (field as any)[metaKey] = {
+          originalDisabled: props.disabled,
+          originalAriaDescribedBy: props["aria-describedby"],
+        };
+      }
+      // Apply disabled state and merge aria-describedby with the disabled reason ID
+      props.disabled = true;
+      props["aria-describedby"] = mergeAriaDescribedBy(
+        disabledReasonId,
+        props["aria-describedby"]
+      );
+    } else if (meta) {
+      /*
+       * Restore original disabled state and aria-describedby from meta because if disableAfter
+       * is false and we've previously disabled the field, we want to revert to the original state
+       */
+      props.disabled = meta.originalDisabled;
+      props["aria-describedby"] = meta.originalAriaDescribedBy;
+      delete (field as any)[metaKey];
+      if (props.disabled === undefined) delete props.disabled;
+      if (props["aria-describedby"] === undefined)
+        delete props["aria-describedby"];
+      console.log(
+        "Cleaned up meta from field:",
+        JSON.parse(JSON.stringify(field))
+      );
+    }
+  }
+};
 
 export const Form = forwardRef<HTMLFormElement, Props>(function Form(
   {
@@ -72,6 +176,23 @@ export const Form = forwardRef<HTMLFormElement, Props>(function Form(
     ...(options as AnyObject),
   });
 
+  const notReportingSelection = useWatch({
+    control: form.control,
+    name: NOT_REPORTING_FIELD_ID,
+  });
+  const notReportingReasonSelection = useWatch({
+    control: form.control,
+    name: NOT_REPORTING_REASON_FIELD_ID,
+  });
+
+  const notReportingChosen = isNotReportingSelected(notReportingSelection);
+  const notReportingReasonChosen = hasSelectedOption(
+    notReportingReasonSelection
+  );
+  const disableFieldsAfterNotReporting =
+    notReportingChosen && notReportingReasonChosen;
+  const notReportingDisabledReasonId = `${id}-not-reporting-disabled-reason`;
+
   // will run if any validation errors exist on form submission
   const onErrorHandler: SubmitErrorHandler<FieldValues> = (
     errors: AnyObject
@@ -89,6 +210,28 @@ export const Form = forwardRef<HTMLFormElement, Props>(function Form(
   // hydrate and create form fields using formFieldFactory
   const renderFormFields = (fields: (FormField | FormLayoutElement)[]) => {
     const fieldsToRender = hydrateFormFields(fields, formData);
+
+    // If the user indicates they're not reporting and provides a reason,
+    // disable every subsequent top-level field.
+    applyDisableAfterField(fieldsToRender, {
+      triggerFieldId: NOT_REPORTING_FIELD_ID,
+      disableAfter: disableFieldsAfterNotReporting,
+      disabledReasonId: notReportingDisabledReasonId,
+    });
+
+    // Render a single disabled-reason message under the Not reporting field.
+    const notReportingField = fieldsToRender.find(
+      (field) => isFieldElement(field) && field.id === NOT_REPORTING_FIELD_ID
+    ) as FormField | undefined;
+    if (notReportingField) {
+      notReportingField.props ??= {};
+      notReportingField.props.disabledStateMessageId =
+        notReportingDisabledReasonId;
+      notReportingField.props.disabledStateMessage =
+        "Fields disabled because Not Reporting is selected";
+      notReportingField.props.showDisabledStateMessage =
+        disableFieldsAfterNotReporting;
+    }
 
     return formFieldFactory(fieldsToRender, {
       disabled: !!fieldInputDisabled,

--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -1,13 +1,18 @@
 import {
+  NOT_REPORTING_FIELD_ID,
   cleanSuppressed,
   createRepeatedFields,
   defineProgramName,
   filterFormData,
   flattenFormFields,
   formFieldFactory,
+  applyDisableAfterField,
+  hasSelectedOption,
   getEntriesToClear,
   hydrateFormFields,
   initializeChoiceListFields,
+  isNotReportingSelected,
+  mergeAriaDescribedBy,
   resetClearProp,
   setClearedEntriesToDefaultValue,
   sortFormErrors,
@@ -430,6 +435,131 @@ describe("utils/forms", () => {
 
       const result = cleanSuppressed(enteredData);
       expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe("Not reporting helpers", () => {
+    describe("mergeAriaDescribedBy()", () => {
+      it("adds an id when no existing aria-describedby", () => {
+        expect(mergeAriaDescribedBy("new-id")).toBe("new-id");
+      });
+
+      it("merges ids and avoids duplicates", () => {
+        expect(mergeAriaDescribedBy("b", "a b")).toBe("a b");
+        expect(mergeAriaDescribedBy("c", "a b")).toBe("a b c");
+      });
+    });
+
+    describe("isNotReportingSelected()", () => {
+      it("returns true when option key matches or endsWith trigger id", () => {
+        expect(
+          isNotReportingSelected([
+            { key: "37sMoqg5MNOb17KDCpTO1w", value: "Not reporting" },
+          ])
+        ).toBe(true);
+        expect(
+          isNotReportingSelected([
+            {
+              key: "measure_isReporting-37sMoqg5MNOb17KDCpTO1w",
+              value: "Not reporting",
+            },
+          ])
+        ).toBe(true);
+      });
+
+      it("returns false when trigger id not present", () => {
+        expect(
+          isNotReportingSelected([{ key: "some-other-id", value: "X" }])
+        ).toBe(false);
+        expect(isNotReportingSelected([])).toBe(false);
+      });
+    });
+
+    describe("hasSelectedOption()", () => {
+      it("returns true only for non-empty arrays", () => {
+        expect(hasSelectedOption([])).toBe(false);
+        expect(hasSelectedOption([{ key: "k", value: "v" }])).toBe(true);
+      });
+    });
+
+    describe("applyDisableAfterField()", () => {
+      it("does nothing if trigger field is not present", () => {
+        const fields: any[] = [
+          {
+            id: "some-other-field",
+            type: "text",
+            validation: "text",
+            props: { label: "X" },
+          },
+        ];
+
+        applyDisableAfterField(fields as any, {
+          triggerFieldId: NOT_REPORTING_FIELD_ID,
+          disableAfter: true,
+          disabledReasonId: "reason-id",
+        });
+
+        expect(fields[0].props.disabled).toBeUndefined();
+        expect(fields[0].props["aria-describedby"]).toBeUndefined();
+      });
+
+      it("disables subsequent field elements and restores original state", () => {
+        const fields: any[] = [
+          {
+            id: NOT_REPORTING_FIELD_ID,
+            type: "checkbox",
+            validation: "checkboxOptional",
+            props: { label: "Trigger" },
+          },
+          {
+            id: "layout-1",
+            type: "sectionHeader",
+            props: { content: "Layout" },
+          },
+          {
+            id: "after-1",
+            type: "text",
+            validation: "text",
+            props: {
+              label: "After 1",
+              "aria-describedby": "existing",
+            },
+          },
+          {
+            id: "after-2",
+            type: "text",
+            validation: "text",
+            props: { label: "After 2", disabled: false },
+          },
+        ];
+
+        applyDisableAfterField(fields as any, {
+          triggerFieldId: NOT_REPORTING_FIELD_ID,
+          disableAfter: true,
+          disabledReasonId: "reason-id",
+        });
+
+        // layout element should be untouched
+        expect(fields[1].props.disabled).toBeUndefined();
+
+        // subsequent fields should be disabled + described
+        expect(fields[2].props.disabled).toBe(true);
+        expect(fields[2].props["aria-describedby"]).toBe("existing reason-id");
+        expect(fields[3].props.disabled).toBe(true);
+        expect(fields[3].props["aria-describedby"]).toBe("reason-id");
+
+        // restore
+        applyDisableAfterField(fields as any, {
+          triggerFieldId: NOT_REPORTING_FIELD_ID,
+          disableAfter: false,
+          disabledReasonId: "reason-id",
+        });
+
+        expect(fields[2].props.disabled).toBeUndefined();
+        expect(fields[2].props["aria-describedby"]).toBe("existing");
+        expect(fields[3].props.disabled).toBe(false);
+        expect(fields[3].props["aria-describedby"]).toBeUndefined();
+      });
     });
   });
 });

--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -13,6 +13,7 @@ import {
   initializeChoiceListFields,
   isNotReportingSelected,
   mergeAriaDescribedBy,
+  removeAddedAriaDescribedBy,
   resetClearProp,
   setClearedEntriesToDefaultValue,
   sortFormErrors,
@@ -450,6 +451,22 @@ describe("utils/forms", () => {
       });
     });
 
+    describe("removeAddedAriaDescribedBy()", () => {
+      it("returns undefined when no existing aria-describedby", () => {
+        expect(removeAddedAriaDescribedBy("x")).toBeUndefined();
+      });
+
+      it("removes the id and returns undefined when it was the only reason", () => {
+        expect(removeAddedAriaDescribedBy("reason-id", "reason-id")).toBe(
+          undefined
+        );
+      });
+
+      it("removes the id", () => {
+        expect(removeAddedAriaDescribedBy("reason", "reason a b")).toBe("a b");
+      });
+    });
+
     describe("isNotReportingSelected()", () => {
       it("returns true when option key matches or endsWith trigger id", () => {
         expect(
@@ -559,7 +576,7 @@ describe("utils/forms", () => {
 
         expect(fields[2].props.disabled).toBeUndefined();
         expect(fields[2].props["aria-describedby"]).toBe("existing");
-        expect(fields[3].props.disabled).toBe(false);
+        expect(fields[3].props.disabled).toBeUndefined();
         expect(fields[3].props["aria-describedby"]).toBeUndefined();
       });
     });

--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -493,12 +493,12 @@ describe("utils/forms", () => {
           },
         ];
 
-        applyDisableAfterField(fields as any, {
-          triggerFieldId: NOT_REPORTING_FIELD_ID,
-          disableAfter: true,
-          disabledReasonId: "reason-id",
-        });
-
+        applyDisableAfterField(
+          fields as any,
+          NOT_REPORTING_FIELD_ID,
+          true,
+          "reason-id"
+        );
         expect(fields[0].props.disabled).toBeUndefined();
         expect(fields[0].props["aria-describedby"]).toBeUndefined();
       });
@@ -533,11 +533,12 @@ describe("utils/forms", () => {
           },
         ];
 
-        applyDisableAfterField(fields as any, {
-          triggerFieldId: NOT_REPORTING_FIELD_ID,
-          disableAfter: true,
-          disabledReasonId: "reason-id",
-        });
+        applyDisableAfterField(
+          fields as any,
+          NOT_REPORTING_FIELD_ID,
+          true,
+          "reason-id"
+        );
 
         // layout element should be untouched
         expect(fields[1].props.disabled).toBeUndefined();
@@ -548,12 +549,13 @@ describe("utils/forms", () => {
         expect(fields[3].props.disabled).toBe(true);
         expect(fields[3].props["aria-describedby"]).toBe("reason-id");
 
-        // restore
-        applyDisableAfterField(fields as any, {
-          triggerFieldId: NOT_REPORTING_FIELD_ID,
-          disableAfter: false,
-          disabledReasonId: "reason-id",
-        });
+        // restore original state
+        applyDisableAfterField(
+          fields as any,
+          NOT_REPORTING_FIELD_ID,
+          false,
+          "reason-id"
+        );
 
         expect(fields[2].props.disabled).toBeUndefined();
         expect(fields[2].props["aria-describedby"]).toBe("existing");

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -485,3 +485,78 @@ export const applyDisableAfterField = (
     }
   }
 };
+
+// NOT REPORTING CLEAR HELPERS
+export const getClearedValueForField = (field: FormField): any => {
+  switch (field.type) {
+    // Choice lists store arrays of { key, value } selections.
+    case "radio":
+    case "checkbox":
+      return [];
+
+    // Single checkbox stores a boolean.
+    case "checkboxSingle":
+      return false;
+
+    // Dropdown stores an object with a .value (and optional .label).
+    case "dropdown":
+      return { label: "", value: "" };
+
+    // Dynamic stores an array of entities.
+    case "dynamic":
+      return [];
+
+    // Most other fields store strings.
+    default:
+      return "";
+  }
+};
+
+const collectDescendantFieldsFromChoices = (
+  field: FormField,
+  out: FormField[]
+): void => {
+  const choices = field.props?.choices as FieldChoice[] | undefined;
+  if (!choices) return;
+
+  for (const choice of choices) {
+    const children = choice.children as FormField[] | undefined;
+    if (!children) continue;
+
+    for (const child of children) {
+      out.push(child);
+      collectDescendantFieldsFromChoices(child, out);
+    }
+  }
+};
+
+export const getFieldElementsAfterField = (
+  fields: (FormField | FormLayoutElement)[],
+  triggerFieldId: string
+): FormField[] => {
+  const triggerIndex = fields.findIndex(
+    (field) => isFieldElement(field) && field.id === triggerFieldId
+  );
+  if (triggerIndex === -1) return [];
+
+  const out: FormField[] = [];
+  for (let i = triggerIndex + 1; i < fields.length; i++) {
+    const field = fields[i];
+    if (!isFieldElement(field)) continue;
+
+    out.push(field);
+    collectDescendantFieldsFromChoices(field, out);
+  }
+  return out;
+};
+
+export const applyClearedHydrationAfterField = (
+  fields: (FormField | FormLayoutElement)[],
+  triggerFieldId: string
+): void => {
+  const fieldsToClear = getFieldElementsAfterField(fields, triggerFieldId);
+  for (const field of fieldsToClear) {
+    field.props ??= {};
+    (field.props as AnyObject).hydrate = getClearedValueForField(field);
+  }
+};

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -420,15 +420,60 @@ export const hasSelectedOption = (value: Choice[]): boolean => {
   return value.length > 0;
 };
 
+const applyNotReportingDisabledState = (
+  field: FormField,
+  props: AnyObject,
+  metaKey: string,
+  disabledReasonId: string
+) => {
+  /*
+   * The meta object stores the original disabled state and aria-describedby
+   * value of the field before we modify them, so that we can restore them
+   * properly when re-enabling the field.
+   */
+  const meta = (field as AnyObject)[metaKey];
+  if (!meta) {
+    (field as AnyObject)[metaKey] = {
+      originalDisabled:
+        typeof props.disabled === "boolean" ? props.disabled : undefined,
+      originalAriaDescribedBy:
+        typeof props["aria-describedby"] === "string"
+          ? (props["aria-describedby"] as string)
+          : undefined,
+    };
+  }
+
+  // Apply the actual disabled behavior.
+  props.disabled = true;
+  props["aria-describedby"] = mergeAriaDescribedBy(
+    disabledReasonId,
+    props["aria-describedby"]
+  );
+};
+
+const restoreNotReportingDisabledState = (
+  field: FormField,
+  props: AnyObject,
+  metaKey: string
+) => {
+  const meta = (field as AnyObject)[metaKey];
+  if (!meta) return;
+
+  props.disabled = meta.originalDisabled;
+  props["aria-describedby"] = meta.originalAriaDescribedBy;
+  delete (field as AnyObject)[metaKey];
+
+  // If a prop was originally unset, delete it to avoid leaking undefined.
+  if (props.disabled === undefined) delete props.disabled;
+  if (props["aria-describedby"] === undefined) delete props["aria-describedby"];
+};
+
 export const applyDisableAfterField = (
   fields: (FormField | FormLayoutElement)[],
-  params: {
-    triggerFieldId: string;
-    disableAfter: boolean;
-    disabledReasonId: string;
-  }
+  triggerFieldId: string,
+  disableAfter: boolean,
+  disabledReasonId: string
 ) => {
-  const { triggerFieldId, disableAfter, disabledReasonId } = params;
   const metaKey = "__notReportingDisableMeta";
 
   /*
@@ -447,38 +492,10 @@ export const applyDisableAfterField = (
     field.props ??= {};
     const props = field.props as AnyObject;
 
-    const meta = (field as AnyObject)[metaKey];
-
     if (disableAfter) {
-      /*
-       * The meta object stores the original disabled state and aria-describedby
-       * value of the field before we modify them, so that we can restore them
-       * properly when re-enabling the field.
-       */
-      if (!meta) {
-        (field as AnyObject)[metaKey] = {
-          originalDisabled:
-            typeof props.disabled === "boolean" ? props.disabled : undefined,
-          originalAriaDescribedBy:
-            typeof props["aria-describedby"] === "string"
-              ? (props["aria-describedby"] as string)
-              : undefined,
-        };
-      }
-
-      props.disabled = true;
-      props["aria-describedby"] = mergeAriaDescribedBy(
-        disabledReasonId,
-        props["aria-describedby"]
-      );
-    } else if (meta) {
-      props.disabled = meta.originalDisabled;
-      props["aria-describedby"] = meta.originalAriaDescribedBy;
-      delete (field as AnyObject)[metaKey];
-
-      if (props.disabled === undefined) delete props.disabled;
-      if (props["aria-describedby"] === undefined)
-        delete props["aria-describedby"];
+      applyNotReportingDisabledState(field, props, metaKey, disabledReasonId);
+    } else {
+      restoreNotReportingDisabledState(field, props, metaKey);
     }
   }
 };

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -385,11 +385,17 @@ export const cleanSuppressed = (enteredData: AnyObject) => {
 };
 
 // NOT REPORTING HELPERS (MCPAR Quality Measures)
-
 export const NOT_REPORTING_OPTION_ID = "37sMoqg5MNOb17KDCpTO1w";
 export const NOT_REPORTING_FIELD_ID = "measure_isReporting";
 export const NOT_REPORTING_REASON_FIELD_ID = "measure_isNotReportingReason";
 
+/*
+ * This function merges the id of the disabled reason message to
+ * the existing aria-describedby attribute on fields. If there is already
+ * an aria-describedby value, the new id will be added to it, separated by a space.
+ * If not, the aria-describedby attribute will be created with the new id as
+ * its value.
+ */
 export const mergeAriaDescribedBy = (
   toAdd: string,
   existing?: string
@@ -425,6 +431,10 @@ export const applyDisableAfterField = (
   const { triggerFieldId, disableAfter, disabledReasonId } = params;
   const metaKey = "__notReportingDisableMeta";
 
+  /*
+   * Find the index of the trigger field (The Not Reporting checkbox)
+   * in the fields array so that we know where to start disabling subsequent fields.
+   */
   const triggerIndex = fields.findIndex(
     (field) => isFieldElement(field) && field.id === triggerFieldId
   );
@@ -440,6 +450,11 @@ export const applyDisableAfterField = (
     const meta = (field as AnyObject)[metaKey];
 
     if (disableAfter) {
+      /*
+       * The meta object stores the original disabled state and aria-describedby
+       * value of the field before we modify them, so that we can restore them
+       * properly when re-enabling the field.
+       */
       if (!meta) {
         (field as AnyObject)[metaKey] = {
           originalDisabled:

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -383,3 +383,83 @@ export const cleanSuppressed = (enteredData: AnyObject) => {
 
   return enteredData;
 };
+
+// NOT REPORTING HELPERS (MCPAR Quality Measures)
+
+export const NOT_REPORTING_OPTION_ID = "37sMoqg5MNOb17KDCpTO1w";
+export const NOT_REPORTING_FIELD_ID = "measure_isReporting";
+export const NOT_REPORTING_REASON_FIELD_ID = "measure_isNotReportingReason";
+
+export const mergeAriaDescribedBy = (
+  toAdd: string,
+  existing?: string
+): string | undefined => {
+  const existingStr = typeof existing === "string" ? existing.trim() : "";
+  const existingIds = existingStr ? existingStr.split(/\s+/) : [];
+  const ids = new Set([...existingIds, toAdd]);
+  const merged = [...ids].join(" ");
+  return merged.length > 0 ? merged : undefined;
+};
+
+export const isNotReportingSelected = (value: Choice[]): boolean => {
+  return value.some((opt: Choice) => {
+    const key = opt.key;
+    return (
+      key === NOT_REPORTING_OPTION_ID || key.endsWith(NOT_REPORTING_OPTION_ID)
+    );
+  });
+};
+
+export const hasSelectedOption = (value: Choice[]): boolean => {
+  return value.length > 0;
+};
+
+export const applyDisableAfterField = (
+  fields: (FormField | FormLayoutElement)[],
+  params: {
+    triggerFieldId: string;
+    disableAfter: boolean;
+    disabledReasonId: string;
+  }
+) => {
+  const { triggerFieldId, disableAfter, disabledReasonId } = params;
+  const metaKey = "__notReportingDisableMeta";
+
+  const triggerIndex = fields.findIndex(
+    (field) => isFieldElement(field) && field.id === triggerFieldId
+  );
+  if (triggerIndex === -1) return;
+
+  for (let i = triggerIndex + 1; i < fields.length; i++) {
+    const field = fields[i];
+    if (!isFieldElement(field)) continue;
+
+    field.props ??= {};
+    const props: any = field.props;
+
+    const meta: any = (field as any)[metaKey];
+
+    if (disableAfter) {
+      if (!meta) {
+        (field as any)[metaKey] = {
+          originalDisabled: props.disabled,
+          originalAriaDescribedBy: props["aria-describedby"],
+        };
+      }
+
+      props.disabled = true;
+      props["aria-describedby"] = mergeAriaDescribedBy(
+        disabledReasonId,
+        props["aria-describedby"]
+      );
+    } else if (meta) {
+      props.disabled = meta.originalDisabled;
+      props["aria-describedby"] = meta.originalAriaDescribedBy;
+      delete (field as any)[metaKey];
+
+      if (props.disabled === undefined) delete props.disabled;
+      if (props["aria-describedby"] === undefined)
+        delete props["aria-describedby"];
+    }
+  }
+};

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -394,7 +394,7 @@ export const mergeAriaDescribedBy = (
   toAdd: string,
   existing?: string
 ): string | undefined => {
-  const existingStr = typeof existing === "string" ? existing.trim() : "";
+  const existingStr = existing ? existing.trim() : "";
   const existingIds = existingStr ? existingStr.split(/\s+/) : [];
   const ids = new Set([...existingIds, toAdd]);
   const merged = [...ids].join(" ");
@@ -435,15 +435,19 @@ export const applyDisableAfterField = (
     if (!isFieldElement(field)) continue;
 
     field.props ??= {};
-    const props: any = field.props;
+    const props = field.props as AnyObject;
 
-    const meta: any = (field as any)[metaKey];
+    const meta = (field as AnyObject)[metaKey];
 
     if (disableAfter) {
       if (!meta) {
-        (field as any)[metaKey] = {
-          originalDisabled: props.disabled,
-          originalAriaDescribedBy: props["aria-describedby"],
+        (field as AnyObject)[metaKey] = {
+          originalDisabled:
+            typeof props.disabled === "boolean" ? props.disabled : undefined,
+          originalAriaDescribedBy:
+            typeof props["aria-describedby"] === "string"
+              ? (props["aria-describedby"] as string)
+              : undefined,
         };
       }
 
@@ -455,7 +459,7 @@ export const applyDisableAfterField = (
     } else if (meta) {
       props.disabled = meta.originalDisabled;
       props["aria-describedby"] = meta.originalAriaDescribedBy;
-      delete (field as any)[metaKey];
+      delete (field as AnyObject)[metaKey];
 
       if (props.disabled === undefined) delete props.disabled;
       if (props["aria-describedby"] === undefined)

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -407,6 +407,17 @@ export const mergeAriaDescribedBy = (
   return merged.length > 0 ? merged : undefined;
 };
 
+export const removeAddedAriaDescribedBy = (
+  toRemove: string,
+  existing?: string
+): string | undefined => {
+  if (!existing) return undefined;
+  const existingIds = existing.trim().split(/\s+/);
+  const filteredIds = existingIds.filter((id) => id !== toRemove);
+  const merged = filteredIds.join(" ");
+  return merged.length > 0 ? merged : undefined;
+};
+
 export const isNotReportingSelected = (value: Choice[]): boolean => {
   return value.some((opt: Choice) => {
     const key = opt.key;
@@ -421,28 +432,9 @@ export const hasSelectedOption = (value: Choice[]): boolean => {
 };
 
 const applyNotReportingDisabledState = (
-  field: FormField,
   props: AnyObject,
-  metaKey: string,
   disabledReasonId: string
 ) => {
-  /*
-   * The meta object stores the original disabled state and aria-describedby
-   * value of the field before we modify them, so that we can restore them
-   * properly when re-enabling the field.
-   */
-  const meta = (field as AnyObject)[metaKey];
-  if (!meta) {
-    (field as AnyObject)[metaKey] = {
-      originalDisabled:
-        typeof props.disabled === "boolean" ? props.disabled : undefined,
-      originalAriaDescribedBy:
-        typeof props["aria-describedby"] === "string"
-          ? (props["aria-describedby"] as string)
-          : undefined,
-    };
-  }
-
   // Apply the actual disabled behavior.
   props.disabled = true;
   props["aria-describedby"] = mergeAriaDescribedBy(
@@ -452,19 +444,15 @@ const applyNotReportingDisabledState = (
 };
 
 const restoreNotReportingDisabledState = (
-  field: FormField,
   props: AnyObject,
-  metaKey: string
+  disabledReasonId: string
 ) => {
-  const meta = (field as AnyObject)[metaKey];
-  if (!meta) return;
-
-  props.disabled = meta.originalDisabled;
-  props["aria-describedby"] = meta.originalAriaDescribedBy;
-  delete (field as AnyObject)[metaKey];
-
-  // If a prop was originally unset, delete it to avoid leaking undefined.
-  if (props.disabled === undefined) delete props.disabled;
+  //Remove the disabled state and the disabled reason from the aria-describedby attribute
+  delete props.disabled;
+  props["aria-describedby"] = removeAddedAriaDescribedBy(
+    disabledReasonId,
+    props["aria-describedby"]
+  );
   if (props["aria-describedby"] === undefined) delete props["aria-describedby"];
 };
 
@@ -474,8 +462,6 @@ export const applyDisableAfterField = (
   disableAfter: boolean,
   disabledReasonId: string
 ) => {
-  const metaKey = "__notReportingDisableMeta";
-
   /*
    * Find the index of the trigger field (The Not Reporting checkbox)
    * in the fields array so that we know where to start disabling subsequent fields.
@@ -493,9 +479,9 @@ export const applyDisableAfterField = (
     const props = field.props as AnyObject;
 
     if (disableAfter) {
-      applyNotReportingDisabledState(field, props, metaKey, disabledReasonId);
+      applyNotReportingDisabledState(props, disabledReasonId);
     } else {
-      restoreNotReportingDisabledState(field, props, metaKey);
+      restoreNotReportingDisabledState(props, disabledReasonId);
     }
   }
 };


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
This PR adds the ability for the user to click on Not Report, then click a reason for not reporting, to have all the child fields after it become disabled. Heres what that looks like in practice:

https://github.com/user-attachments/assets/a9cfc5b9-34b2-49b5-8b26-50535c3e0318

#### Implementation Notes:
A unique approach we did was get as low to the code as possible. This means that the form renderer is responsible for handling this action. There are pros and cons to this, however.
**The Pros:**
- All in 1 file (Moved helper functions out to helper function file)
- Clear line of responsibility
- Watching for data changes and manipulation everything is easy

**The Cons:**
- Reusable? Sure, but can quickly get out of hand if not careful.
- This _is_ low to the code. Business functions likely shouldn't be handled here, but rather in higher up files. That would create a clear separation of responsibilities. 

If we had gone with implementing a json code we would have had to track that variable across _a lot_ of files. That would make this PR quite huge. However, it could make things quite a bit more sustainable and readable for the developer. 

I recognize there are trade offs happening in this PR. Feel free to discuss this implementation and leave your thoughts!

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5446

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Create a MCPAR Report
- Add a couple plans in A: Add Plans
- Navigate to D: Plan Level Indicators; VII: Quality Measures; Measures and Results
- Add a Measure!   

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary