### PR TITLE
prevent program_type-otherText from persisting after user input change in a copied over program

### DIFF
--- a/services/app-api/handlers/reports/update.ts
+++ b/services/app-api/handlers/reports/update.ts
@@ -29,6 +29,7 @@ import {
   notFound,
   ok,
 } from "../../utils/responses/response-lib";
+import { cleanupOtherTextFields } from "../../utils/reports/reports";
 // types
 import { isState, ReportJson, UserRoles } from "../../utils/types";
 
@@ -165,10 +166,10 @@ export const updateReport = handler(async (event, context) => {
   }
 
   // Post validated field data to s3 bucket
-  const fieldData = {
+  const fieldData = cleanupOtherTextFields({
     ...existingFieldData,
     ...validatedFieldData,
-  };
+  });
 
   const updateFieldDataParams = {
     Bucket: reportBucket,

--- a/services/app-api/utils/reports/reports.test.ts
+++ b/services/app-api/utils/reports/reports.test.ts
@@ -2,6 +2,7 @@ import {
   copyFieldDataFromSource,
   makePCCMModifications,
   populateQualityMeasures,
+  cleanupOtherTextFields,
 } from "./reports";
 // utils
 import { mockReportJson } from "../../utils/testing/setupJest";
@@ -235,6 +236,32 @@ describe("reports.ts", () => {
         );
         expect(res).toEqual({ stateName: "Minnesota" });
       });
+    });
+  });
+
+  describe("cleanupOtherTextFields()", () => {
+    test("removes empty otherText fields", () => {
+      const fieldData = {
+        program_type: [{ value: "MCO" }],
+        "program_type-otherText": "",
+        programName: "Test Program",
+      };
+      const result = cleanupOtherTextFields(fieldData);
+      expect(result).toEqual({
+        program_type: [{ value: "MCO" }],
+        programName: "Test Program",
+      });
+      expect(result).not.toHaveProperty("program_type-otherText");
+    });
+
+    test("keeps non-empty otherText fields", () => {
+      const fieldData = {
+        program_type: [{ value: "Other, specify" }],
+        "program_type-otherText": "Custom program type",
+        programName: "Test Program",
+      };
+      const result = cleanupOtherTextFields(fieldData);
+      expect(result).toEqual(fieldData);
     });
   });
 });

--- a/services/app-api/utils/reports/reports.ts
+++ b/services/app-api/utils/reports/reports.ts
@@ -137,3 +137,13 @@ export function populateQualityMeasures(
   }
   return fieldData;
 }
+
+export function cleanupOtherTextFields(fieldData: AnyObject): AnyObject {
+  const fieldDataCopy = { ...fieldData };
+  for (const key of Object.keys(fieldDataCopy)) {
+    if (key.endsWith("-otherText") && fieldDataCopy[key] === "") {
+      delete fieldDataCopy[key];
+    }
+  }
+  return fieldDataCopy;
+}


### PR DESCRIPTION
…e in a copied over program

<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
from the card:

> In the MCPAR program type (Section C: Program-Level Indicators), when a report has been copied over and changes the program type from "Other, specify" to one of the other radio choices, the "other, specify" text persists in the field data that is ingested by DataConnect.


This PR removes "-otherText" fields from fieldData when their value is empty. The UI sets these fields to "" when a user deselects "Other, specify", but the empty string can persist in the database via the merge with existing field data in a copied report.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6500

---
### How to test
Use the deployed env. https://d1so0bfe6uuop3.cloudfront.net/
There is a filled out MCAR program (titled `PMAP`) where `Program Type` is `Other, specify`, copy that program.
Go to `Section C > Program Characteristics`, and select a different option for `Program Type`.
Inspect the field data and see that the value for `program_type` has changed, and confirm that the key `program_type-otherText` is not present anymore in `fieldData`.



### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
