### PR TITLE
CMDCT-6464: Bug fix for ILOS numbers not displaying in export

### DIFF
--- a/services/ui-src/src/utils/other/export.test.tsx
+++ b/services/ui-src/src/utils/other/export.test.tsx
@@ -339,12 +339,22 @@ describe("Test rendering methods", () => {
     expect(screen.queryByText("mock-ilos: N/A")).not.toBeInTheDocument();
   });
 
-  test("Correctly renders nested ILOS fields", () => {
+  test("Correctly renders nested ILOS fields with legacy, unprefixed choice ids", () => {
+    const mockFieldResponseData = [{ key: "123", value: "mock-ilos" }];
+    const mockPlan = {
+      id: "mock-id",
+      plan_ilosUtilizationByPlan: [...mockFieldResponseData],
+      plan_ilosUtilizationByPlan_123: "N/A",
+    };
+
+    const result = getNestedIlosResponses(mockFieldResponseData, mockPlan);
+    expect(result[0].key).toEqual("mock-ilos");
+    expect(result[0].value).toEqual("N/A");
+  });
+
+  test("Correctly renders nested ILOS fields with prefixed choice ids", () => {
     const mockFieldResponseData = [
-      {
-        key: "123",
-        value: "mock-ilos",
-      },
+      { key: "plan_ilosUtilizationByPlan-123", value: "mock-ilos" },
     ];
     const mockPlan = {
       id: "mock-id",
@@ -355,6 +365,46 @@ describe("Test rendering methods", () => {
     const result = getNestedIlosResponses(mockFieldResponseData, mockPlan);
     expect(result[0].key).toEqual("mock-ilos");
     expect(result[0].value).toEqual("N/A");
+  });
+
+  test("Correctly renders a utilization value of 0", () => {
+    const mockFieldResponseData = [
+      { key: "plan_ilosUtilizationByPlan-123", value: "mock-ilos" },
+    ];
+    const mockPlan = {
+      id: "mock-id",
+      plan_ilosUtilizationByPlan: [...mockFieldResponseData],
+      plan_ilosUtilizationByPlan_123: "0",
+    };
+
+    const result = getNestedIlosResponses(mockFieldResponseData, mockPlan);
+    expect(result[0].value).toEqual("0");
+  });
+
+  test("Correctly renders multiple nested ILOS fields for the same plan", () => {
+    const mockFieldResponseData = [
+      {
+        key: "plan_ilosUtilizationByPlan-111",
+        value: "mock-ilos-one",
+      },
+      {
+        key: "plan_ilosUtilizationByPlan-222",
+        value: "mock-ilos-two",
+      },
+    ];
+    const mockPlan = {
+      id: "mock-id",
+      plan_ilosUtilizationByPlan: [...mockFieldResponseData],
+      plan_ilosUtilizationByPlan_111: "13",
+      plan_ilosUtilizationByPlan_222: "17",
+    };
+
+    const result = getNestedIlosResponses(mockFieldResponseData, mockPlan);
+
+    expect(result[0].key).toEqual("mock-ilos-one");
+    expect(result[0].value).toEqual("13");
+    expect(result[1].key).toEqual("mock-ilos-two");
+    expect(result[1].value).toEqual("17");
   });
 
   test("If there are ILOS but no plans, renders error message", () => {

--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -383,8 +383,13 @@ export const getNestedIlosResponses = (
   fieldResponseData: AnyObject,
   entity: EntityShape
 ) => {
+  const ilosFieldName = "plan_ilosUtilizationByPlan";
+
   return fieldResponseData.map((data: AnyObject) => {
-    const nestedResponse = entity[`plan_ilosUtilizationByPlan_${data.key}`];
+    const ilosId = data.key.startsWith(`${ilosFieldName}-`)
+      ? data.key.replace(`${ilosFieldName}-`, "")
+      : data.key;
+    const nestedResponse = entity[`${ilosFieldName}_${ilosId}`];
     return {
       key: data.value,
       value: nestedResponse,


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
Fixes a bug where ILOS utilization numbers are blank in the exported MCPAR PDF (Section D, Topic XI, D4.XI.2a), even though the data exists and displays correctly in the interactive drawer.

Root Cause

PR #12085 changed the choice-id prefixing condition in `initializeChoiceListFields` (`services/ui-src/src/utils/forms/forms.ts`) from `!choice.id.includes("-")` (a check that never actually fired for ILOS, since its UUID-based choice ids always contain hyphens) to `!choice.id.startsWith(prefix)`, which correctly prefixes any choice id not already starting with its parent field name. This fixed the bug it targeted, but had a side effect: ILOS checkbox choices, which previously escaped prefixing entirely, now save with keys like `plan_ilosUtilizationByPlan-<ilosId>`.

The PDF export's `getNestedIlosResponses` (`services/ui-src/src/utils/other/export.tsx`) builds its lookup by concatenating the checkbox key onto a separate, unrelated key format used by the nested utilization number field (`plan_ilosUtilizationByPlan_<ilosId>`, underscore-joined). With the new hyphen-prefixed checkbox key, this concatenation now produces a key that doesn't exist, so the lookup returns undefined and the PDF shows blank.

The interactive drawer is unaffected because the utilization number field hydrates from its own field id, generated independently in `services/ui-src/src/utils/forms/dynamicItemFields.ts` and never touched by the prefixing change.

ILOS selections saved before 2025-03-25 have unprefixed keys and export correctly. Any plan whose ILOS checkboxes were saved or edited after that date shows blank utilization in the PDF.

Fix

`getNestedIlosResponses` now derives both the checkbox prefix and the nested field key from a single shared `ilosFieldName` base ("plan_ilosUtilizationByPlan"), stripping the `${ilosFieldName}-` prefix from the checkbox key when present before building the `${ilosFieldName}_${ilosId}` lookup key, mirroring the existing pattern used in `dynamicItemFields.ts`'s availableItems. Legacy, unprefixed keys are handled unchanged.

Note: the original "Correctly renders nested ILOS fields" test was renamed to "...with legacy, unprefixed choice ids" and expanded alongside the three new tests above.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6464

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Cloudfront URL: https://dk97henzqr5e3.cloudfront.net/
- In an MCPAR report, add at least one plan (Section A → Add Plans).
- Add at least two ILOS entities (Section A → Program Information → Add In Lieu of Services and Settings).
- Go to Section D, Topic XI: ILOS, open the drawer for a plan, select "Yes, at least 1 ILOS is offered by this plan," check both ILOS options, enter different utilization numbers for each (e.g. 13 and 17), and save.
- Confirm the drawer shows both numbers correctly when reopened.
- Open Review & Submit → Review PDF, find the D4.XI.2a row, confirm both ILOS names show with their correct, correctly-matched utilization numbers.
- Confirm a utilization value of 0 renders as 0, not blank.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
While investigating this, I noticed a broader pattern worth flagging separately: several places in the codebase (`forms.ts`, `dynamicItemFields.ts`, `naaarPlanCompliance.ts`, `dataModifications.ts`) build derived field/choice keys by concatenating a base field name with different separators (hyphen vs. underscore) depending on the code path. `initializeChoiceListFields` also mutates `choice.id` in place, permanently discarding the original bare id, so any code needing the bare id later has to reverse-engineer it via string parsing, which can/has caused issues for future prefix-format changes. There may be a reason for this that I just can't see yet, and it's not in scope here, but might be worth a follow-up ticket to consider preserving the original id separately (e.g. an optionId field) rather than relying on parsing conventions.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
