### PR TITLE
[CMDCT-6567] Preload measures in old copied reports

### DIFF
--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -20,7 +20,9 @@ import {
 import { getOrCreateFormTemplate } from "../../utils/formTemplates/formTemplates";
 import {
   copyFieldDataFromSource,
+  getSourceFieldData,
   makePCCMModifications,
+  needsPreloadedQualityMeasures,
   populateQualityMeasures,
 } from "../../utils/reports/reports";
 import {
@@ -30,7 +32,12 @@ import {
   internalServerError,
 } from "../../utils/responses/response-lib";
 // types
-import { isReportType, isState, UserRoles } from "../../utils/types";
+import {
+  isReportType,
+  isState,
+  ReportType,
+  UserRoles,
+} from "../../utils/types";
 
 export const createReport = handler(async (event, _context) => {
   const requiredParams = ["reportType", "state"];
@@ -120,12 +127,18 @@ export const createReport = handler(async (event, _context) => {
   // If the `copyFieldDataSourceId` parameter is passed, merge the validated field data with the source ids data.
   let newFieldData;
   const copyFieldDataSourceId = unvalidatedMetadata?.copyFieldDataSourceId;
+  let sourceFieldData;
 
   if (copyFieldDataSourceId) {
+    sourceFieldData = await getSourceFieldData(
+      copyFieldDataSourceId,
+      reportBucket,
+      state
+    );
     newFieldData = await copyFieldDataFromSource(
       reportBucket,
       state,
-      copyFieldDataSourceId,
+      sourceFieldData,
       formTemplate,
       validatedFieldData!,
       reportType,
@@ -140,8 +153,12 @@ export const createReport = handler(async (event, _context) => {
     newFieldData = makePCCMModifications(newFieldData);
   }
 
-  // prefill MCPAR quality measures if not copying report
-  if (newQualityMeasuresSectionEnabled && !copyFieldDataSourceId) {
+  // prefill MCPAR quality measures
+  if (
+    newQualityMeasuresSectionEnabled &&
+    reportType === ReportType.MCPAR &&
+    needsPreloadedQualityMeasures(sourceFieldData)
+  ) {
     newFieldData = populateQualityMeasures(
       newFieldData,
       state,

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -136,8 +136,6 @@ export const createReport = handler(async (event, _context) => {
       state
     );
     newFieldData = await copyFieldDataFromSource(
-      reportBucket,
-      state,
       sourceFieldData,
       formTemplate,
       validatedFieldData!,

--- a/services/app-api/utils/constants/copyover.ts
+++ b/services/app-api/utils/constants/copyover.ts
@@ -96,7 +96,7 @@ export const mcparFieldsToCopy = {
 };
 
 // fields to copy when newQualityMeasuresSectionEnabled flag is true
-export const newQualityMeasureFieldsToCopy = [
+export const qualityMeasuresV2FieldsToCopy = [
   "id",
   "measure_name",
   "measure_identifier",

--- a/services/app-api/utils/reports/reports.test.ts
+++ b/services/app-api/utils/reports/reports.test.ts
@@ -2,7 +2,9 @@ import {
   cleanupOtherTextFields,
   copyFieldDataFromSource,
   getPlansNotExemptFromQualityMeasures,
+  getSourceFieldData,
   makePCCMModifications,
+  needsPreloadedQualityMeasures,
   populateQualityMeasures,
 } from "./reports";
 // constants
@@ -58,15 +60,15 @@ describe("reports.ts", () => {
         },
       };
       test("Test copyFieldDataFromSource accepts only those entities in the formTemplate", async () => {
-        jest.spyOn(s3Lib, "get").mockResolvedValueOnce({
+        const mockSourceFieldData = {
           stateName: "Alabama",
           plans: [{ id: "foo", name: "name", notAllowed: "false" }],
           bssEntities: [{ id: "bar", name: "name", notAllowed: "false" }],
-        });
+        };
         const res = await copyFieldDataFromSource(
           "database-local-mcpar",
           "Minnesota",
-          "mockReportJson",
+          mockSourceFieldData,
           mockMcparJson,
           { stateName: "Minnesota" },
           ReportType.MCPAR
@@ -106,57 +108,19 @@ describe("reports.ts", () => {
           },
         });
 
-        test("Test populateQualityMeasures sets correct field data", () => {
-          let testFieldData = {};
-          testFieldData = populateQualityMeasures(testFieldData, "MN", "PMAP");
-          const qualityMeasures = MN.PMAP.map((item) => ({
-            ...item,
-            id: expect.stringMatching(uuidRegex),
-          }));
-
-          expect(testFieldData).toEqual({
-            qualityMeasures,
-          });
-        });
-
-        test("returns new quality measures copyover", async () => {
-          jest.spyOn(s3Lib, "get").mockResolvedValueOnce({
-            stateName: "Minnesota",
-            qualityMeasures: [{ id: "foo", measure_name: "name" }],
-          });
-          const res = await copyFieldDataFromSource(
-            "database-local-mcpar",
-            "Minnesota",
-            "mockReportQualityMeasuresJson",
-            mockReportQualityMeasuresJson,
-            { stateName: "Minnesota" },
-            ReportType.MCPAR,
-            true // newQualityMeasuresSectionEnabled
-          );
-          expect(res).toEqual({
+        test("filters quality measures v1 and id-only entities in copyover", async () => {
+          const mockSourceFieldData = {
             stateName: "Minnesota",
             qualityMeasures: [
-              {
-                id: "foo",
-                measure_name: "name",
-              },
-            ],
-          });
-        });
-
-        test("filters id only entities on copyover", async () => {
-          jest.spyOn(s3Lib, "get").mockResolvedValueOnce({
-            stateName: "Minnesota",
-            qualityMeasures: [
-              { id: "foo", measure_name: "name" },
-              { id: "bar" },
+              { id: "foo", measure_name: "v2 name" },
+              { id: "bar", qualityMeasure_name: "v1 name" },
               { id: "baz" },
             ],
-          });
+          };
           const res = await copyFieldDataFromSource(
             "database-local-mcpar",
             "Minnesota",
-            "mockReportQualityMeasuresJson",
+            mockSourceFieldData,
             mockReportQualityMeasuresJson,
             { stateName: "Minnesota" },
             ReportType.MCPAR,
@@ -167,7 +131,7 @@ describe("reports.ts", () => {
             qualityMeasures: [
               {
                 id: "foo",
-                measure_name: "name",
+                measure_name: "v2 name",
               },
             ],
           });
@@ -177,10 +141,11 @@ describe("reports.ts", () => {
 
     describe("MLR", () => {
       test("returns validatedField data", async () => {
+        const mockSourceFieldData = undefined;
         const res = await copyFieldDataFromSource(
           "database-local-mlr",
           "Minnesota",
-          "mockReportJson",
+          mockSourceFieldData,
           mockReportJson,
           { stateName: "Minnesota" },
           ReportType.MLR
@@ -205,14 +170,14 @@ describe("reports.ts", () => {
         },
       };
       test("uses S3 object for validatedField data", async () => {
-        jest.spyOn(s3Lib, "get").mockResolvedValueOnce({
+        const mockSourceFieldData = {
           stateName: "Alabama",
           plans: [{ id: "foo", name: "name", notAllowed: "false" }],
-        });
+        };
         const res = await copyFieldDataFromSource(
           "database-local-naaar",
           "Minnesota",
-          "mockReportJson",
+          mockSourceFieldData,
           mockNaaarJson,
           { stateName: "Minnesota" },
           ReportType.NAAAR
@@ -224,16 +189,81 @@ describe("reports.ts", () => {
       });
 
       test("returns validatedField data if no S3 object", async () => {
-        jest.spyOn(s3Lib, "get").mockResolvedValueOnce(undefined);
+        const mockSourceFieldData = undefined;
         const res = await copyFieldDataFromSource(
           "database-local-naaar",
           "Minnesota",
-          "mockReportJson",
+          mockSourceFieldData,
           mockNaaarJson,
           { stateName: "Minnesota" },
           ReportType.NAAAR
         );
         expect(res).toEqual({ stateName: "Minnesota" });
+      });
+    });
+  });
+
+  describe("getSourceFieldData()", () => {
+    test("returns field data", async () => {
+      jest.spyOn(s3Lib, "get").mockResolvedValueOnce({
+        stateName: "Minnesota",
+        plans: [{ id: "foo", name: "name" }],
+      });
+      const result = await getSourceFieldData(
+        "mockSourceId",
+        "database-local-mcpar",
+        "Minnesota"
+      );
+
+      expect(result).toEqual({
+        stateName: "Minnesota",
+        plans: [{ id: "foo", name: "name" }],
+      });
+    });
+  });
+
+  describe("needsPreloadedQualityMeasures()", () => {
+    test("returns true for new report", () => {
+      const mockSourceData = undefined;
+      const result = needsPreloadedQualityMeasures(mockSourceData);
+      expect(result).toBe(true);
+    });
+
+    test("returns true for copied report with quality measures v1", () => {
+      const mockSourceData = {
+        qualityMeasures: [
+          {
+            qualityMeasure_name: "v1 name",
+          },
+        ],
+      };
+      const result = needsPreloadedQualityMeasures(mockSourceData);
+      expect(result).toBe(true);
+    });
+
+    test("returns false for copied report with quality measures v2", () => {
+      const mockSourceData = {
+        qualityMeasures: [
+          {
+            measure_name: "v2 name",
+          },
+        ],
+      };
+      const result = needsPreloadedQualityMeasures(mockSourceData);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("populateQualityMeasures()", () => {
+    test("Test populateQualityMeasures sets correct field data", () => {
+      const result = populateQualityMeasures({}, "MN", "PMAP");
+      const qualityMeasures = MN.PMAP.map((item) => ({
+        ...item,
+        id: expect.stringMatching(uuidRegex),
+      }));
+
+      expect(result).toEqual({
+        qualityMeasures,
       });
     });
   });

--- a/services/app-api/utils/reports/reports.test.ts
+++ b/services/app-api/utils/reports/reports.test.ts
@@ -66,8 +66,6 @@ describe("reports.ts", () => {
           bssEntities: [{ id: "bar", name: "name", notAllowed: "false" }],
         };
         const res = await copyFieldDataFromSource(
-          "database-local-mcpar",
-          "Minnesota",
           mockSourceFieldData,
           mockMcparJson,
           { stateName: "Minnesota" },
@@ -118,8 +116,6 @@ describe("reports.ts", () => {
             ],
           };
           const res = await copyFieldDataFromSource(
-            "database-local-mcpar",
-            "Minnesota",
             mockSourceFieldData,
             mockReportQualityMeasuresJson,
             { stateName: "Minnesota" },
@@ -143,8 +139,6 @@ describe("reports.ts", () => {
       test("returns validatedField data", async () => {
         const mockSourceFieldData = undefined;
         const res = await copyFieldDataFromSource(
-          "database-local-mlr",
-          "Minnesota",
           mockSourceFieldData,
           mockReportJson,
           { stateName: "Minnesota" },
@@ -175,8 +169,6 @@ describe("reports.ts", () => {
           plans: [{ id: "foo", name: "name", notAllowed: "false" }],
         };
         const res = await copyFieldDataFromSource(
-          "database-local-naaar",
-          "Minnesota",
           mockSourceFieldData,
           mockNaaarJson,
           { stateName: "Minnesota" },
@@ -191,8 +183,6 @@ describe("reports.ts", () => {
       test("returns validatedField data if no S3 object", async () => {
         const mockSourceFieldData = undefined;
         const res = await copyFieldDataFromSource(
-          "database-local-naaar",
-          "Minnesota",
           mockSourceFieldData,
           mockNaaarJson,
           { stateName: "Minnesota" },

--- a/services/app-api/utils/reports/reports.ts
+++ b/services/app-api/utils/reports/reports.ts
@@ -24,13 +24,11 @@ import {
  * @param validatedFieldData validated field data from request
  */
 export async function copyFieldDataFromSource(
-  reportBucket: string,
-  state: string | undefined,
   sourceFieldData: AnyObject | undefined,
   formTemplate: any,
   validatedFieldData: AnyObject,
   reportType: ReportType,
-  newQualityMeasuresSectionEnabled?: boolean
+  newQualityMeasuresSectionEnabled: boolean = false
 ) {
   // If we couldn't find the data to copy, we will quietly do nothing
   if (!sourceFieldData) return validatedFieldData;

--- a/services/app-api/utils/reports/reports.ts
+++ b/services/app-api/utils/reports/reports.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import {
   mcparFieldsToCopy,
   naaarFieldsToCopy,
-  newQualityMeasureFieldsToCopy,
+  qualityMeasuresV2FieldsToCopy,
 } from "../constants/copyover";
 import { mcparQualityMeasuresList } from "../data/mcparQualityMeasuresList";
 import { getPossibleFieldsFromFormTemplate } from "../formTemplates/formTemplates";
@@ -26,12 +26,15 @@ import {
 export async function copyFieldDataFromSource(
   reportBucket: string,
   state: string | undefined,
-  copyFieldDataSourceId: any,
+  sourceFieldData: AnyObject | undefined,
   formTemplate: any,
   validatedFieldData: AnyObject,
   reportType: ReportType,
   newQualityMeasuresSectionEnabled?: boolean
 ) {
+  // If we couldn't find the data to copy, we will quietly do nothing
+  if (!sourceFieldData) return validatedFieldData;
+
   // Year-over-year copy is currently only supported for MCPAR and NAAAR
   let fieldsToCopy: AnyObject = mcparFieldsToCopy;
   if (reportType === ReportType.NAAAR) {
@@ -42,17 +45,7 @@ export async function copyFieldDataFromSource(
 
   // if newQualityMeasuresSectionEnabled is true, copy new quality measure fields
   if (reportType === ReportType.MCPAR && newQualityMeasuresSectionEnabled) {
-    fieldsToCopy.qualityMeasures = newQualityMeasureFieldsToCopy;
-  }
-
-  const sourceFieldData = (await s3Lib.get({
-    Bucket: reportBucket,
-    Key: getFieldDataKey(state as State, copyFieldDataSourceId),
-  })) as AnyObject;
-
-  // If we couldn't find the data to copy, we will quietly do nothing
-  if (!sourceFieldData) {
-    return validatedFieldData;
+    fieldsToCopy.qualityMeasures = qualityMeasuresV2FieldsToCopy;
   }
 
   // All fields in the current form template are valid. Additionally, entities have IDs and names that should be copied.
@@ -126,6 +119,28 @@ export function makePCCMModifications(fieldData: any) {
   delete fieldData["program_type-otherText"];
 
   return fieldData;
+}
+
+export async function getSourceFieldData(
+  copyFieldDataSourceId: string,
+  reportBucket: string,
+  state?: string
+) {
+  const sourceFieldData = (await s3Lib.get({
+    Bucket: reportBucket,
+    Key: getFieldDataKey(state as State, copyFieldDataSourceId),
+  })) as AnyObject;
+
+  return sourceFieldData;
+}
+
+export function needsPreloadedQualityMeasures(sourceFieldData?: AnyObject) {
+  if (!sourceFieldData) return true;
+
+  const hasQualityMeasuresV1 = (sourceFieldData.qualityMeasures || []).some(
+    (qm: any) => qm.qualityMeasure_name
+  );
+  return hasQualityMeasuresV1;
 }
 
 export function populateQualityMeasures(

--- a/tests/seeds/fixtures/mcpar.ts
+++ b/tests/seeds/fixtures/mcpar.ts
@@ -214,7 +214,7 @@ export const fillMcpar = (
   );
 
   const qualityMeasures = Array.from({ length: numberOfExamples }, () =>
-    createQualityMeasure(planIds)
+    createQualityMeasureV1(planIds)
   );
 
   const sanctions = planIds.map((planId) => createSanction(planId));
@@ -226,7 +226,7 @@ export const fillMcpar = (
     const plansExemptFromQualityMeasures = [createPlanExemption(plans[0])];
     let newQualityMeasures = Array.from(
       { length: numberOfExamples },
-      (_, index) => createNewQualityMeasure(index)
+      (_, index) => createQualityMeasureV2(index)
     );
 
     // Remove timestamp from program name
@@ -242,7 +242,7 @@ export const fillMcpar = (
 
     if (measuresByStateAndProgram) {
       newQualityMeasures = measuresByStateAndProgram.map((measure, index) =>
-        createNewQualityMeasure(index, measure)
+        createQualityMeasureV2(index, measure)
       );
     }
 
@@ -854,7 +854,7 @@ const createPlan = (
   return data;
 };
 
-const createQualityMeasure = (planIds: string[]) => {
+const createQualityMeasureV1 = (planIds: string[]) => {
   const measureResults = planIds.reduce(
     (results, planId) => {
       results[`qualityMeasure_plan_measureResults_${planId}`] =
@@ -897,7 +897,7 @@ const createQualityMeasure = (planIds: string[]) => {
   };
 };
 
-const createNewQualityMeasure = (index: number, measure?: Measure) => {
+const createQualityMeasureV2 = (index: number, measure?: Measure) => {
   const measureIdentifiers = [
     {
       measure_identifier: [


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
This PR addresses a bug in the copyover functionality to allow preloading quality measures if the copied over report is in our old format.

Changes:
- Move source fieldData retrieval out of `copyFieldDataFromSource` and into separate `getSourceFieldData`
- Use `sourceFieldData` to determine if the report to be copied over has old quality measures
- Add `needsPreloadedQualityMeasures` to determine if preloaded measures should be added to the report
- Rename quality measure variables with `v1` or `v2` to clarify which format it's using

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6567

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Run MCR locally with flag off, change your `.env`:
```
LD_LOCAL_FLAGS='{"local": true, "flags": { "newQualityMeasuresSectionEnabled": false }}'
```
2. Run `yarn db:seed` and create a submitted MCPAR
3. Log in as `stateuser@test.com`
4. Confirm MCPAR with old quality measures was created
5. Turn on flag:
```
LD_LOCAL_FLAGS='{"local": true, "flags": { "newQualityMeasuresSectionEnabled": true }}'
```
Temporaily edit `services/app-api/utils/featureFlags/featureFlags.ts`. This is necessary because process.env requires the API to be restarted, which will empty your local DB:
```
const localFlags = process.env.launchDarklyLocalFlags
  // ? JSON.parse(process.env.launchDarklyLocalFlags)
  ? JSON.parse('{"local": true, "flags": { "newQualityMeasuresSectionEnabled": true }}')
  : {};
```
6. Wait for API to rebuild
7. Create a new MCPAR with program `PMAP`
8. Confirm new report has preloaded quality measures
9. Create a copied over MCPAR with program `PMAP` using the report with old quality measures
10. Copied over report should have new preloaded quality measures

<!-- ### Notes -->
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
