### PR TITLE
CMDCT-6122: skips sending objects over 1MB to Kafka

### DIFF
--- a/services/app-api/utils/kafka/kafka-source-lib.test.ts
+++ b/services/app-api/utils/kafka/kafka-source-lib.test.ts
@@ -181,6 +181,21 @@ describe("Test Kafka Lib", () => {
     expect(mockSendBatch).toHaveBeenCalledTimes(1);
   });
 
+  test("Skips oversized bucket events before sending to Kafka", async () => {
+    const s3GetSpy = jest.spyOn(s3Lib, "get");
+    const sourceLib = new KafkaSourceLib("mcr", "v0", [table], [bucket]);
+    const event = structuredClone(s3Event) as any;
+    event.Records[0].s3.object.size = 1_000_000;
+
+    await sourceLib.handler(event);
+
+    expect(consoleSpy.log).toHaveBeenCalledWith(
+      expect.stringContaining("Skipping Kafka publish for oversized S3 object")
+    );
+    expect(s3GetSpy).not.toHaveBeenCalled();
+    expect(mockSendBatch).not.toHaveBeenCalled();
+  });
+
   test("Handles events without versions", async () => {
     const sourceLib = new KafkaSourceLib("mcr", null, [table], [bucket]);
     await sourceLib.handler(dynamoEvent);

--- a/services/app-api/utils/kafka/kafka-source-lib.ts
+++ b/services/app-api/utils/kafka/kafka-source-lib.ts
@@ -24,6 +24,9 @@ type SourceBucketTopicMapping = {
   s3Prefix: string;
 };
 
+// Kafka rejects messages at 1 MB and above.
+const MAX_KAFKA_S3_PAYLOAD_BYTES = 1_000_000;
+
 let kafka: Kafka;
 let producer: Producer;
 
@@ -184,6 +187,16 @@ class KafkaSourceLib {
 
         // Filter for only the response info
         if (!topicName || !key.includes(".json")) {
+          continue;
+        }
+        const objectSize = Number(s3Record.s3.object.size);
+        if (
+          Number.isFinite(objectSize) &&
+          objectSize >= MAX_KAFKA_S3_PAYLOAD_BYTES
+        ) {
+          console.log(
+            `Skipping Kafka publish for oversized S3 object ${key} (${objectSize} bytes) from bucket ${s3Record.s3.bucket.name}; Kafka/Splunk rejects 1MB+ messages.`
+          );
           continue;
         }
         payload = await this.createS3Payload(record);


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
CMDCT-6122: skips sending objects over 1MB to Kafka


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6122

---
### How to test
In the deployed environment, verify an object over 1MB logs a warning in cloudwatch and is not attempted to be sent to Kafka.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
