### PR TITLE
[CMDCT-6442] NAAAR Plan Compliance Fix

### DIFF
--- a/services/app-api/forms/routes/naaar/state-and-program-information/index.ts
+++ b/services/app-api/forms/routes/naaar/state-and-program-information/index.ts
@@ -10,7 +10,7 @@ export const stateAndProgramInformationRoute: ParentRoute = {
   children: [
     stateInformationAndReportingScenarioRoute,
     addPlansRoute,
-    analysisMethodsRoute,
     providerTypeCoverageRoute,
+    analysisMethodsRoute,
   ],
 };

--- a/services/ui-src/src/components/overlays/PlanComplianceTableOverlay.test.tsx
+++ b/services/ui-src/src/components/overlays/PlanComplianceTableOverlay.test.tsx
@@ -43,22 +43,25 @@ const reportWithAnalysisMethods = (analysisMethods: any[]) =>
     fieldData: { ...mockNaaarReport.fieldData, analysisMethods },
   }) as ReportShape;
 
-const planComplianceTableOverlayComponent = (
-  disabled: boolean = false,
-  submitting: boolean = false,
-  selectedEntity: any = mockEntityStore.selectedEntity,
-  report: ReportShape = mockNaaarReport
-) => (
+interface OverlayOverrides {
+  selectedEntity?: EntityShape;
+  report?: ReportShape;
+}
+
+const planComplianceTableOverlayComponent = ({
+  selectedEntity = mockEntityStore.selectedEntity,
+  report = mockNaaarReport,
+}: OverlayOverrides = {}) => (
   <RouterWrappedComponent>
     <OverlayProvider>
       <PlanComplianceTableOverlay
         closeEntityDetailsOverlay={mockCloseEntityDetailsOverlay}
-        disabled={disabled}
+        disabled={false}
         standards={mockNaaarStandards}
         form={mockForm}
         onSubmit={mockOnSubmit}
         selectedEntity={selectedEntity}
-        submitting={submitting}
+        submitting={false}
         table={mockTable}
         validateOnRender={false}
         verbiage={mockVerbiage}
@@ -141,11 +144,9 @@ describe("<PlanComplianceTableOverlay />", () => {
     } as EntityShape;
 
     render(
-      planComplianceTableOverlayComponent(
-        undefined,
-        undefined,
-        mockSelectedEntity
-      )
+      planComplianceTableOverlayComponent({
+        selectedEntity: mockSelectedEntity,
+      })
     );
 
     // Table
@@ -198,11 +199,9 @@ describe("<PlanComplianceTableOverlay />", () => {
     } as EntityShape;
 
     render(
-      planComplianceTableOverlayComponent(
-        undefined,
-        undefined,
-        mockSelectedEntity
-      )
+      planComplianceTableOverlayComponent({
+        selectedEntity: mockSelectedEntity,
+      })
     );
 
     // Table
@@ -230,12 +229,9 @@ describe("<PlanComplianceTableOverlay />", () => {
 
     test("renders methods applied to the selected plan, even when the stored plan name is stale", async () => {
       render(
-        planComplianceTableOverlayComponent(
-          undefined,
-          undefined,
-          undefined,
-          reportWithAnalysisMethods(mockNaaarAnalysisMethods)
-        )
+        planComplianceTableOverlayComponent({
+          report: reportWithAnalysisMethods(mockNaaarAnalysisMethods),
+        })
       );
 
       await openNonComplianceForm();
@@ -260,12 +256,9 @@ describe("<PlanComplianceTableOverlay />", () => {
       }));
 
       render(
-        planComplianceTableOverlayComponent(
-          undefined,
-          undefined,
-          undefined,
-          reportWithAnalysisMethods(methodsForAnotherPlan)
-        )
+        planComplianceTableOverlayComponent({
+          report: reportWithAnalysisMethods(methodsForAnotherPlan),
+        })
       );
 
       await openNonComplianceForm();

--- a/services/ui-src/src/components/overlays/PlanComplianceTableOverlay.test.tsx
+++ b/services/ui-src/src/components/overlays/PlanComplianceTableOverlay.test.tsx
@@ -8,11 +8,13 @@ import {
   EntityDetailsTableVerbiage,
   EntityShape,
   FormJson,
+  ReportShape,
 } from "types";
 // utils
 import {
   mockEntityDetailsMultiformOverlayJson,
   mockEntityStore,
+  mockNaaarAnalysisMethods,
   mockNaaarReport,
   mockNaaarStandards,
   mockStateUserStore,
@@ -35,10 +37,17 @@ const mockVerbiage = details?.forms![1].verbiage as EntityDetailsTableVerbiage;
 const mockCloseEntityDetailsOverlay = jest.fn();
 const mockOnSubmit = jest.fn();
 
+const reportWithAnalysisMethods = (analysisMethods: any[]) =>
+  ({
+    ...mockNaaarReport,
+    fieldData: { ...mockNaaarReport.fieldData, analysisMethods },
+  }) as ReportShape;
+
 const planComplianceTableOverlayComponent = (
   disabled: boolean = false,
   submitting: boolean = false,
-  selectedEntity: any = mockEntityStore.selectedEntity
+  selectedEntity: any = mockEntityStore.selectedEntity,
+  report: ReportShape = mockNaaarReport
 ) => (
   <RouterWrappedComponent>
     <OverlayProvider>
@@ -53,7 +62,7 @@ const planComplianceTableOverlayComponent = (
         table={mockTable}
         validateOnRender={false}
         verbiage={mockVerbiage}
-        report={mockNaaarReport}
+        report={report}
       />
     </OverlayProvider>
   </RouterWrappedComponent>
@@ -207,6 +216,69 @@ describe("<PlanComplianceTableOverlay />", () => {
         name: "Edit",
       })
     ).toBeVisible();
+  });
+
+  describe("analysis method choices", () => {
+    const openNonComplianceForm = async () => {
+      await act(async () => {
+        await userEvent.click(screen.getByRole("button", { name: "Enter" }));
+      });
+      await act(async () => {
+        await userEvent.click(screen.getByRole("radio", { name: "Mock Yes" }));
+      });
+    };
+
+    test("renders methods applied to the selected plan, even when the stored plan name is stale", async () => {
+      render(
+        planComplianceTableOverlayComponent(
+          undefined,
+          undefined,
+          undefined,
+          reportWithAnalysisMethods(mockNaaarAnalysisMethods)
+        )
+      );
+
+      await openNonComplianceForm();
+
+      expect(
+        screen.getByRole("checkbox", { name: "Mock Method 1" })
+      ).toBeVisible();
+      expect(
+        screen.getByRole("checkbox", { name: "Mock Method 2" })
+      ).toBeVisible();
+    });
+
+    test("explains the empty list when no method applies to both the plan and the standard", async () => {
+      const methodsForAnotherPlan = mockNaaarAnalysisMethods.map((method) => ({
+        ...method,
+        analysis_method_applicable_plans: [
+          {
+            key: "analysis_method_applicable_plans-mock-plan-id-2",
+            value: "mock-plan-1",
+          },
+        ],
+      }));
+
+      render(
+        planComplianceTableOverlayComponent(
+          undefined,
+          undefined,
+          undefined,
+          reportWithAnalysisMethods(methodsForAnotherPlan)
+        )
+      );
+
+      await openNonComplianceForm();
+
+      expect(
+        screen.queryByRole("checkbox", { name: "Mock Method 1" })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /No analysis methods apply to both this plan and this standard/
+        )
+      ).toBeVisible();
+    });
   });
 
   test("closes overlay", async () => {

--- a/services/ui-src/src/components/overlays/PlanComplianceTableOverlay.tsx
+++ b/services/ui-src/src/components/overlays/PlanComplianceTableOverlay.tsx
@@ -98,7 +98,7 @@ export const PlanComplianceTableOverlay = ({
         standardKeyPrefix,
         entity,
         report?.fieldData.analysisMethods,
-        selectedEntity?.name
+        selectedEntity?.id
       );
     }
 

--- a/services/ui-src/src/types/other.ts
+++ b/services/ui-src/src/types/other.ts
@@ -1,6 +1,6 @@
 import { SystemStyleObject } from "@chakra-ui/react";
 import React from "react";
-import { EntityShape } from "./formFields";
+import { Choice, EntityShape } from "./formFields";
 
 // GLOBAL
 
@@ -99,6 +99,19 @@ export interface NaaarStandardsTableShape {
   edit?: null;
   delete?: null;
   actions?: null;
+}
+
+/**
+ * An analysis method entity, as created in
+ * Part 1: State and program information, D. Analysis methods.
+ * Predefined methods carry `name`; state-added methods carry
+ * `custom_analysis_method_name` instead.
+ */
+export interface AnalysisMethodEntity {
+  id: string;
+  name?: string;
+  custom_analysis_method_name?: string;
+  analysis_method_applicable_plans?: Choice[];
 }
 
 export interface ErrorVerbiage {

--- a/services/ui-src/src/utils/forms/dynamicItemFields.test.ts
+++ b/services/ui-src/src/utils/forms/dynamicItemFields.test.ts
@@ -233,6 +233,12 @@ describe("availableAnalysisMethods for NAAAR plan compliance", () => {
       },
     ]);
   });
+  it("should return no choices when no items are available", () => {
+    const mockObjectId =
+      "planCompliance43868_standard-id-nonComplianceAnalyses";
+    const result = availableAnalysisMethods(mockObjectId, [], mockNestedForms);
+    expect(result).toEqual([]);
+  });
   it("should append a child form if the item is Geomapping", () => {
     const mockObjectId =
       "planCompliance43868_standard-id-nonComplianceAnalyses";

--- a/services/ui-src/src/utils/forms/naaarPlanCompliance.test.ts
+++ b/services/ui-src/src/utils/forms/naaarPlanCompliance.test.ts
@@ -6,7 +6,13 @@ import {
   planComplianceStandardKey,
 } from "../../constants";
 // types
-import { EntityShape, FormJson, NaaarStandardsTableShape } from "types";
+import {
+  Choice,
+  EntityShape,
+  FormField,
+  FormJson,
+  NaaarStandardsTableShape,
+} from "types";
 // utils
 import {
   addAnalysisMethods,
@@ -172,67 +178,242 @@ describe("utils/forms/naaarPlanCompliance", () => {
   });
 
   describe("addAnalysisMethods", () => {
-    test("should inject associated analysis methods into the correct form field", () => {
-      const mockForm = {
-        id: "mockId",
-        fields: [
-          {
-            id: "planCompliance43868-standard-id-nonComplianceAnalyses",
+    const standardKeyPrefix = "planCompliance43868";
+    const entityId = "standard-id";
+    const analysisMethodsFieldId =
+      "standard_analysisMethodsUtilized-mockStandardTypeId";
+    const nonComplianceAnalysesId = `${standardKeyPrefix}-${entityId}-nonComplianceAnalyses`;
+    const applicablePlansPrefix = "analysis_method_applicable_plans-";
+    const plan1Id = "mock-plan-id-1";
+    const plan2Id = "mock-plan-id-2";
+
+    const mockForm = () => ({
+      id: "mockId",
+      fields: [
+        {
+          id: nonComplianceAnalysesId,
+          type: "checkbox",
+          validation: {
             type: "checkbox",
-            props: {
-              choices: [
-                {
-                  label: "Geomapping",
-                  children: [],
-                },
-              ],
-            },
+            nested: true,
+            parentFieldName: "planCompliance43868_standard",
+            parentOptionId: "mockParentOptionId",
           },
-        ],
-      };
-
-      const standardKeyPrefix = "planCompliance43868";
-      const entityId = "standard-id";
-      const selectedPlanName = "Plan 1";
-
-      const createdAnalysisMethods = [
-        {
-          id: "mockUUID1",
-          name: "Geomapping",
-          analysis_method_applicable_plans: [{ value: "Plan 1" }],
-        },
-        {
-          id: "mockUUID2",
-          name: "MockItem2",
-          analysis_method_applicable_plans: [{ value: "Plan 2" }],
-        },
-      ];
-
-      const selectedStandard = {
-        id: "standard-id",
-        [`standard_analysisMethodsUtilized-${entityId}-mockUUID1`]: [
-          {
-            key: `standard_analysisMethodsUtilized-${entityId}-mockUUID1`,
-            value: "Geomapping",
+          props: {
+            hint: "Indicate which analyses reflect the deficiencies.",
+            choices: [
+              {
+                label: "Geomapping",
+                children: [],
+              },
+            ],
           },
-        ],
-      };
+        },
+      ],
+    });
 
+    // Applied to plan 1, with a stale display value (the plan has since been renamed)
+    const geomapping = {
+      id: "mockUUID1",
+      name: "Geomapping",
+      analysis_method_applicable_plans: [
+        { key: `${applicablePlansPrefix}${plan1Id}`, value: "Stale Plan Name" },
+      ],
+    };
+
+    // Applied to plan 2 only
+    const otherMethod = {
+      id: "mockUUID2",
+      name: "MockItem2",
+      analysis_method_applicable_plans: [
+        { key: `${applicablePlansPrefix}${plan2Id}`, value: "Plan 2" },
+      ],
+    };
+
+    const selectedStandard = {
+      id: entityId,
+      [analysisMethodsFieldId]: [
+        {
+          key: `${analysisMethodsFieldId}-mockUUID1`,
+          value: "Geomapping",
+        },
+      ],
+    };
+
+    const geomappingChoice = {
+      id: `${nonComplianceAnalysesId}_mockUUID1`,
+      label: "Geomapping",
+      children: expect.any(Array),
+    };
+
+    test("should inject associated analysis methods into the correct form field", () => {
       const result = addAnalysisMethods(
-        mockForm,
+        mockForm(),
         standardKeyPrefix,
         selectedStandard,
-        createdAnalysisMethods,
-        selectedPlanName
+        [geomapping, otherMethod],
+        plan1Id
+      );
+
+      expect(result.fields[0]?.props?.choices).toEqual([geomappingChoice]);
+    });
+
+    test("should match applicable plans by id even when the stored plan name is stale", () => {
+      const result = addAnalysisMethods(
+        mockForm(),
+        standardKeyPrefix,
+        selectedStandard,
+        [
+          {
+            ...geomapping,
+            analysis_method_applicable_plans: [
+              {
+                key: `${applicablePlansPrefix}${plan1Id}`,
+                value: "A Name No Plan Has",
+              },
+            ],
+          },
+        ],
+        plan1Id
+      );
+
+      expect(result.fields[0]?.props?.choices).toEqual([geomappingChoice]);
+    });
+
+    test("should match plan ids containing dashes", () => {
+      const dashedPlanId = "6235f12-4b1a-4c3d-9e8f-38a36a8d7e8c";
+      const result = addAnalysisMethods(
+        mockForm(),
+        standardKeyPrefix,
+        selectedStandard,
+        [
+          {
+            ...geomapping,
+            analysis_method_applicable_plans: [
+              {
+                key: `${applicablePlansPrefix}${dashedPlanId}`,
+                value: "Stale Plan Name",
+              },
+            ],
+          },
+        ],
+        dashedPlanId
+      );
+
+      expect(result.fields[0]?.props?.choices).toEqual([geomappingChoice]);
+    });
+
+    test("should use the custom analysis method name when present", () => {
+      const result = addAnalysisMethods(
+        mockForm(),
+        standardKeyPrefix,
+        selectedStandard,
+        [{ ...geomapping, custom_analysis_method_name: "Mock Custom Method" }],
+        plan1Id
       );
 
       expect(result.fields[0]?.props?.choices).toEqual([
         {
-          id: "planCompliance43868-standard-id-nonComplianceAnalyses_mockUUID1",
-          label: "Geomapping",
-          children: expect.any(Array),
+          id: `${nonComplianceAnalysesId}_mockUUID1`,
+          label: "Mock Custom Method",
         },
       ]);
+    });
+
+    test("should exclude methods applied to a different plan", () => {
+      const result = addAnalysisMethods(
+        mockForm(),
+        standardKeyPrefix,
+        {
+          id: entityId,
+          [analysisMethodsFieldId]: [
+            { key: `${analysisMethodsFieldId}-mockUUID1`, value: "Geomapping" },
+            { key: `${analysisMethodsFieldId}-mockUUID2`, value: "MockItem2" },
+          ],
+        },
+        [geomapping, otherMethod],
+        plan1Id
+      );
+
+      expect(result.fields[0]?.props?.choices).toEqual([geomappingChoice]);
+    });
+
+    test("should make the field optional and explain when no methods apply", () => {
+      const result = addAnalysisMethods(
+        mockForm(),
+        standardKeyPrefix,
+        selectedStandard,
+        [otherMethod],
+        plan1Id
+      );
+
+      const field = result.fields[0] as FormField;
+      expect(field?.props?.choices).toEqual([]);
+      expect(field?.validation).toBe("checkboxOptional");
+      expect(field?.props?.hint).toContain(
+        "No analysis methods apply to both this plan and this standard."
+      );
+    });
+
+    test("should return no choices when no plan is selected", () => {
+      const result = addAnalysisMethods(
+        mockForm(),
+        standardKeyPrefix,
+        selectedStandard,
+        [geomapping, otherMethod],
+        undefined
+      );
+
+      expect(result.fields[0]?.props?.choices).toEqual([]);
+      expect((result.fields[0] as FormField)?.validation).toBe(
+        "checkboxOptional"
+      );
+    });
+
+    test("should ignore methods without usable applicable plan data", () => {
+      const result = addAnalysisMethods(
+        mockForm(),
+        standardKeyPrefix,
+        selectedStandard,
+        [
+          { id: "mockUUID1", name: "Geomapping" },
+          {
+            id: "mockUUID1",
+            name: "Geomapping",
+            // intentionally malformed (no `key`) to exercise the runtime guard
+            analysis_method_applicable_plans: [
+              { value: "Stale Plan Name" },
+            ] as Choice[],
+          },
+        ],
+        plan1Id
+      );
+
+      expect(result.fields[0]?.props?.choices).toEqual([]);
+    });
+
+    test("should return no choices when there are no analysis methods", () => {
+      const result = addAnalysisMethods(
+        mockForm(),
+        standardKeyPrefix,
+        selectedStandard,
+        undefined,
+        plan1Id
+      );
+
+      expect(result.fields[0]?.props?.choices).toEqual([]);
+    });
+
+    test("should return no choices when the standard utilizes no analysis methods", () => {
+      const result = addAnalysisMethods(
+        mockForm(),
+        standardKeyPrefix,
+        { id: entityId },
+        [geomapping],
+        plan1Id
+      );
+
+      expect(result.fields[0]?.props?.choices).toEqual([]);
     });
   });
 

--- a/services/ui-src/src/utils/forms/naaarPlanCompliance.test.ts
+++ b/services/ui-src/src/utils/forms/naaarPlanCompliance.test.ts
@@ -7,7 +7,6 @@ import {
 } from "../../constants";
 // types
 import {
-  Choice,
   EntityShape,
   FormField,
   FormJson,
@@ -370,22 +369,12 @@ describe("utils/forms/naaarPlanCompliance", () => {
       );
     });
 
-    test("should ignore methods without usable applicable plan data", () => {
+    test("should ignore methods not yet applied to any plan", () => {
       const result = addAnalysisMethods(
         mockForm(),
         standardKeyPrefix,
         selectedStandard,
-        [
-          { id: "mockUUID1", name: "Geomapping" },
-          {
-            id: "mockUUID1",
-            name: "Geomapping",
-            // intentionally malformed (no `key`) to exercise the runtime guard
-            analysis_method_applicable_plans: [
-              { value: "Stale Plan Name" },
-            ] as Choice[],
-          },
-        ],
+        [{ id: "mockUUID1", name: "Geomapping" }],
         plan1Id
       );
 

--- a/services/ui-src/src/utils/forms/naaarPlanCompliance.ts
+++ b/services/ui-src/src/utils/forms/naaarPlanCompliance.ts
@@ -62,9 +62,7 @@ export const addAnalysisMethods = (
    */
   const isAppliedToSelectedPlan = (analysisMethod: AnalysisMethodEntity) =>
     (analysisMethod?.analysis_method_applicable_plans ?? []).some(
-      (plan) =>
-        typeof plan?.key === "string" &&
-        plan.key.split(applicablePlansPrefix).pop() === selectedPlanId
+      (plan) => plan.key.split(applicablePlansPrefix).pop() === selectedPlanId
     );
 
   const associatedAnalysisMethodsWithSelectedPlan: AnalysisMethodChoice[] =

--- a/services/ui-src/src/utils/forms/naaarPlanCompliance.ts
+++ b/services/ui-src/src/utils/forms/naaarPlanCompliance.ts
@@ -22,6 +22,21 @@ const applicablePlansPrefix = "analysis_method_applicable_plans-";
 // An analysis method reduced to what the compliance form needs to render a choice
 type AnalysisMethodChoice = { id: string; name?: string };
 
+const isAppliedToPlan = (
+  analysisMethod: AnalysisMethodEntity,
+  planId: string
+) =>
+  (analysisMethod.analysis_method_applicable_plans ?? []).some(
+    (plan) => plan.key === `${applicablePlansPrefix}${planId}`
+  );
+
+const toAnalysisMethodChoice = (
+  analysisMethod: AnalysisMethodEntity
+): AnalysisMethodChoice => ({
+  id: analysisMethod.id,
+  name: analysisMethod.custom_analysis_method_name ?? analysisMethod.name,
+});
+
 export const hasComplianceDetails = (
   exceptionsNonCompliance: string[],
   standardKeyPrefix: string,
@@ -39,7 +54,7 @@ export const addAnalysisMethods = (
   form: FormJson,
   standardKeyPrefix: string,
   selectedStandard: EntityShape,
-  createdAnalysisMethods?: AnalysisMethodEntity[],
+  createdAnalysisMethods: AnalysisMethodEntity[] = [],
   selectedPlanId?: string
 ) => {
   // First we'll create a copy of the form to make future changes to
@@ -60,20 +75,11 @@ export const addAnalysisMethods = (
    * },
    * ]
    */
-  const isAppliedToSelectedPlan = (analysisMethod: AnalysisMethodEntity) =>
-    (analysisMethod?.analysis_method_applicable_plans ?? []).some(
-      (plan) => plan.key.split(applicablePlansPrefix).pop() === selectedPlanId
-    );
-
   const associatedAnalysisMethodsWithSelectedPlan: AnalysisMethodChoice[] =
     selectedPlanId
-      ? (createdAnalysisMethods ?? [])
-          .filter(isAppliedToSelectedPlan)
-          .map((analysisMethod) => ({
-            id: analysisMethod.id,
-            name:
-              analysisMethod.custom_analysis_method_name ?? analysisMethod.name,
-          }))
+      ? createdAnalysisMethods
+          .filter((method) => isAppliedToPlan(method, selectedPlanId))
+          .map(toAnalysisMethodChoice)
       : [];
 
   // Step 2: Grab all the Analysis Methods associated with the selected Standard

--- a/services/ui-src/src/utils/forms/naaarPlanCompliance.ts
+++ b/services/ui-src/src/utils/forms/naaarPlanCompliance.ts
@@ -150,9 +150,7 @@ export const addAnalysisMethods = (
            */
           obj.validation = ValidationType.CHECKBOX_OPTIONAL;
           obj.props.hint =
-            "No analysis methods apply to both this plan and this standard. " +
-            "To report analyses here, return to “I.D Analysis methods” to apply a method to this plan, " +
-            "or to “II. Program-level access and network adequacy standards” to update the methods used for this standard.";
+            "No analysis methods apply to both this plan and this standard. To report analyses here, return to “I.D Analysis methods” to apply a method to this plan, or to “II. Program-level access and network adequacy standards” to update the methods used for this standard.";
         }
       }
     });

--- a/services/ui-src/src/utils/forms/naaarPlanCompliance.ts
+++ b/services/ui-src/src/utils/forms/naaarPlanCompliance.ts
@@ -7,12 +7,20 @@ import {
 } from "../../constants";
 // types
 import {
+  AnalysisMethodEntity,
   AnyObject,
+  Choice,
   EntityShape,
   FormJson,
   NaaarStandardsTableShape,
+  ValidationType,
 } from "types";
 import { availableAnalysisMethods } from "./dynamicItemFields";
+
+const applicablePlansPrefix = "analysis_method_applicable_plans-";
+
+// An analysis method reduced to what the compliance form needs to render a choice
+type AnalysisMethodChoice = { id: string; name?: string };
 
 export const hasComplianceDetails = (
   exceptionsNonCompliance: string[],
@@ -31,11 +39,8 @@ export const addAnalysisMethods = (
   form: FormJson,
   standardKeyPrefix: string,
   selectedStandard: EntityShape,
-  createdAnalysisMethods: {
-    analysis_method_applicable_plans: AnyObject[];
-    name: string;
-  }[],
-  selectedPlanName?: string
+  createdAnalysisMethods?: AnalysisMethodEntity[],
+  selectedPlanId?: string
 ) => {
   // First we'll create a copy of the form to make future changes to
   const updatedForm = structuredClone(form);
@@ -55,20 +60,23 @@ export const addAnalysisMethods = (
    * },
    * ]
    */
-  const associatedAnalysisMethodsWithSelectedPlan: AnyObject[] =
-    createdAnalysisMethods?.map((analysisMethod: AnyObject) => {
-      if (!analysisMethod?.analysis_method_applicable_plans) return [];
-      for (const method of analysisMethod.analysis_method_applicable_plans) {
-        if (method.value == selectedPlanName) {
-          return {
+  const isAppliedToSelectedPlan = (analysisMethod: AnalysisMethodEntity) =>
+    (analysisMethod?.analysis_method_applicable_plans ?? []).some(
+      (plan) =>
+        typeof plan?.key === "string" &&
+        plan.key.split(applicablePlansPrefix).pop() === selectedPlanId
+    );
+
+  const associatedAnalysisMethodsWithSelectedPlan: AnalysisMethodChoice[] =
+    selectedPlanId
+      ? (createdAnalysisMethods ?? [])
+          .filter(isAppliedToSelectedPlan)
+          .map((analysisMethod) => ({
             id: analysisMethod.id,
             name:
               analysisMethod.custom_analysis_method_name ?? analysisMethod.name,
-          };
-        }
-      }
-      return [];
-    });
+          }))
+      : [];
 
   // Step 2: Grab all the Analysis Methods associated with the selected Standard
   /*
@@ -81,7 +89,7 @@ export const addAnalysisMethods = (
    * }
    * ]
    */
-  let utilizedAnalysisMethodsWithSelectedStandard: AnyObject[] = [];
+  let utilizedAnalysisMethodsWithSelectedStandard: Choice[] = [];
   const analysisMethodsKey = Object.keys(selectedStandard).find((key) =>
     key.startsWith("standard_analysisMethodsUtilized-")
   );
@@ -102,12 +110,13 @@ export const addAnalysisMethods = (
    * ]
    * Since Geomapping is an Analysis Method in both the Plan and the Standard
    */
-  const associatedMethodsBetweenStandardsAndPlan =
-    associatedAnalysisMethodsWithSelectedPlan?.filter((plan) =>
-      utilizedAnalysisMethodsWithSelectedStandard?.some((standard) =>
-        standard?.key?.endsWith(plan.id)
+  const associatedMethodsBetweenStandardsAndPlan = analysisMethodsKey
+    ? associatedAnalysisMethodsWithSelectedPlan.filter((method) =>
+        utilizedAnalysisMethodsWithSelectedStandard?.some(
+          (standard) => standard?.key === `${analysisMethodsKey}-${method.id}`
+        )
       )
-    );
+    : [];
 
   // Step 4: Go through and find any associated questions relating to the Analysis Methods and inject those choices into the form
   /*
@@ -128,11 +137,25 @@ export const addAnalysisMethods = (
         `${standardKeyPrefix}-${selectedStandard.id}-nonComplianceAnalyses`
       ) {
         // creating and injecting the analysis method choices into the form
-        obj.props.choices = availableAnalysisMethods(
+        const choices = availableAnalysisMethods(
           obj.id,
           associatedMethodsBetweenStandardsAndPlan,
           obj.props.choices
         );
+        obj.props.choices = choices;
+
+        if (choices.length === 0) {
+          /*
+           * No analysis method is applied to both this plan (I.D) and this standard (II).
+           * Rendering zero checkboxes under a required schema makes the form unsubmittable
+           * with no visible control, so downgrade to optional and explain the empty list.
+           */
+          obj.validation = ValidationType.CHECKBOX_OPTIONAL;
+          obj.props.hint =
+            "No analysis methods apply to both this plan and this standard. " +
+            "To report analyses here, return to “I.D Analysis methods” to apply a method to this plan, " +
+            "or to “II. Program-level access and network adequacy standards” to update the methods used for this standard.";
+        }
       }
     });
   }

--- a/services/ui-src/src/utils/forms/naaarPlanCompliance.ts
+++ b/services/ui-src/src/utils/forms/naaarPlanCompliance.ts
@@ -93,14 +93,11 @@ export const addAnalysisMethods = (
    * }
    * ]
    */
-  let utilizedAnalysisMethodsWithSelectedStandard: Choice[] = [];
   const analysisMethodsKey = Object.keys(selectedStandard).find((key) =>
     key.startsWith("standard_analysisMethodsUtilized-")
   );
-  if (analysisMethodsKey) {
-    utilizedAnalysisMethodsWithSelectedStandard =
-      selectedStandard[analysisMethodsKey];
-  }
+  const utilizedAnalysisMethodsWithSelectedStandard: Choice[] =
+    analysisMethodsKey ? (selectedStandard[analysisMethodsKey] ?? []) : [];
 
   // Step 3: Grab the intersection of Analysis Methods associated with Plans and Standards
   /*
@@ -114,13 +111,12 @@ export const addAnalysisMethods = (
    * ]
    * Since Geomapping is an Analysis Method in both the Plan and the Standard
    */
-  const associatedMethodsBetweenStandardsAndPlan = analysisMethodsKey
-    ? associatedAnalysisMethodsWithSelectedPlan.filter((method) =>
-        utilizedAnalysisMethodsWithSelectedStandard?.some(
-          (standard) => standard?.key === `${analysisMethodsKey}-${method.id}`
-        )
+  const associatedMethodsBetweenStandardsAndPlan =
+    associatedAnalysisMethodsWithSelectedPlan.filter((method) =>
+      utilizedAnalysisMethodsWithSelectedStandard.some(
+        (standard) => standard.key === `${analysisMethodsKey}-${method.id}`
       )
-    : [];
+    );
 
   // Step 4: Go through and find any associated questions relating to the Analysis Methods and inject those choices into the form
   /*

--- a/services/ui-src/src/utils/testing/mockEntities.tsx
+++ b/services/ui-src/src/utils/testing/mockEntities.tsx
@@ -218,8 +218,8 @@ export const mockNaaarAnalysisMethods: EntityShape[] = [
     name: "Mock Method 1",
     analysis_method_applicable_plans: [
       {
-        key: "mock-plan-id-1",
-        name: "mock-plan-1",
+        key: "analysis_method_applicable_plans-mock-plan-id-1",
+        value: "mock-plan-1",
       },
     ],
   },
@@ -228,8 +228,8 @@ export const mockNaaarAnalysisMethods: EntityShape[] = [
     name: "Mock Method 2",
     analysis_method_applicable_plans: [
       {
-        key: "mock-plan-id-1",
-        name: "mock-plan-1",
+        key: "analysis_method_applicable_plans-mock-plan-id-1",
+        value: "mock-plan-1",
       },
     ],
   },

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -1090,7 +1090,7 @@ export const mockEntityDetailsMultiformOverlayJson: OverlayReportPageShape = {
                         validation: "textOptional",
                       },
                       {
-                        id: "planCompliance43868_standard-mockStandard-nonComplianceAnalyses",
+                        id: "planCompliance43868_standard-nonComplianceAnalyses",
                         type: "checkbox",
                         validation: "checkboxOneOptional",
                         props: {

--- a/services/ui-src/src/utils/testing/mockReport.tsx
+++ b/services/ui-src/src/utils/testing/mockReport.tsx
@@ -402,7 +402,7 @@ export const mockNaaarReportFieldData = {
       ],
       analysis_method_applicable_plans: [
         {
-          key: "analysis_method_applicable_plans-mock-id1",
+          key: "analysis_method_applicable_plans-id1",
           value: "plan",
         },
       ],
@@ -419,7 +419,7 @@ export const mockNaaarReportFieldData = {
       ],
       analysis_method_applicable_plans: [
         {
-          key: "analysis_method_applicable_plans-mock-id2",
+          key: "analysis_method_applicable_plans-id2",
           value: "1",
         },
       ],


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
So this PR fixes 2 problems, the tier 3 issue & a possible edge case that can trigger the exact same issue. I'll try and break this down as best as possible:

1. Tier 3 Fix

Rhode Island cannot submit their NAAAR. In III. Plan compliance, when they tick **"III.C.1 Plan is non-compliant for this standard"**, the child question **"III.C.2a Plan deficiencies: analyses used to identify deficiencies with this standard"** renders with **no checkboxes at all**, yet still shows a required-field error.

The reason is because the field data show the following:
```
plans[0] = { id: "6235f12-…-38a36a8d7e8c", name: "UnitedHealthcare Insurance Company" }
analysis_method_applicable_plans =  { key: "analysis_method_applicable_plans-6235f12-…-38a36a8d7e8c", value: "RIte Smiles" 
```

When we compare the data, we're looking at the values, not the id's. And obviously RIte Smiles =/= UnitedHealthcare Insurance Company. We should be looking at the ids so that we can match up (6235f12-…-38a36a8d7e8c).

This PR fixes that so they use the ID instead of the name when doing a comparison to make sure we render the correct checkboxes.

"But Nick, how'd this happen in the first place?" I hear you ask. And TBH... I dont know. I'm still investigating. They shouldn't have been able to be different in the first place so we still have an issue elsewhere. This will fix it though for now. 

2. Fun fact, theres a second part to this! You can actually trigger this in a different way! So with 2+ plans a standard can utilize a method that isn't applied to the plan being reported on, and thus one of the plans will have nothing in it! For now, I've temporarily made the question become optional, with the hint text changing to "No analysis methods apply to both this plan and this standard. To report analyses here, return to “I.D Analysis methods” to apply a method to this plan, or to “II. Program-level access and network adequacy standards” to update the methods used for this standard."


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6442 & #CS5632764

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

This can replicate part 2 of the above description
#### How to replicate a possible empty question "III.C.2a Plan deficiencies: analyses used to identify deficiencies with this standard" (Do this on the main branch if you want to see the problem, and this branch to see the fix!)

1. Create a NAAAR
2. **I.B Add plans**: Add two rows, `Plan A` and `Plan B`
3. **I.C Provider type coverage**: tick **Dental**.
4. **I.D Analysis methods**:  all 7 must be filled
   - **Geomapping**: Enter → *Yes* → any frequency → tick **Plan A only** → Save
   - **Secret Shopper: Appointment Availability**: → Enter → *Yes* → any frequency → tick **Plan B only** → Save
   - The remaining 5 → Enter → *No* → Save
5. **II. Program-level standards** → **Add standard**:
   - II.A.1 Provider type → **Dental**
   - II.A.3 Standard type → **Maximum time or distance** → II.A.4 description (required, any text)
   - II.A.5 Analysis method(s) utilized → tick **Geomapping only** (only the two "Yes" methods appear here)
   - II.A.6 Population → **Pediatric**; II.A.7 Region → **Statewide** → Save
6. **III. Plan compliance** → **Enter** on **`Plan B`**.
7. III.A.1 → **"No, the plan does not comply on all standards…"**
8. In the 438.68 table row → **Enter** → the standard → **Enter**
9. Tick **"III.C.1 Plan is non-compliant for this standard"**
10. **III.C.2a renders its heading and hint with zero checkboxes.**
11. **Save & return** → nothing happens; a red *"Select at least one response"* appears under III.C.2a with no
    control to satisfy it.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary