### PR TITLE
CMDCT-6167 footer link focus color fix

### DIFF
--- a/services/ui-src/src/components/layout/Footer.tsx
+++ b/services/ui-src/src/components/layout/Footer.tsx
@@ -240,6 +240,9 @@ const sx = {
   },
   link: {
     margin: "0.5rem 0",
+    "&:focus-visible, &:visited:focus-visible": {
+      color: "gray_lighter",
+    },
     ".desktop &": {
       "&:first-of-type": {
         paddingRight: "spacer1",


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
Links in the footer changed to an inaccessible color on keyboard focus. This was [found in MFP](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/1471), and MCR has the same issue.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6167
CMDCT-6151

---
### How to test
- Run local env or use the [deployed env](https://d3sq3xyrhtyezd.cloudfront.net/)
- Log in
- On the home page (or any other page), use the `Tab` key to move keyboard focus to the footer links
- Confirm that when links in the footer have focus, they are still readable

