### PR TITLE
[CMDCT-5446] Quality Measure Reporting Fields

### DIFF
--- a/services/app-api/forms/routes/mcpar/flags/newQualityMeasuresSectionEnabled/plan-level-indicators/quality-measures/measures-and-results.ts
+++ b/services/app-api/forms/routes/mcpar/flags/newQualityMeasuresSectionEnabled/plan-level-indicators/quality-measures/measures-and-results.ts
@@ -253,12 +253,70 @@ export const measuresAndResultsRoute: ModalDrawerRoute = {
     fields: [
       {
         id: "measure_isReporting",
-        type: ReportFormFieldType.CHECKBOX,
-        validation: ValidationType.CHECKBOX_OPTIONAL,
+        type: ReportFormFieldType.RADIO,
+        validation: ValidationType.RADIO,
         props: {
           label: "D2.VII.6 Are you reporting results for this measure?",
           hint: "Are you reporting results for this measure for this reporting period?",
           choices: [
+            {
+              id: "xvBx2RGFpvmUf2Wk5bLe9u",
+              label: "Yes, I am reporting",
+              children: [
+                {
+                  id: "measure_dataCollectionMethod",
+                  type: ReportFormFieldType.RADIO,
+                  validation: {
+                    type: ValidationType.RADIO,
+                    nested: true,
+                    parentFieldName: "measure_isReporting",
+                    parentOptionId: "xvBx2RGFpvmUf2Wk5bLe9u",
+                  },
+                  props: {
+                    label: "D2.VII.7 Data collection method",
+                    hint: "What data collection method did the plan use for this measure? (see technical guide for definitions).",
+                    choices: [
+                      {
+                        id: "bkD4uguEEiRjo5GyoCVNMi",
+                        label: "Administrative",
+                      },
+                      {
+                        id: "tL67PrkzTlW7sYbwvLX20u",
+                        label: "Electronic clinical data systems (ECDS)",
+                      },
+                      {
+                        id: "ZMOGJqcMYUpz9kfB5U7WKW",
+                        label: "Electronic health record (EHR)",
+                      },
+                      {
+                        id: "sr81F3S6pBZcmyr4iiBDmR",
+                        label: "Hybrid",
+                      },
+                      {
+                        id: "UaVA7pFl6zfrYIVFaZXkX0",
+                        label: "Survey",
+                      },
+                      {
+                        id: "D3x0tz0657GlrkneNtssdn",
+                        label: "Other, specify",
+                        children: [
+                          {
+                            id: "measure_dataCollectionMethod-otherText",
+                            type: ReportFormFieldType.TEXT,
+                            validation: {
+                              type: ValidationType.TEXT_OPTIONAL,
+                              nested: true,
+                              parentFieldName: "measure_dataCollectionMethod",
+                              parentOptionId: "D3x0tz0657GlrkneNtssdn",
+                            },
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
             {
               id: "37sMoqg5MNOb17KDCpTO1w",
               label: "Not reporting",
@@ -300,57 +358,6 @@ export const measuresAndResultsRoute: ModalDrawerRoute = {
                         ],
                       },
                     ],
-                  },
-                },
-              ],
-            },
-          ],
-        },
-      },
-      {
-        id: "measure_section_divider",
-        type: ReportFormFieldType.SECTION_DIVIDER,
-      },
-      {
-        id: "measure_dataCollectionMethod",
-        type: ReportFormFieldType.RADIO,
-        validation: ValidationType.RADIO_OPTIONAL,
-        props: {
-          label: "D2.VII.7 Data collection method",
-          hint: "What data collection method did the plan use for this measure? (see technical guide for definitions).",
-          choices: [
-            {
-              id: "bkD4uguEEiRjo5GyoCVNMi",
-              label: "Administrative",
-            },
-            {
-              id: "tL67PrkzTlW7sYbwvLX20u",
-              label: "Electronic clinical data systems (ECDS)",
-            },
-            {
-              id: "ZMOGJqcMYUpz9kfB5U7WKW",
-              label: "Electronic health record (EHR)",
-            },
-            {
-              id: "sr81F3S6pBZcmyr4iiBDmR",
-              label: "Hybrid",
-            },
-            {
-              id: "UaVA7pFl6zfrYIVFaZXkX0",
-              label: "Survey",
-            },
-            {
-              id: "D3x0tz0657GlrkneNtssdn",
-              label: "Other, specify",
-              children: [
-                {
-                  id: "measure_dataCollectionMethod-otherText",
-                  type: ReportFormFieldType.TEXT,
-                  validation: {
-                    type: ValidationType.TEXT_OPTIONAL,
-                    nested: true,
-                    parentFieldName: "measure_dataCollectionMethod",
-                    parentOptionId: "D3x0tz0657GlrkneNtssdn",
                   },
                 },
               ],

--- a/services/app-api/utils/validation/completionStatus.test.ts
+++ b/services/app-api/utils/validation/completionStatus.test.ts
@@ -369,16 +369,16 @@ describe("Completion Status Tests", () => {
 
   describe("calculateMeasureCompletion()", () => {
     const mockMeasureId = "mock-measure-1";
+    const mockMeasureRates = [{ id: "mock-rate-1" }];
     const mockPlan = {
       id: "mock-plan-1",
       name: "Mock plan 1",
     };
-    const mockForm = measuresAndResultsRoute.drawerForm;
     test("returns false for plan with no measure data", () => {
       const result = calculateMeasureCompletion(
         mockMeasureId,
-        mockForm,
-        mockPlan
+        mockPlan,
+        mockMeasureRates
       );
       expect(result).toBe(false);
     });
@@ -395,8 +395,8 @@ describe("Completion Status Tests", () => {
       };
       const result = calculateMeasureCompletion(
         mockMeasureId,
-        mockForm,
-        mockNotReportingPlan
+        mockNotReportingPlan,
+        mockMeasureRates
       );
       expect(result).toBe(true);
     });
@@ -407,13 +407,14 @@ describe("Completion Status Tests", () => {
         measures: {
           [mockMeasureId]: {
             measure_dataCollectionMethod: [{}],
+            "measure_rateResults-mock-rate-1": "42",
           },
         },
       };
       const result = calculateMeasureCompletion(
         mockMeasureId,
-        mockForm,
-        mockCompletePlan
+        mockCompletePlan,
+        mockMeasureRates
       );
       expect(result).toBe(true);
     });

--- a/services/app-api/utils/validation/completionStatus.ts
+++ b/services/app-api/utils/validation/completionStatus.ts
@@ -11,11 +11,9 @@ import {
   PageTypes,
   ReportRoute,
   EntityShape,
-  FormLayoutElement,
 } from "../types";
 // utils
 import { validateFieldData } from "./completionValidation";
-import { isFieldElement } from "../formTemplates/formTemplates";
 
 export const isComplete = (completionStatus: CompletionData): Boolean => {
   const flatten = (obj: AnyObject, out: AnyObject) => {
@@ -170,30 +168,25 @@ export const calculateEntityCompletion = async (
 
 export const calculateMeasureCompletion = (
   measureId: string,
-  form: FormJson,
-  plan: EntityShape
+  plan: EntityShape,
+  measureRates: AnyObject
 ) => {
-  const calculateEntityCompletion = (
-    fields: (FormField | FormLayoutElement)[],
-    entityData: EntityShape
-  ) => {
-    return fields
-      ?.filter(isFieldElement)
-      .every((field) => field.id in entityData);
-  };
-
   const planMeasureData = plan.measures?.[measureId];
   if (!planMeasureData) return false;
 
-  const isNotReporting = planMeasureData.measure_isReporting?.length > 0;
-  const hasReasons = planMeasureData.measure_isNotReportingReason?.length > 0;
-  if (isNotReporting && hasReasons) return true;
+  const reporting = planMeasureData.measure_isReporting?.length > 0;
+  const notReportingReasons =
+    planMeasureData.measure_isNotReportingReason?.length > 0;
+  if (reporting && notReportingReasons) return true;
 
-  const requiredFields = form.fields
-    ?.filter(isFieldElement)
-    .filter((field) => field.id !== "measure_isReporting");
+  const dataMethod = planMeasureData.measure_dataCollectionMethod?.length > 0;
 
-  return calculateEntityCompletion(requiredFields, planMeasureData);
+  const ratesAreAnswered = measureRates.every((rate: any) => {
+    const rateResult = planMeasureData[`measure_rateResults-${rate.id}`];
+    return rateResult && rateResult !== "";
+  });
+
+  return dataMethod && ratesAreAnswered;
 };
 
 export const calculateRouteCompletion = async (
@@ -325,8 +318,8 @@ export const calculateRouteCompletion = async (
             plans.every((plan: EntityShape) =>
               calculateMeasureCompletion(
                 measure.id,
-                route.drawerForm as FormJson,
-                plan
+                plan,
+                measure?.measure_rates
               )
             )
           );

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlayQualityMeasures.test.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlayQualityMeasures.test.tsx
@@ -7,7 +7,6 @@ import { ReportContext } from "components";
 import { DrawerReportPageShape, ModalOverlayReportPageShape } from "types";
 // utils
 import {
-  mockDrawerForm,
   mockEntityStore,
   mockMcparReport,
   mockMcparReportContext,
@@ -18,6 +17,50 @@ import {
 import { useStore } from "utils";
 // verbiage
 import overlayVerbiage from "verbiage/pages/overlays";
+
+const mockQualityMeasuresDrawerForm = {
+  id: "mock-quality-measures-drawer-form",
+  fields: [
+    {
+      id: "measure_isReporting",
+      type: "radio",
+      validation: "radio",
+      props: {
+        label: "Are you reporting results for this measure?",
+        choices: [
+          {
+            id: "xvBx2RGFpvmUf2Wk5bLe9u",
+            label: "Yes",
+            children: [
+              {
+                id: "measure_dataCollectionMethod",
+                type: "radio",
+                validation: "radio",
+                props: {
+                  label: "Data collection method",
+                  choices: [
+                    {
+                      id: "mock-administrative",
+                      label: "Administrative",
+                    },
+                    {
+                      id: "mock-hybrid",
+                      label: "Hybrid",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            id: "mock-no",
+            label: "No",
+          },
+        ],
+      },
+    },
+  ],
+};
 
 const mockCloseEntityDetailsOverlay = jest.fn();
 
@@ -81,7 +124,7 @@ describe("<EntityDetailsOverlayQualityMeasures />", () => {
   test("should have drawer form with rates and be able to submit", async () => {
     const mockDrawerFormRoute = {
       ...mockModalOverlayReportPageJson,
-      drawerForm: mockDrawerForm,
+      drawerForm: mockQualityMeasuresDrawerForm,
     };
     render(entityDetailsOverlayQualityMeasuresComponent(mockDrawerFormRoute));
 
@@ -99,18 +142,30 @@ describe("<EntityDetailsOverlayQualityMeasures />", () => {
 
     // fill out drawer form
     expect(screen.getByRole("form")).toBeVisible();
-    const mockDrawerField = screen.getByRole("textbox", {
-      name: "mock drawer text field",
+    const reportingYesButton = screen.getByRole("radio", {
+      name: "Yes",
     });
-    expect(mockDrawerField).toBeVisible();
+    expect(reportingYesButton).toBeVisible();
     await act(async () => {
-      await userEvent.type(mockDrawerField, "test");
+      await userEvent.click(reportingYesButton);
     });
 
     // verify rate field gets appended
-    expect(
-      screen.getByRole("textbox", { name: "mock rate 1 results" })
-    ).toBeVisible();
+    const dataCollectionMethodField = screen.getByRole("radio", {
+      name: "Administrative",
+    });
+    expect(dataCollectionMethodField).toBeVisible();
+    await act(async () => {
+      await userEvent.click(dataCollectionMethodField);
+    });
+
+    const rateField = screen.getByRole("textbox", {
+      name: "mock rate 1 results",
+    });
+    expect(rateField).toBeVisible();
+    await act(async () => {
+      await userEvent.type(rateField, "123");
+    });
 
     // close drawer
     const closeDrawerButton = screen.getByRole("button", {

--- a/services/ui-src/src/utils/forms/qualityMeasures.test.ts
+++ b/services/ui-src/src/utils/forms/qualityMeasures.test.ts
@@ -3,8 +3,30 @@ import {
   createRateField,
   RATE_ID_PREFIX,
 } from "./qualityMeasures";
-// utils
-import { mockDrawerForm } from "utils/testing/setupJest";
+
+const mockQualityMeasureDrawerForm = {
+  id: "mock-drawer-form-id",
+  fields: [
+    {
+      id: "measure_isReporting",
+      type: "radio",
+      validation: "radio",
+      props: {
+        choices: [
+          {
+            id: "xvBx2RGFpvmUf2Wk5bLe9u",
+            label: "Yes",
+            children: [],
+          },
+          {
+            id: "mock-no-choice",
+            label: "No",
+          },
+        ],
+      },
+    },
+  ],
+};
 
 const mockMeasure = {
   id: "mock-measure-1",
@@ -20,16 +42,21 @@ const mockMeasure = {
 describe("qualityMeasures utils", () => {
   describe("addRatesToForm()", () => {
     test("adds rate field", () => {
-      expect(mockDrawerForm.fields.length).toBe(1);
-      const modifiedForm = addRatesToForm(mockDrawerForm, mockMeasure);
-      expect(modifiedForm.fields.length).toBe(2);
-      expect(modifiedForm.fields[0]).toEqual(mockDrawerForm.fields[0]);
-      expect(modifiedForm.fields[1]).toEqual(
+      const modifiedForm = addRatesToForm(
+        mockQualityMeasureDrawerForm as any,
+        mockMeasure
+      );
+
+      expect(modifiedForm.fields).toHaveLength(1);
+      expect(
+        mockQualityMeasureDrawerForm.fields[0].props.choices[0].children
+      ).toEqual([]);
+      expect(modifiedForm.fields[0].props?.choices[0].children).toEqual([
         createRateField(
           mockMeasure.measure_rates[0].id,
           mockMeasure.measure_rates[0].name
-        )
-      );
+        ),
+      ]);
     });
   });
 
@@ -41,7 +68,7 @@ describe("qualityMeasures utils", () => {
       );
       expect(rateField.id).toEqual(`${RATE_ID_PREFIX}mock-rate-1`);
       expect(rateField.type).toEqual("number");
-      expect(rateField.validation).toEqual("numberOptional");
+      expect(rateField.validation).toEqual("number");
       expect(rateField.props.label).toEqual("mock rate 1 results");
     });
   });

--- a/services/ui-src/src/utils/forms/qualityMeasures.ts
+++ b/services/ui-src/src/utils/forms/qualityMeasures.ts
@@ -1,12 +1,12 @@
 // types
-import { EntityShape, FormJson } from "types";
+import { Choice, ChoiceFieldProps, EntityShape, FormJson } from "types";
 
 export const RATE_ID_PREFIX = "measure_rateResults-";
 
 export const createRateField = (id: string, name: string) => ({
   id: `${RATE_ID_PREFIX}${id}`,
   type: "number",
-  validation: "numberOptional",
+  validation: "number",
   props: {
     label: `${name} results`,
     hint: "If you are reporting results for this performance rate for this reporting period, enter a number. Enter “NR” if you are suppressing data for data privacy purposes. Enter “N/A” for all other reasons.",
@@ -18,8 +18,16 @@ export const addRatesToForm = (form: FormJson, measure: EntityShape) => {
   if (!rates) return form;
 
   const copiedDrawerForm = structuredClone(form);
+  const isReportingField = copiedDrawerForm.fields.find(
+    (field) => field.id === "measure_isReporting"
+  );
+  const answeredYesField: ChoiceFieldProps =
+    isReportingField?.props?.choices?.find(
+      (field: Choice) => field.id === "xvBx2RGFpvmUf2Wk5bLe9u"
+    );
+
   for (const rate of rates) {
-    copiedDrawerForm.fields.push(createRateField(rate.id, rate.name));
+    answeredYesField.children.push(createRateField(rate.id, rate.name));
   }
   return copiedDrawerForm;
 };

--- a/services/ui-src/src/utils/tables/entityRows.test.ts
+++ b/services/ui-src/src/utils/tables/entityRows.test.ts
@@ -27,6 +27,8 @@ import {
   mockModalDrawerReportPageJson,
   mockModalOverlayReportPageJson,
   mockNaaarAnalysisMethodsPageJson,
+  mockPlanEntities,
+  mockQualityMeasuresEntityV2,
 } from "utils/testing/setupJest";
 
 describe("buildDrawerReportPageEntityRows()", () => {
@@ -201,6 +203,8 @@ describe("calculateIsEntityCompleted()", () => {
       },
     ],
   };
+  const completeMeasureEntity = mockPlanEntities[0];
+  const qualityMeasures = [mockQualityMeasuresEntityV2];
 
   const baseCalculateIsEntityCompletedProps = {
     addEntityForm: mockDrawerForm,
@@ -209,6 +213,7 @@ describe("calculateIsEntityCompleted()", () => {
     isCustomEntity: false,
     reportingOnIlos: false,
     isMeasuresAndResultsPage: false,
+    qualityMeasures,
   };
 
   test("returns true for complete entity", () => {
@@ -268,8 +273,9 @@ describe("calculateIsEntityCompleted()", () => {
   test("returns true for measure and results when complete", () => {
     const props = {
       ...baseCalculateIsEntityCompletedProps,
+      entity: completeMeasureEntity,
       isMeasuresAndResultsPage: true,
-      measureId: "mock-measure-id-1",
+      measureId: mockQualityMeasuresEntityV2.id,
     };
     const input = calculateIsEntityCompleted(props);
     expect(input).toBe(true);
@@ -279,11 +285,11 @@ describe("calculateIsEntityCompleted()", () => {
     const props = {
       ...baseCalculateIsEntityCompletedProps,
       isMeasuresAndResultsPage: true,
-      measureId: "mock-measure-id-1",
+      measureId: mockQualityMeasuresEntityV2.id,
       entity: {
         id: "test-measure-plan-1",
         measures: {
-          "mock-measure-id-1": {
+          [mockQualityMeasuresEntityV2.id]: {
             measure_isReporting: [
               {
                 label: "Not reporting",
@@ -307,7 +313,7 @@ describe("calculateIsEntityCompleted()", () => {
       ...baseCalculateIsEntityCompletedProps,
       entity: incompleteEntity,
       isMeasuresAndResultsPage: true,
-      measureId: "mock-measure-id-1",
+      measureId: mockQualityMeasuresEntityV2.id,
     };
     const input = calculateIsEntityCompleted(props);
     expect(input).toBe(false);

--- a/services/ui-src/src/utils/tables/entityRows.ts
+++ b/services/ui-src/src/utils/tables/entityRows.ts
@@ -373,7 +373,7 @@ interface CalculateEntityCompletionProps {
   reportingOnIlos?: boolean;
   isMeasuresAndResultsPage?: boolean;
   measureId?: string;
-  qualityMeasures?: EntityShape;
+  qualityMeasures?: EntityShape[];
 }
 
 interface GetCompleteTextProps {

--- a/services/ui-src/src/utils/tables/entityRows.ts
+++ b/services/ui-src/src/utils/tables/entityRows.ts
@@ -50,6 +50,8 @@ export const buildDrawerReportPageEntityRows = ({
     const isCustomEntity =
       canAddEntities && !getDefaultAnalysisMethodIds().includes(entity.id);
 
+    const qualityMeasures = report.fieldData?.qualityMeasures;
+
     const isEntityCompleted = calculateIsEntityCompleted({
       addEntityForm,
       entity,
@@ -58,6 +60,7 @@ export const buildDrawerReportPageEntityRows = ({
       reportingOnIlos,
       isMeasuresAndResultsPage,
       measureId,
+      qualityMeasures,
     });
 
     const enterButton = getButtonProps({
@@ -111,19 +114,32 @@ export const calculateIsEntityCompleted = ({
   reportingOnIlos,
   isMeasuresAndResultsPage,
   measureId,
+  qualityMeasures,
 }: CalculateEntityCompletionProps) => {
   const calculateMeasureCompletion = () => {
     if (!measureId) return false;
     const planMeasureData = entity?.measures?.[measureId];
-    const isNotReporting = planMeasureData?.measure_isReporting?.length > 0;
-    const hasReasons =
-      planMeasureData?.measure_isNotReportingReason?.length > 0;
-    if (isNotReporting && hasReasons) return true;
+    if (!planMeasureData) return false;
 
-    const requiredFields = form.fields
-      ?.filter(isFieldElement)
-      .filter((field) => field.id !== "measure_isReporting");
-    return calculateEntityCompletion(requiredFields, planMeasureData);
+    const reporting = planMeasureData.measure_isReporting?.length > 0;
+    const notReportingReasons =
+      planMeasureData.measure_isNotReportingReason?.length > 0;
+    if (reporting && notReportingReasons) return true;
+
+    const dataMethod = planMeasureData.measure_dataCollectionMethod?.length > 0;
+
+    const qualityMeasureData = qualityMeasures?.find(
+      (qm: any) => qm.id === measureId
+    );
+
+    const ratesAreAnswered = qualityMeasureData?.measure_rates.every(
+      (rate: any) => {
+        const rateResult = planMeasureData[`measure_rateResults-${rate.id}`];
+        return rateResult && rateResult !== "";
+      }
+    );
+
+    return dataMethod && ratesAreAnswered;
   };
 
   const calculateEntityCompletion = (
@@ -357,6 +373,7 @@ interface CalculateEntityCompletionProps {
   reportingOnIlos?: boolean;
   isMeasuresAndResultsPage?: boolean;
   measureId?: string;
+  qualityMeasures?: EntityShape;
 }
 
 interface GetCompleteTextProps {

--- a/services/ui-src/src/utils/tables/getMcparEntityStatus.ts
+++ b/services/ui-src/src/utils/tables/getMcparEntityStatus.ts
@@ -15,12 +15,13 @@ export const getMcparEntityStatus = (
   entityType: EntityType,
   route: ModalOverlayReportPageShape
 ) => {
-  const plans = report?.fieldData?.plans;
-  const planForm = route?.drawerForm;
+  const plans = report.fieldData?.plans;
+  const planForm = route.drawerForm;
   if (entityType !== EntityType.QUALITY_MEASURES || !plans || !planForm)
     return false;
 
   const filteredPlans = getPlansNotExemptFromQualityMeasures(report);
+  const qualityMeasures = report.fieldData?.qualityMeasures;
 
   // If all plans are exempted, return true (nothing to complete)
   if (filteredPlans.length === 0) return true;
@@ -31,6 +32,7 @@ export const getMcparEntityStatus = (
       form: planForm,
       isMeasuresAndResultsPage: true,
       measureId: entity.id,
+      qualityMeasures: qualityMeasures,
     })
   );
 };


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
We've got an updated Quality Measure Reporting Fields PR! This one goes with our tried and true method of having a "Yes, I am reporting" choice rather than attempting to disable and clear the fields underneath it. A much, much easier approach. 

Heres a video of this working!

https://github.com/user-attachments/assets/7cfc93d3-5133-4200-b6db-a4ba99862e89

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5446

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Create a MCPAR Report
- Add a couple plans in A: Add Plans
- Navigate to D: Plan Level Indicators; VII: Quality Measures; Measures and Results
- Add a Measure!
- Go all the way through the measure, and play with entering data in the drawer. You should now be required to enter data either through "Yes, I am reporting" or "No I am not reporting"

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary