### PR TITLE
[CMDCT-5996] Add Launch Darkly local override

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -4,6 +4,7 @@ COGNITO_USER_POOL_CLIENT_ID=op://mdct_devs/mcr_secrets/COGNITO_USER_POOL_CLIENT_
 COGNITO_USER_POOL_ID=op://mdct_devs/mcr_secrets/COGNITO_USER_POOL_ID
 COGNITO_USER_POOL_CLIENT_DOMAIN=op://mdct_devs/mcr_secrets/COGNITO_USER_POOL_CLIENT_DOMAIN
 COGNITO_IDENTITY_POOL_ID=op://mdct_devs/mcr_secrets/COGNITO_IDENTITY_POOL_ID
+LD_LOCAL_FLAGS='{"local": false, "flags": { "naaarProgramList": false, "newQualityMeasuresSectionEnabled": false, "summer2026SansQm": false }}'
 LD_SDK_KEY=op://mdct_devs/mcr_secrets/LD_SDK_KEY_DEV
 REACT_APP_LD_SDK_CLIENT=op://mdct_devs/mcr_secrets/REACT_APP_LD_SDK_CLIENT
 

--- a/cli/lib/utils.ts
+++ b/cli/lib/utils.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import dotenv from "dotenv";
 import {
   CloudFormationClient,
   DescribeStacksCommand,
@@ -31,6 +33,25 @@ const buildUiEnvObject = (
   cfnOutputs: Record<string, string>
 ): Record<string, string> => {
   if (stage === "localstack") {
+    const escapeDoubleQuotes = (value: string) => {
+      return value.replaceAll('"', String.raw`\"`);
+    };
+
+    function checkLocalFlagsFormat(value?: string) {
+      const defaultValue = '{"local": false, "flags": {}}';
+      if (!value) return defaultValue;
+
+      try {
+        const parsed = JSON.parse(value);
+        return JSON.stringify(parsed);
+      } catch {
+        console.error(
+          "Invalid local flags format. Soft failing to empty flags."
+        );
+        return defaultValue;
+      }
+    }
+
     return {
       SKIP_PREFLIGHT_CHECK: "true",
       API_REGION: region,
@@ -46,6 +67,10 @@ const buildUiEnvObject = (
       COGNITO_REDIRECT_SIGNOUT: "http://localhost:3000/postLogout",
       POST_SIGNOUT_REDIRECT: "http://localhost:3000/",
       REACT_APP_LD_SDK_CLIENT: process.env.REACT_APP_LD_SDK_CLIENT!,
+      LD_LOCAL_FLAGS: escapeDoubleQuotes(
+        checkLocalFlagsFormat(process.env.LD_LOCAL_FLAGS)
+      ),
+      LD_SDK_KEY: process.env.LD_SDK_KEY!,
       STAGE: "local",
     };
   }
@@ -68,13 +93,32 @@ const buildUiEnvObject = (
   };
 };
 
-export const runFrontendLocally = async (stage: string) => {
+const buildEnvFiles = async (stage: string) => {
+  dotenv.config({ override: true });
+
   const outputs = await getCloudFormationStackOutputValues(
     `${project}-${stage}`
   );
   const envVars = buildUiEnvObject(stage, outputs);
   await writeLocalUiEnvFile(envVars);
   await writeSeedEnvFile(envVars);
+};
 
+const watchLocalEnv = (stage: string) => {
+  let timeout: NodeJS.Timeout | null = null;
+
+  function updateEnvFiles() {
+    if (timeout) clearTimeout(timeout);
+    timeout = setTimeout(async () => {
+      await buildEnvFiles(stage);
+    }, 100);
+  }
+  updateEnvFiles();
+
+  fs.watch(".env", updateEnvFiles);
+};
+
+export const runFrontendLocally = async (stage: string) => {
+  watchLocalEnv(stage);
   runCommand("ui", ["yarn", "start"], "services/ui-src");
 };

--- a/cli/lib/write-seed-env-file.ts
+++ b/cli/lib/write-seed-env-file.ts
@@ -4,16 +4,24 @@ import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const outputPath = path.join(__dirname, "../../");
-const configFilePath = path.resolve(outputPath, ".env.seed");
+const configFilePath = path.resolve(
+  path.join(__dirname, "../../"),
+  ".env.seed"
+);
 
 export const writeSeedEnvFile = async (
   envVariables: Record<string, string>
 ) => {
   await fs.rm(configFilePath, { force: true });
 
+  const unescapeDoubleQuotes = (value: string) => {
+    return value.replaceAll(String.raw`\"`, '"');
+  };
+
   const envConfigContent = [
     `API_URL=${envVariables["API_URL"].replace("https", "http")}`,
+    `launchDarklyLocalFlags='${unescapeDoubleQuotes(envVariables["LD_LOCAL_FLAGS"])}'`,
+    `launchDarklyServer=${envVariables["LD_SDK_KEY"]}`,
   ].join("\n");
 
   await fs.writeFile(configFilePath, envConfigContent);

--- a/deployment/local/prerequisites.ts
+++ b/deployment/local/prerequisites.ts
@@ -29,6 +29,21 @@ export class LocalPrerequisiteStack extends Stack {
       cidrBlock: "10.0.1.0/24",
     });
 
+    function checkLocalFlagsFormat(value?: string) {
+      const defaultValue = '{"local": false, "flags": {}}';
+      if (!value) return defaultValue;
+
+      try {
+        const parsed = JSON.parse(value);
+        return JSON.stringify(parsed);
+      } catch {
+        console.error(
+          "Invalid local flags format. Soft failing to empty flags."
+        );
+        return defaultValue;
+      }
+    }
+
     new secretsmanager.Secret(this, "DefaultSecret", {
       secretName: `${process.env.PROJECT!}-default`, // pragma: allowlist secret
       secretObjectValue: {
@@ -37,6 +52,9 @@ export class LocalPrerequisiteStack extends Stack {
         launchDarklyClient: SecretValue.unsafePlainText("localstack"),
         launchDarklyServer: SecretValue.unsafePlainText(
           process.env.LD_SDK_KEY!
+        ),
+        launchDarklyLocalFlags: SecretValue.unsafePlainText(
+          checkLocalFlagsFormat(process.env.LD_LOCAL_FLAGS)
         ),
         oktaMetadataUrl: SecretValue.unsafePlainText("localstack"),
         redirectSignout: SecretValue.unsafePlainText("localstack"),

--- a/deployment/stacks/api.ts
+++ b/deployment/stacks/api.ts
@@ -29,6 +29,7 @@ interface CreateApiComponentsProps {
   mlrFormBucket: s3.IBucket;
   naaarFormBucket: s3.IBucket;
   launchDarklyServer: string;
+  launchDarklyLocalFlags?: string;
 }
 
 export function createApiComponents(props: CreateApiComponentsProps) {
@@ -45,6 +46,7 @@ export function createApiComponents(props: CreateApiComponentsProps) {
     mlrFormBucket,
     naaarFormBucket,
     launchDarklyServer,
+    launchDarklyLocalFlags = '{"local": false, "flags": {}}',
   } = props;
 
   const service = "app-api";
@@ -118,6 +120,7 @@ export function createApiComponents(props: CreateApiComponentsProps) {
     brokerString,
     STAGE: stage,
     launchDarklyServer,
+    launchDarklyLocalFlags,
     MCPAR_FORM_BUCKET: mcparFormBucket.bucketName,
     MLR_FORM_BUCKET: mlrFormBucket.bucketName,
     NAAAR_FORM_BUCKET: naaarFormBucket.bucketName,

--- a/services/app-api/utils/featureFlags/featureFlags.test.ts
+++ b/services/app-api/utils/featureFlags/featureFlags.test.ts
@@ -60,6 +60,52 @@ describe("utils/featureFlags", () => {
       expect(consoleSpy.error).toHaveBeenCalled();
       expect(expectedResult).toBe(false);
     });
+
+    test("uses local flags - returns true", async () => {
+      process.env.launchDarklyLocalFlags =
+        '{"local": true, "flags": {"mockLocalFlag": true}}';
+      await getLaunchDarklyClient();
+
+      const expectedResult = await getFlagValue("mockLocalFlag");
+      expect(expectedResult).toBe(true);
+    });
+
+    test("uses local flags - returns false", async () => {
+      process.env.launchDarklyLocalFlags =
+        '{"local": true, "flags": {"mockLocalFlag": false}}';
+      await getLaunchDarklyClient();
+
+      const expectedResult = await getFlagValue("mockLocalFlag");
+      expect(expectedResult).toBe(false);
+    });
+
+    test("uses LD client flags - returns true", async () => {
+      (LD.init as jest.Mock).mockReturnValue({
+        variation,
+        waitForInitialization,
+      });
+      process.env.launchDarklyLocalFlags =
+        '{"local": false, "flags": {"mockLocalFlag": false}}';
+
+      await getLaunchDarklyClient();
+
+      const expectedResult = await getFlagValue("mockLocalFlag");
+      expect(expectedResult).toBe(true);
+    });
+
+    test("uses LD client flags - returns false", async () => {
+      (LD.init as jest.Mock).mockReturnValue({
+        variation: jest.fn().mockResolvedValue(false),
+        waitForInitialization,
+      });
+      process.env.launchDarklyLocalFlags =
+        '{"local": false, "flags": {"mockLocalFlag": true}}';
+
+      await getLaunchDarklyClient();
+
+      const expectedResult = await getFlagValue("mockLocalFlag");
+      expect(expectedResult).toBe(false);
+    });
   });
 
   describe("isFeatureFlagEnabled()", () => {

--- a/services/app-api/utils/featureFlags/featureFlags.ts
+++ b/services/app-api/utils/featureFlags/featureFlags.ts
@@ -1,17 +1,29 @@
 import * as LD from "@launchdarkly/node-server-sdk";
 
 export const getLaunchDarklyClient = async () => {
-  const fallback = {
-    variation: (_key: string, _context: any, defaultValue: Promise<any>) =>
-      defaultValue,
+  const localFlags = process.env.launchDarklyLocalFlags
+    ? JSON.parse(process.env.launchDarklyLocalFlags)
+    : {};
+  const { local = false, flags = {} } = localFlags;
+
+  const localClient = {
+    variation: (
+      flagName: string,
+      _context: any,
+      defaultValue: Promise<boolean>
+    ) => flags[flagName] ?? defaultValue,
   } as LD.LDClient;
-  const sdkKey = process.env.LD_SDK_KEY || process.env.launchDarklyServer;
+
+  const sdkKey = process.env.launchDarklyServer;
 
   if (!sdkKey) {
     console.error(
-      "Missing LaunchDarkly SDK server key. Soft failing to fallback client."
+      "Missing LaunchDarkly SDK server key. Soft failing to local client."
     );
-    return fallback;
+  }
+
+  if (local || !sdkKey) {
+    return localClient;
   }
 
   try {
@@ -24,7 +36,7 @@ export const getLaunchDarklyClient = async () => {
     return client;
   } catch (error) {
     console.error(error);
-    return fallback;
+    return localClient;
   }
 };
 
@@ -35,8 +47,15 @@ export const getFlagValue = async (flagName: string) => {
 };
 
 export const isFeatureFlagEnabled = async (flagName: string) => {
+  const localFlags = process.env.launchDarklyLocalFlags
+    ? JSON.parse(process.env.launchDarklyLocalFlags)
+    : {};
+  const { local = false } = localFlags;
+
   const flagValue = await getFlagValue(flagName);
 
-  console.log(`FEATURE FLAG: ${flagName}, enabled: ${flagValue}`);
+  console.log(
+    `FEATURE FLAG: ${flagName}, enabled: ${flagValue}, local: ${local}`
+  );
   return flagValue;
 };

--- a/services/ui-src/src/config.ts
+++ b/services/ui-src/src/config.ts
@@ -18,6 +18,7 @@ const config = {
   },
   POST_SIGNOUT_REDIRECT: window._env_.POST_SIGNOUT_REDIRECT,
   REACT_APP_LD_SDK_CLIENT: window._env_.REACT_APP_LD_SDK_CLIENT,
+  launchDarklyLocalFlags: window._env_.LD_LOCAL_FLAGS,
 };
 
 export default config;

--- a/services/ui-src/src/index.tsx
+++ b/services/ui-src/src/index.tsx
@@ -6,7 +6,7 @@ import config from "config";
 import "aws-amplify/auth/enable-oauth-listener";
 // utils
 import { ApiProvider, UserProvider } from "utils";
-import { asyncWithLDProvider } from "launchdarkly-react-client-sdk";
+import { asyncWithLDProvider, LDOptions } from "launchdarkly-react-client-sdk";
 // components
 import { App, Error } from "components";
 // styles
@@ -43,14 +43,28 @@ Amplify.configure({
 
 // LaunchDarkly configuration
 const ldClientId = config.REACT_APP_LD_SDK_CLIENT;
-(async () => {
-  const LDProvider = await asyncWithLDProvider({
-    clientSideID: ldClientId!,
-    options: {
+const localFlags = config.launchDarklyLocalFlags
+  ? JSON.parse(config.launchDarklyLocalFlags)
+  : {};
+const { local = false, flags = {} } = localFlags;
+
+const options: LDOptions = local
+  ? {
+      baseUrl: "https://clientsdk.launchdarkly.us",
+      bootstrap: flags,
+      sendEvents: false,
+      streaming: false,
+    }
+  : {
       baseUrl: "https://clientsdk.launchdarkly.us",
       streamUrl: "https://clientstream.launchdarkly.us",
       eventsUrl: "https://events.launchdarkly.us",
-    },
+    };
+
+(async () => {
+  const LDProvider = await asyncWithLDProvider({
+    clientSideID: ldClientId,
+    options,
     deferInitialization: false,
   });
 

--- a/services/ui-src/vite.config.mts
+++ b/services/ui-src/vite.config.mts
@@ -4,7 +4,25 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   base: "/",
-  plugins: [react(), tsconfigPaths()],
+  plugins: [
+    react(),
+    tsconfigPaths(),
+    {
+      name: "watch-env-config",
+      configureServer(server) {
+        const envFile = "services/ui-src/public/env-config.js";
+        server.watcher.add(envFile);
+        server.watcher.on("change", (file) => {
+          if (file.endsWith(envFile)) {
+            console.log("[vite] page reload public/env-config.js");
+            server.ws.send({
+              type: "full-reload",
+            });
+          }
+        });
+      },
+    },
+  ],
   server: {
     open: true,
     port: 3000,


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
This PR adds the ability to override Launch Darkly flags locally. Based on https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/1366/

Changes:
- Add `LD_LOCAL_FLAGS` to `.env` to set local flag values
- Reload `LD_LOCAL_FLAGS` in front-end if `.env` is changed without needing to restart the app entirely
- To reload `LD_LOCAL_FLAGS` in back-end still requires restarting the app

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5996

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

1. Run `./run update-env` to update your local `.env`

**Test Back-End:**

With local flags:
1. In your `.env`, set `LD_LOCAL_FLAGS='{"local": true, "flags": { "naaarProgramList": false, "newQualityMeasuresSectionEnabled": false, "summer2026SansQm": false }}'`
2. Run `colima stop` (process.env can be sticky in backend)
3. Start MCR locally: `./run local`
4. Create an MLR
5. Go to MLR Reporting
6. Click `Add program reporting information`, add info
7. Click `Enter MLR`
8. Under Section 4 it should say `4. Remittance` because the local flag is used:
<img width="808" height="500" alt="Screenshot 2026-05-27 at 5 28 44 PM" src="https://github.com/user-attachments/assets/8b4cd7ac-5717-4380-acd0-4b5c6d79cdaa" />

Without local flags:
1. In your `.env`, set `LD_LOCAL_FLAGS='{"local": false, "flags": { "naaarProgramList": false, "newQualityMeasuresSectionEnabled": false, "summer2026SansQm": false }}'`
2. Run `colima stop` (process.env can be sticky in backend)
3. Start MCR locally: `./run local`
4. Create an MLR
5. Go to MLR Reporting
6. Click `Add program reporting information`, add info
7. Click `Enter MLR`
8. Under Section 4 it should say `4. Remittance/Overpayment` because the local flag is ignored (`summer2026SansQm` is `true` in dev):
<img width="812" height="488" alt="Screenshot 2026-05-27 at 5 21 52 PM" src="https://github.com/user-attachments/assets/7d6dcfaf-3092-496c-a8e5-21fb7517e3ad" />

**Test Front-End:**

With local flags:
1. In your `.env`, set `LD_LOCAL_FLAGS='{"local": true, "flags": { "naaarProgramList": true, "newQualityMeasuresSectionEnabled": false, "summer2026SansQm": false }}'`
2. Start MCR locally: `./run local`
3. Go to create a NAAAR
4. There should be a program list because the local flag is used:
<img width="476" height="698" alt="Screenshot 2026-05-27 at 5 11 13 PM" src="https://github.com/user-attachments/assets/157b5e22-6e6b-4351-80ac-62bac46a8a29" />

Without local flags:
1. Continue from the previous steps
2. In your `.env`, set `LD_LOCAL_FLAGS='{"local": false, "flags": { "naaarProgramList": true, "newQualityMeasuresSectionEnabled": false, "summer2026SansQm": false }}'`
3. NAAAR dashboard page should auto-reload
4. There should not be a program list because the local flags are ignored (`naaarProgramList` is `false` in dev):
<img width="479" height="496" alt="Screenshot 2026-05-27 at 5 10 26 PM" src="https://github.com/user-attachments/assets/2d2d0983-362b-45e0-8a74-299c24fe91a2" />

<!-- ### Notes -->
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->
<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->