### PR TITLE
[CMDCT-5872] Preselect Quality Measures with Yes, I am reporting

### DIFF
--- a/services/ui-src/src/components/overlays/EntityDetailsOverlayQualityMeasures.test.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlayQualityMeasures.test.tsx
@@ -180,4 +180,24 @@ describe("<EntityDetailsOverlayQualityMeasures />", () => {
       expect(mockMcparReportContext.updateReport).toHaveBeenCalledTimes(1);
     });
   });
+
+  test("should pre-select 'Yes, I am reporting' when opening the drawer for a plan with no existing measure data", async () => {
+    const mockDrawerFormRoute = {
+      ...mockModalOverlayReportPageJson,
+      drawerForm: mockQualityMeasuresDrawerForm,
+    };
+    render(entityDetailsOverlayQualityMeasuresComponent(mockDrawerFormRoute));
+
+    const openDrawerButton = screen.getByRole("button", {
+      name: "Enter mock-plan-name-2",
+    });
+
+    await act(async () => {
+      await userEvent.click(openDrawerButton);
+    });
+    const reportingYesButton = screen.getByRole("radio", {
+      name: "Yes",
+    });
+    expect(reportingYesButton).toBeChecked();
+  });
 });

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlayQualityMeasures.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlayQualityMeasures.tsx
@@ -81,6 +81,7 @@ export const EntityDetailsOverlayQualityMeasures = ({
       plan?.measures?.[selectedMeasure.id] ?? {
         measure_isReporting: [
           {
+            // pragma: allowlist secret
             key: "measure_isReporting-xvBx2RGFpvmUf2Wk5bLe9u",
             value: "Yes, I am reporting",
           },

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlayQualityMeasures.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlayQualityMeasures.tsx
@@ -73,7 +73,20 @@ export const EntityDetailsOverlayQualityMeasures = ({
     );
     setDrawerForm(drawerFormWithRates);
     setSelectedPlan(plan);
-    setPlanMeasureData(plan?.measures?.[selectedMeasure.id]);
+
+    // If this plan has no existing data for the selected measure, pre-select
+    // "Yes, I am reporting" on the drawer form so users don't have to manually
+    // check it.
+    setPlanMeasureData(
+      plan?.measures?.[selectedMeasure.id] ?? {
+        measure_isReporting: [
+          {
+            key: "measure_isReporting-xvBx2RGFpvmUf2Wk5bLe9u",
+            value: "Yes, I am reporting",
+          },
+        ],
+      }
+    );
     onOpen();
   };
 

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlayQualityMeasures.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlayQualityMeasures.tsx
@@ -81,7 +81,7 @@ export const EntityDetailsOverlayQualityMeasures = ({
       plan?.measures?.[selectedMeasure.id] ?? {
         measure_isReporting: [
           {
-            // pragma: allowlist secret
+            // pragma: allowlist nextline secret
             key: "measure_isReporting-xvBx2RGFpvmUf2Wk5bLe9u",
             value: "Yes, I am reporting",
           },

--- a/services/ui-src/src/utils/forms/qualityMeasures.test.ts
+++ b/services/ui-src/src/utils/forms/qualityMeasures.test.ts
@@ -68,7 +68,12 @@ describe("qualityMeasures utils", () => {
       );
       expect(rateField.id).toEqual(`${RATE_ID_PREFIX}mock-rate-1`);
       expect(rateField.type).toEqual("number");
-      expect(rateField.validation).toEqual("number");
+      expect(rateField.validation).toEqual({
+        type: "number",
+        nested: true,
+        parentFieldName: "measure_isReporting",
+        parentOptionId: "xvBx2RGFpvmUf2Wk5bLe9u",
+      });
       expect(rateField.props.label).toEqual("mock rate 1 results");
     });
   });

--- a/services/ui-src/src/utils/forms/qualityMeasures.ts
+++ b/services/ui-src/src/utils/forms/qualityMeasures.ts
@@ -6,7 +6,12 @@ export const RATE_ID_PREFIX = "measure_rateResults-";
 export const createRateField = (id: string, name: string) => ({
   id: `${RATE_ID_PREFIX}${id}`,
   type: "number",
-  validation: "number",
+  validation: {
+    type: "number",
+    nested: true,
+    parentFieldName: "measure_isReporting",
+    parentOptionId: "xvBx2RGFpvmUf2Wk5bLe9u",
+  },
   props: {
     label: `${name} results`,
     hint: "If you are reporting results for this performance rate for this reporting period, enter a number. Enter “NR” if you are suppressing data for data privacy purposes. Enter “N/A” for all other reasons.",


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
The business owners requested that to save clicks when filling out Quality Measures, we make it so that newly created measures have 'Yes, I am reporting' pre checked. So I made that happen!

I also noted there was a bug in that if a user were to have selected "Yes, I am reporting" and saved the form, then went back in and tried to select "No, I am not reporting", the validation would still trigger for the child rate field living underneath the "Yes, I am reporting" choice. So I fixed that too!

Heres a video of the completed work and bugfix in action:

https://github.com/user-attachments/assets/0148ebda-4cec-4810-8847-cc432ff2065f

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5872

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

- Create a new MCPAR report
- Add a new plan, or 2 on the Add Plans page in Section A
- Scroll down and enter the Measure and Results page, located in Section D, and then further underneath that in Quality Measures
- Create a measure, filling in any details youd like
- Enter the measure
- Enter the plan 
- Fill out the drawer! See that it preselected "Yes, I am reporting" for you.
- Feel free to try and break it and save it different ways. It should all work as expected.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary