### PR TITLE
CMDCT-6350: Connect dropdown error messages to field

### DIFF
--- a/services/ui-src/src/components/fields/DropdownField.test.tsx
+++ b/services/ui-src/src/components/fields/DropdownField.test.tsx
@@ -96,6 +96,15 @@ const dropdownComponentWithYoYCopyNoSubmittedReports = (
   </RouterWrappedComponent>
 );
 
+const dropdownComponentWithHint = (
+  <DropdownField
+    name="testDropdown"
+    label="test-dropdown-label"
+    hint="Select the option that applies"
+    options={mockDropdownOptions}
+  />
+);
+
 describe("<DropdownField />", () => {
   describe("Test DropdownField basic functionality", () => {
     test("Dropdown renders", () => {
@@ -103,6 +112,7 @@ describe("<DropdownField />", () => {
       render(dropdownComponentWithOptions);
       const dropdown = screen.getByLabelText("test-dropdown-label");
       expect(dropdown).toBeVisible();
+      expect(dropdown).toHaveAttribute("aria-invalid", "false");
     });
 
     test("DropdownField calls onChange function successfully", async () => {
@@ -310,15 +320,7 @@ describe("<DropdownField />", () => {
     });
   });
 
-  testA11yAct(dropdownComponentWithOptions, () => {
-    mockGetValues(undefined);
-  });
-
   describe("Dropdown connects error message to select for accessibility", () => {
-    afterEach(() => {
-      jest.clearAllMocks();
-    });
-
     test("Sets aria-invalid and aria-describedby, and renders the error text, when validation fails", () => {
       mockUseFormContext.mockImplementation((): any => ({
         ...mockRhfMethods,
@@ -334,13 +336,29 @@ describe("<DropdownField />", () => {
       const dropdown = screen.getByLabelText("test-dropdown-label");
 
       expect(dropdown).toHaveAttribute("aria-invalid", "true");
+      // no hint present, so aria-describedby only includes the error id
+      expect(dropdown).toHaveAttribute(
+        "aria-describedby",
+        "testDropdown__error"
+      );
+      expect(dropdown).toHaveClass("ds-c-field", "ds-c-field--error");
 
-      const describedById = dropdown.getAttribute("aria-describedby");
-      expect(describedById).toContain("testDropdown__error");
-
-      const errorEl = document.getElementById("testDropdown__error");
-      expect(errorEl).toBeInTheDocument();
-      expect(errorEl).toHaveTextContent("A response is required");
+      const errorEl = screen.getByText("A response is required");
+      expect(errorEl).toHaveAttribute("id", "testDropdown__error");
     });
+
+    test("Includes the hint id in aria-describedby when a hint is present", () => {
+      mockGetValues(undefined);
+      render(dropdownComponentWithHint);
+      const dropdown = screen.getByLabelText("test-dropdown-label");
+      expect(dropdown).toHaveAttribute(
+        "aria-describedby",
+        "testDropdown__error testDropdown-hint"
+      );
+    });
+  });
+
+  testA11yAct(dropdownComponentWithOptions, () => {
+    mockGetValues(undefined);
   });
 });

--- a/services/ui-src/src/components/fields/DropdownField.test.tsx
+++ b/services/ui-src/src/components/fields/DropdownField.test.tsx
@@ -313,4 +313,34 @@ describe("<DropdownField />", () => {
   testA11yAct(dropdownComponentWithOptions, () => {
     mockGetValues(undefined);
   });
+
+  describe("Dropdown connects error message to select for accessibility", () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test("Sets aria-invalid and aria-describedby, and renders the error text, when validation fails", () => {
+      mockUseFormContext.mockImplementation((): any => ({
+        ...mockRhfMethods,
+        getValues: jest.fn().mockReturnValueOnce([]).mockReturnValue(undefined),
+        formState: {
+          errors: {
+            testDropdown: { value: { message: "A response is required" } },
+          },
+        },
+      }));
+
+      render(dropdownComponentWithOptions);
+      const dropdown = screen.getByLabelText("test-dropdown-label");
+
+      expect(dropdown).toHaveAttribute("aria-invalid", "true");
+
+      const describedById = dropdown.getAttribute("aria-describedby");
+      expect(describedById).toContain("testDropdown__error");
+
+      const errorEl = document.getElementById("testDropdown__error");
+      expect(errorEl).toBeInTheDocument();
+      expect(errorEl).toHaveTextContent("A response is required");
+    });
+  });
 });

--- a/services/ui-src/src/components/fields/DropdownField.tsx
+++ b/services/ui-src/src/components/fields/DropdownField.tsx
@@ -210,7 +210,9 @@ export const DropdownField = ({
   const formErrorState: AnyObject = form?.formState?.errors;
   const errorMessage = formErrorState?.[name]?.value.message;
   const parsedHint = hint && parseCustomHtml(hint);
+  const ariaDescribedBy = `${name}__error${parsedHint ? ` ${name}-hint` : ""}`;
   const nestedChildClasses = nested ? "nested ds-c-choice__checkedChild" : "";
+  const selectClasses = `ds-c-field${errorMessage ? " ds-c-field--error" : ""}`;
   const labelClass = !label ? "no-label" : "";
   const labelText =
     label && styleAsOptional ? labelTextWithOptional(label) : label;
@@ -220,17 +222,18 @@ export const DropdownField = ({
       <Label htmlFor={name} id={`${name}-label`}>
         {labelText || ""}
       </Label>
-      {parsedHint && <Hint id={name}>{parsedHint}</Hint>}
-      {errorMessage && <InlineError>{errorMessage}</InlineError>}
+      {parsedHint && <Hint id={`${name}-hint`}>{parsedHint}</Hint>}
+      <InlineError id={`${name}__error`}>{errorMessage}</InlineError>
       <select
         name={name}
         id={name}
+        aria-describedby={ariaDescribedBy}
         aria-label={labelText ? undefined : name}
-        aria-invalid="false"
+        aria-invalid={!!errorMessage}
         onChange={onChangeHandler}
         onBlur={onBlurHandler}
         value={displayValue?.value}
-        className="ds-c-field"
+        className={selectClasses}
         {...props}
       >
         {formattedOptions.map((option: DropdownOptions) => (


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
Error messages for the dropdown field are not connected to the input, therefore Assistive Tech (AT) will not announce the error message. This PR programmatically connects error message to input field via aria-describedby and aria-invalid.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6350

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Run this PR locally
- Navigate to NAAAR -> Add/copy NAAAR
- With the Add/copy modal open, [turn on VoiceOver](https://support.apple.com/guide/voiceover/turn-voiceover-on-or-off-vo2682/mac) (if you're on macOS)
- Use the Tab key to navigate to the required Program name field or another required dropdown field
- Once you blur one of the required fields, return to the errored field, you should be able to hear that the error message is read
- You should be able to hear the error message when it's visible and the field is focused


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
See [this PR](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/1476) for similar work in MFP


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
