### PR TITLE
[CMDCT-5873] Make other specify fields have an accessible label

### DIFF
--- a/services/ui-src/src/components/fields/ChoiceListField.test.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.test.tsx
@@ -168,6 +168,24 @@ describe("<ChoiceListField />", () => {
       expect(screen.getByText("Choice 4")).toBeVisible();
       expect(screen.getByText("Choice 5")).toBeVisible();
     });
+
+    test("Nested child fields without their own label receive an accessible name derived from the choice and parent question labels", () => {
+      mockGetValues(undefined);
+      render(RadioComponentWithNestedChildren);
+
+      // Reveal the nested children
+      const thirdRadioOption = screen.getByLabelText("Choice 3");
+      fireEvent.click(thirdRadioOption);
+
+      // The nested "Choice 3-otherText" text input has no label of its own, so
+      // it should receive an aria-label combining the choice label and the
+      // parent question label so it has a unique accessible name.
+      const nestedInput = document.getElementById("Choice 3-otherText");
+      expect(nestedInput).toHaveAttribute(
+        "aria-label",
+        "Choice 3: Radio example"
+      );
+    });
   });
 
   describe("Test Choicelist Hydration", () => {

--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -98,6 +98,7 @@ export const ChoiceListField = ({
 
   // format choices with nested child fields to render (if any)
   const formatChoices = (choices: FieldChoice[]) => {
+    const parentQuestionLabel = label;
     return choices.map((choice: FieldChoice) => {
       const {
         id,
@@ -126,7 +127,12 @@ export const ChoiceListField = ({
 
       if (children) {
         const isNested = true;
-        const formattedChildren = formFieldFactory(children, {
+        const labeledChildren = applyAccessibleLabelsToChildFields(
+          children,
+          choice.label,
+          parentQuestionLabel
+        );
+        const formattedChildren = formFieldFactory(labeledChildren, {
           disabled: shouldDisableChildFields,
           nested: isNested,
           autosave,
@@ -343,6 +349,39 @@ const sx = {
   ".ds-c-choice[type='checkbox']:checked:disabled::before": {
     boxShadow: "inset 0 0 4em 1em #A6A6A6;",
   },
+};
+
+/*
+ * Ensure that nested child fields rendered under a choice have an
+ * accessible label. This is particularly important for "Other, specify"
+ * textfields. We can generate one by combining the parent choice and
+ * the parent question so multiple "Other, specify" inputs on the
+ * same page each have a unique accessible name.
+ */
+export const applyAccessibleLabelsToChildFields = (
+  children: FormField[],
+  parentChoiceLabel?: string,
+  parentQuestionLabel?: string
+): FormField[] => {
+  return children.map((child) => {
+    const existingProps = child.props ?? {};
+    const hasLabel = !!existingProps.label;
+    const hasAriaLabel =
+      !!existingProps["aria-label"] || !!existingProps.ariaLabel;
+    if (hasLabel || hasAriaLabel || !parentChoiceLabel) {
+      return child;
+    }
+    const ariaLabel = parentQuestionLabel
+      ? `${parentChoiceLabel}: ${parentQuestionLabel}`
+      : parentChoiceLabel;
+    return {
+      ...child,
+      props: {
+        ...existingProps,
+        "aria-label": ariaLabel,
+      },
+    };
+  });
 };
 
 export const getNestedChildFields = (


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->

Other, specify fields were throwing an accessibility error because their labels were empty. This PR makes it so those fields receive an aria-labelledby and targets the parent choice that is rendering that field while including "Other, specify" at the beginning of the label. Pretty neat!

Fixed up result:
<img width="1265" height="214" alt="Screenshot 2026-04-28 at 6 46 18 PM" src="https://github.com/user-attachments/assets/5304aaf2-020f-442e-94b3-ef417dca9548" />


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5873

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Load up a MCPAR report
Navigate to Section B, Part X: Program Integrity. 
Right Click Other, Specify and click inspect
Note that in the console its got an aria-labelled by!
You can also check out Section C, 1: Program Characteristics for another example.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
